### PR TITLE
feat(artist): add artist detail pages

### DIFF
--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -18,6 +18,7 @@ pub enum Destination {
     Library(LibraryTab),
     Album(SharedString),
     Playlist(SharedString),
+    Artist(SharedString),
     Search,
     Settings,
 }

--- a/crates/spotify/src/albums.rs
+++ b/crates/spotify/src/albums.rs
@@ -5,9 +5,10 @@ use librespot_core::Session;
 use librespot_protocol::extended_metadata::{BatchedEntityRequest, EntityRequest, ExtensionQuery};
 use librespot_protocol::extension_kind::ExtensionKind;
 use librespot_protocol::metadata::Album as AlbumMessage;
+use librespot_protocol::metadata::album::Type as AlbumType;
 use protobuf::{EnumOrUnknown, Message as _};
 
-use crate::models::{Album, Track};
+use crate::models::{Album, AlbumDetail, ReleaseType, Track};
 use crate::{collection, collection2, wire};
 
 const ALBUM_PREFIX: &str = "spotify:album:";
@@ -24,7 +25,7 @@ pub async fn saved_albums(session: &Session, limit: u32) -> Result<Vec<Album>> {
     Ok(uris.iter().filter_map(|uri| known.remove(uri)).collect())
 }
 
-pub async fn album_tracks(session: &Session, album_id: &str) -> Result<Vec<Track>> {
+pub async fn album(session: &Session, album_id: &str) -> Result<AlbumDetail> {
     let uri = format!("{ALBUM_PREFIX}{album_id}");
     let request = batched(std::slice::from_ref(&uri));
     let response = session
@@ -33,22 +34,30 @@ pub async fn album_tracks(session: &Session, album_id: &str) -> Result<Vec<Track
         .await
         .context("cannot read album metadata")?;
 
-    let mut ids = Vec::new();
-    for array in response.extended_metadata {
-        for entity in array.extension_data {
-            let Ok(album) = AlbumMessage::parse_from_bytes(&entity.extension_data.value) else {
-                continue;
-            };
-            ids.extend(track_ids(&album));
+    let message = response
+        .extended_metadata
+        .into_iter()
+        .flat_map(|array| array.extension_data)
+        .find_map(|entity| AlbumMessage::parse_from_bytes(&entity.extension_data.value).ok())
+        .context("album metadata is missing")?;
+    let album = album_from(&uri, &message);
+    let uris: Vec<_> = track_ids(&message)
+        .into_iter()
+        .map(|id| format!("{TRACK_PREFIX}{id}"))
+        .collect();
+    let tracks = match uris.is_empty() {
+        true => Vec::new(),
+        false => {
+            let mut known = collection::metadata(session, &uris).await?;
+            uris.iter().filter_map(|uri| known.remove(uri)).collect()
         }
-    }
-    if ids.is_empty() {
-        return Ok(Vec::new());
-    }
+    };
 
-    let uris: Vec<String> = ids.iter().map(|id| format!("{TRACK_PREFIX}{id}")).collect();
-    let mut known = collection::metadata(session, &uris).await?;
-    Ok(uris.iter().filter_map(|uri| known.remove(uri)).collect())
+    Ok(AlbumDetail { album, tracks })
+}
+
+pub async fn album_tracks(session: &Session, album_id: &str) -> Result<Vec<Track>> {
+    Ok(album(session, album_id).await?.tracks)
 }
 
 fn track_ids(album: &AlbumMessage) -> Vec<String> {
@@ -83,7 +92,7 @@ fn batched(uris: &[String]) -> BatchedEntityRequest {
     }
 }
 
-async fn metadata(session: &Session, uris: &[String]) -> Result<HashMap<String, Album>> {
+pub(crate) async fn metadata(session: &Session, uris: &[String]) -> Result<HashMap<String, Album>> {
     let request = batched(uris);
 
     let response = session
@@ -106,27 +115,31 @@ async fn metadata(session: &Session, uris: &[String]) -> Result<HashMap<String, 
 }
 
 fn album_from(uri: &str, album: &AlbumMessage) -> Album {
-    let artists = album
-        .artist
-        .iter()
-        .filter_map(|artist| non_empty(artist.name.as_deref()))
-        .collect::<Vec<_>>()
-        .join(", ");
+    let (artists, artist_refs) = collection::artists_from(&album.artist);
 
     Album {
         id: uri.strip_prefix(ALBUM_PREFIX).unwrap_or(uri).to_owned(),
         name: non_empty(album.name.as_deref())
             .unwrap_or(UNKNOWN)
             .to_owned(),
-        artists: if artists.is_empty() {
-            UNKNOWN.to_owned()
-        } else {
-            artists
-        },
+        artists,
+        artist_refs,
         cover: cover(album),
         cover_large: cover_large(album),
+        release_type: release_type(album.type_()),
         year: album.date.as_ref().map(|date| date.year()).unwrap_or(0),
         track_count: track_ids(album).len() as u32,
+    }
+}
+
+fn release_type(kind: AlbumType) -> ReleaseType {
+    match kind {
+        AlbumType::ALBUM => ReleaseType::Album,
+        AlbumType::SINGLE => ReleaseType::Single,
+        AlbumType::COMPILATION => ReleaseType::Compilation,
+        AlbumType::EP => ReleaseType::Ep,
+        AlbumType::AUDIOBOOK => ReleaseType::Audiobook,
+        AlbumType::PODCAST => ReleaseType::Podcast,
     }
 }
 

--- a/crates/spotify/src/artists.rs
+++ b/crates/spotify/src/artists.rs
@@ -1,0 +1,128 @@
+use std::collections::{HashMap, HashSet};
+
+use anyhow::{Context as _, Result};
+use librespot_core::{Session, SpotifyUri};
+use librespot_protocol::metadata::image::Size as ImageSize;
+use librespot_protocol::metadata::{Artist as ArtistMessage, Image};
+use protobuf::Message as _;
+
+use crate::models::{Album, Artist, Track};
+use crate::{albums, collection, wire};
+
+const ARTIST_PREFIX: &str = "spotify:artist:";
+const ALBUM_PREFIX: &str = "spotify:album:";
+const TRACK_PREFIX: &str = "spotify:track:";
+const LARGE_PORTRAIT: i32 = 300;
+const RELEASES_PER_TYPE: usize = 8;
+
+pub async fn artist(session: &Session, artist_id: &str) -> Result<Artist> {
+    let uri = SpotifyUri::from_uri(&format!("{ARTIST_PREFIX}{artist_id}"))
+        .context("invalid artist ID")?;
+    let body = session
+        .spclient()
+        .get_artist_metadata(&uri)
+        .await
+        .context("cannot read artist metadata")?;
+    let message =
+        ArtistMessage::parse_from_bytes(&body).context("cannot decode artist metadata protobuf")?;
+
+    let track_uris = top_track_uris(&message, &session.country());
+    let release_uris = release_uris(&message);
+    let tracks = async {
+        match track_uris.is_empty() {
+            true => Ok(HashMap::<String, Track>::new()),
+            false => collection::metadata(session, &track_uris).await,
+        }
+    };
+    let releases = async {
+        match release_uris.is_empty() {
+            true => Ok(HashMap::<String, Album>::new()),
+            false => albums::metadata(session, &release_uris).await,
+        }
+    };
+    let (mut known_tracks, mut known_albums) = tokio::try_join!(tracks, releases)?;
+    let top_tracks = track_uris
+        .iter()
+        .filter_map(|uri| known_tracks.remove(uri))
+        .collect();
+    let releases = release_uris
+        .iter()
+        .filter_map(|uri| known_albums.remove(uri))
+        .collect();
+
+    Ok(artist_from(&message, top_tracks, releases))
+}
+
+fn artist_from(artist: &ArtistMessage, top_tracks: Vec<Track>, albums: Vec<Album>) -> Artist {
+    let portraits = portraits(artist);
+
+    Artist {
+        name: artist.name().to_owned(),
+        cover_large: portraits
+            .iter()
+            .filter(|image| image_width(image) >= LARGE_PORTRAIT)
+            .min_by_key(|image| image_width(image))
+            .or_else(|| portraits.iter().max_by_key(|image| image_width(image)))
+            .and_then(|image| wire::image_url(image.file_id())),
+        top_tracks,
+        albums,
+    }
+}
+
+fn top_track_uris(artist: &ArtistMessage, country: &str) -> Vec<String> {
+    artist
+        .top_track
+        .iter()
+        .find(|tracks| tracks.country() == country)
+        .or_else(|| {
+            artist
+                .top_track
+                .iter()
+                .find(|tracks| tracks.country().is_empty())
+        })
+        .into_iter()
+        .flat_map(|tracks| tracks.track.iter())
+        .filter_map(|track| collection::base62(track.gid()))
+        .map(|id| format!("{TRACK_PREFIX}{id}"))
+        .collect()
+}
+
+fn release_uris(artist: &ArtistMessage) -> Vec<String> {
+    let mut seen = HashSet::new();
+
+    artist
+        .album_group
+        .iter()
+        .take(RELEASES_PER_TYPE)
+        .chain(artist.single_group.iter().take(RELEASES_PER_TYPE))
+        .filter_map(|group| group.album.first())
+        .filter_map(|album| collection::base62(album.gid()))
+        .filter(|id| seen.insert(id.clone()))
+        .map(|id| format!("{ALBUM_PREFIX}{id}"))
+        .collect()
+}
+
+fn portraits(artist: &ArtistMessage) -> Vec<&Image> {
+    let mut portraits: Vec<_> = artist
+        .portrait_group
+        .as_ref()
+        .into_iter()
+        .flat_map(|group| group.image.iter())
+        .filter(|image| image.has_file_id())
+        .collect();
+    portraits.extend(artist.portrait.iter().filter(|image| image.has_file_id()));
+    portraits
+}
+
+fn image_width(image: &Image) -> i32 {
+    if image.width() > 0 {
+        return image.width();
+    }
+
+    match image.size() {
+        ImageSize::SMALL => 64,
+        ImageSize::DEFAULT => 300,
+        ImageSize::LARGE => 640,
+        ImageSize::XLARGE => 1_000,
+    }
+}

--- a/crates/spotify/src/client.rs
+++ b/crates/spotify/src/client.rs
@@ -4,15 +4,17 @@ use librespot_core::Session;
 use librespot_protocol::playlist4_external::SelectedListContent as RootList;
 use protobuf::Message as _;
 
-use crate::models::{Album, Playlist, Track, UserProfile};
-use crate::{albums, collection, playlists, profiles, search, wire};
+use crate::models::{Album, AlbumDetail, Artist, Playlist, Track, UserProfile};
+use crate::{albums, artists, collection, playlists, profiles, search, wire};
 
 #[async_trait]
 pub trait SpotifyApi: Send + Sync {
     async fn profile(&self) -> Result<UserProfile>;
+    async fn artist(&self, artist_id: &str) -> Result<Artist>;
     async fn saved_tracks(&self, limit: u32) -> Result<Vec<Track>>;
     async fn playlists(&self, limit: u32) -> Result<Vec<Playlist>>;
     async fn saved_albums(&self, limit: u32) -> Result<Vec<Album>>;
+    async fn album(&self, album_id: &str) -> Result<AlbumDetail>;
     async fn album_tracks(&self, album_id: &str) -> Result<Vec<Track>>;
     async fn playlist_tracks(&self, playlist_id: &str) -> Result<Vec<Track>>;
     async fn search(&self, query: &str) -> Result<Vec<Track>>;
@@ -49,12 +51,20 @@ impl SpotifyApi for LibrespotClient {
         })
     }
 
+    async fn artist(&self, artist_id: &str) -> Result<Artist> {
+        artists::artist(&self.session, artist_id).await
+    }
+
     async fn saved_tracks(&self, limit: u32) -> Result<Vec<Track>> {
         collection::saved_tracks(&self.session, limit).await
     }
 
     async fn saved_albums(&self, limit: u32) -> Result<Vec<Album>> {
         albums::saved_albums(&self.session, limit).await
+    }
+
+    async fn album(&self, album_id: &str) -> Result<AlbumDetail> {
+        albums::album(&self.session, album_id).await
     }
 
     async fn album_tracks(&self, album_id: &str) -> Result<Vec<Track>> {

--- a/crates/spotify/src/collection.rs
+++ b/crates/spotify/src/collection.rs
@@ -6,10 +6,12 @@ use librespot_core::Session;
 use librespot_protocol::extended_metadata::{BatchedEntityRequest, EntityRequest, ExtensionQuery};
 use librespot_protocol::extension_kind::ExtensionKind;
 use librespot_protocol::metadata::image::Size as ImageSize;
-use librespot_protocol::metadata::{Album as AlbumMessage, Track as TrackMessage};
+use librespot_protocol::metadata::{
+    Album as AlbumMessage, Artist as ArtistMessage, Track as TrackMessage,
+};
 use protobuf::{EnumOrUnknown, Message as _};
 
-use crate::models::Track;
+use crate::models::{ArtistRef, Track};
 use crate::wire;
 
 const LIKED_SONGS: &str = "spotify:collection:tracks";
@@ -80,12 +82,7 @@ pub(crate) async fn metadata(session: &Session, uris: &[String]) -> Result<HashM
 }
 
 fn track_from(uri: &str, track: &TrackMessage) -> Track {
-    let artists = track
-        .artist
-        .iter()
-        .filter_map(|artist| non_empty(artist.name.as_deref()))
-        .collect::<Vec<_>>()
-        .join(", ");
+    let (artists, artist_refs) = artists_from(&track.artist);
 
     Track {
         id: uri.strip_prefix(TRACK_PREFIX).map(str::to_owned),
@@ -93,12 +90,8 @@ fn track_from(uri: &str, track: &TrackMessage) -> Track {
         name: non_empty(track.name.as_deref())
             .unwrap_or(UNKNOWN)
             .to_owned(),
-        artists: if artists.is_empty() {
-            UNKNOWN.to_owned()
-        } else {
-            artists
-        },
-        artist_id: track.artist.first().and_then(|artist| base62(artist.gid())),
+        artists,
+        artist_refs,
         album: track
             .album
             .as_ref()
@@ -113,7 +106,29 @@ fn track_from(uri: &str, track: &TrackMessage) -> Track {
     }
 }
 
-fn base62(gid: &[u8]) -> Option<String> {
+pub(crate) fn artists_from(artists: &[ArtistMessage]) -> (String, Vec<ArtistRef>) {
+    let refs: Vec<_> = artists
+        .iter()
+        .filter_map(|artist| {
+            let name = non_empty(artist.name.as_deref())?.to_owned();
+            Some(ArtistRef {
+                name,
+                id: base62(artist.gid()),
+            })
+        })
+        .collect();
+    let names = match refs.is_empty() {
+        true => UNKNOWN.to_owned(),
+        false => refs
+            .iter()
+            .map(|artist| artist.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", "),
+    };
+    (names, refs)
+}
+
+pub(crate) fn base62(gid: &[u8]) -> Option<String> {
     librespot_core::SpotifyId::from_raw(gid)
         .ok()?
         .to_base62()

--- a/crates/spotify/src/lib.rs
+++ b/crates/spotify/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 
 mod albums;
+mod artists;
 mod client;
 mod collection;
 mod collection2;
@@ -13,4 +14,6 @@ mod wire;
 
 pub use auth::AuthConfig;
 pub use client::{LibrespotClient, SpotifyApi};
-pub use models::{Album, Playlist, Track, UserProfile};
+pub use models::{
+    Album, AlbumDetail, Artist, ArtistRef, Playlist, ReleaseType, Track, UserProfile,
+};

--- a/crates/spotify/src/models.rs
+++ b/crates/spotify/src/models.rs
@@ -7,12 +7,18 @@ pub struct UserProfile {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ArtistRef {
+    pub name: String,
+    pub id: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Track {
     pub id: Option<String>,
     pub name: String,
     pub playable: bool,
     pub artists: String,
-    pub artist_id: Option<String>,
+    pub artist_refs: Vec<ArtistRef>,
     pub album: String,
     pub album_id: Option<String>,
     pub cover: Option<String>,
@@ -30,13 +36,52 @@ pub struct Playlist {
     pub track_count: u32,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReleaseType {
+    Album,
+    Single,
+    Compilation,
+    Ep,
+    Audiobook,
+    Podcast,
+}
+
+impl ReleaseType {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Album => "Album",
+            Self::Single => "Single",
+            Self::Compilation => "Compilation",
+            Self::Ep => "EP",
+            Self::Audiobook => "Audiobook",
+            Self::Podcast => "Podcast",
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Album {
     pub id: String,
     pub name: String,
     pub artists: String,
+    pub artist_refs: Vec<ArtistRef>,
     pub cover: Option<String>,
     pub cover_large: Option<String>,
+    pub release_type: ReleaseType,
     pub year: i32,
     pub track_count: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AlbumDetail {
+    pub album: Album,
+    pub tracks: Vec<Track>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Artist {
+    pub name: String,
+    pub cover_large: Option<String>,
+    pub top_tracks: Vec<Track>,
+    pub albums: Vec<Album>,
 }

--- a/crates/state/src/artist.rs
+++ b/crates/state/src/artist.rs
@@ -1,0 +1,118 @@
+use gpui::{Context, Entity, Task};
+use spotify::{Album, Artist, Track};
+use tokio::task::AbortHandle;
+
+use crate::{Io, Session, SessionEvent, join};
+
+pub struct ArtistDetail {
+    id: Option<String>,
+    artist: Option<Artist>,
+    loading: bool,
+    error: Option<String>,
+    session: Entity<Session>,
+    io: Io,
+    task: Option<Task<()>>,
+    request: Option<AbortHandle>,
+}
+
+impl ArtistDetail {
+    pub fn new(session: Entity<Session>, io: Io, cx: &mut Context<Self>) -> Self {
+        cx.subscribe(&session, |this, _, event, cx| {
+            if matches!(event, SessionEvent::SignedOut) {
+                this.clear();
+                cx.notify();
+            }
+        })
+        .detach();
+
+        Self {
+            id: None,
+            artist: None,
+            loading: false,
+            error: None,
+            session,
+            io,
+            task: None,
+            request: None,
+        }
+    }
+
+    pub fn artist(&self) -> Option<&Artist> {
+        self.artist.as_ref()
+    }
+
+    pub fn tracks(&self) -> &[Track] {
+        self.artist
+            .as_ref()
+            .map(|artist| artist.top_tracks.as_slice())
+            .unwrap_or_default()
+    }
+
+    pub fn albums(&self) -> &[Album] {
+        self.artist
+            .as_ref()
+            .map(|artist| artist.albums.as_slice())
+            .unwrap_or_default()
+    }
+
+    pub fn is_loading(&self) -> bool {
+        self.loading
+    }
+
+    pub fn error(&self) -> Option<&str> {
+        self.error.as_deref()
+    }
+
+    pub fn open(&mut self, id: &str, cx: &mut Context<Self>) {
+        if self.id.as_deref() == Some(id) && (self.loading || self.artist.is_some()) {
+            return;
+        }
+
+        self.clear();
+        self.id = Some(id.to_owned());
+
+        let Some(client) = self.session.read(cx).client() else {
+            cx.notify();
+            return;
+        };
+
+        self.loading = true;
+        cx.notify();
+
+        let id = id.to_owned();
+        let request = self.io.spawn({
+            let id = id.clone();
+            async move { client.artist(&id).await }
+        });
+        self.request = Some(request.abort_handle());
+        self.task = Some(cx.spawn(async move |this, cx| {
+            let loaded = join(request).await;
+
+            this.update(cx, |this, cx| {
+                if this.id.as_deref() != Some(id.as_str()) {
+                    return;
+                }
+
+                this.loading = false;
+                this.request = None;
+                match loaded {
+                    Ok(artist) => this.artist = Some(artist),
+                    Err(error) => this.error = Some(format!("{error:#}")),
+                }
+                cx.notify();
+            })
+            .ok();
+        }));
+    }
+
+    fn clear(&mut self) {
+        self.task = None;
+        if let Some(request) = self.request.take() {
+            request.abort();
+        }
+        self.id = None;
+        self.artist = None;
+        self.loading = false;
+        self.error = None;
+    }
+}

--- a/crates/state/src/detail.rs
+++ b/crates/state/src/detail.rs
@@ -1,5 +1,5 @@
 use gpui::{Context, Entity, Task};
-use spotify::{Album, Playlist, Track};
+use spotify::{Album, AlbumDetail, ArtistRef, Playlist, Track};
 
 use crate::{Io, Library, Session, SessionEvent, join};
 
@@ -9,9 +9,16 @@ enum Kind {
     Playlist,
 }
 
+enum Loaded {
+    Album(AlbumDetail),
+    Tracks(Vec<Track>),
+}
+
 pub struct Header {
     pub kind: &'static str,
     pub title: String,
+    pub artist: Option<String>,
+    pub artist_refs: Vec<ArtistRef>,
     pub meta: String,
     pub cover: Option<String>,
 }
@@ -104,8 +111,8 @@ impl Detail {
         self.task = Some(cx.spawn(async move |this, cx| {
             let loaded = join(io.spawn(async move {
                 match kind {
-                    Kind::Album => client.album_tracks(&id).await,
-                    Kind::Playlist => client.playlist_tracks(&id).await,
+                    Kind::Album => client.album(&id).await.map(Loaded::Album),
+                    Kind::Playlist => client.playlist_tracks(&id).await.map(Loaded::Tracks),
                 }
             }))
             .await;
@@ -113,7 +120,11 @@ impl Detail {
             this.update(cx, |this, cx| {
                 this.loading = false;
                 match loaded {
-                    Ok(tracks) => this.tracks = tracks,
+                    Ok(Loaded::Album(detail)) => {
+                        this.header = Some(album_header(&detail.album));
+                        this.tracks = detail.tracks;
+                    }
+                    Ok(Loaded::Tracks(tracks)) => this.tracks = tracks,
                     Err(error) => this.error = Some(format!("{error:#}")),
                 }
                 cx.notify();
@@ -138,7 +149,7 @@ impl Detail {
 }
 
 fn album_header(album: &Album) -> Header {
-    let mut parts = vec![album.artists.clone()];
+    let mut parts = Vec::new();
     if album.year > 0 {
         parts.push(format!("{}", album.year));
     }
@@ -149,6 +160,8 @@ fn album_header(album: &Album) -> Header {
     Header {
         kind: "ALBUM",
         title: album.name.clone(),
+        artist: Some(album.artists.clone()),
+        artist_refs: album.artist_refs.clone(),
         meta: parts.join(" • "),
         cover: album.cover_large.clone(),
     }
@@ -163,6 +176,8 @@ fn playlist_header(playlist: &Playlist) -> Header {
     Header {
         kind: "PLAYLIST",
         title: playlist.name.clone(),
+        artist: None,
+        artist_refs: Vec::new(),
         meta: parts.join(" • "),
         cover: playlist.cover.clone(),
     }

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -1,3 +1,4 @@
+mod artist;
 mod detail;
 mod library;
 mod playback;
@@ -6,6 +7,7 @@ mod search;
 mod session;
 mod settings;
 
+pub use artist::ArtistDetail;
 pub use detail::{Detail, Header};
 pub use library::{Library, LibraryState};
 pub use playback::{Origin, Playback, PlaybackState};

--- a/crates/state/src/search.rs
+++ b/crates/state/src/search.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use gpui::{Context, Entity, Task};
-use spotify::{Album, Track};
+use spotify::{Album, ArtistRef, Track};
 
 use crate::{Io, Library, LibraryState, Session, SessionEvent, join};
 
@@ -39,6 +39,7 @@ pub struct AlbumHit {
     pub id: String,
     pub name: String,
     pub artists: String,
+    pub artist_refs: Vec<ArtistRef>,
     pub cover: Option<String>,
 }
 
@@ -292,6 +293,7 @@ fn albums_of(albums: &[Album], library: &[Track], catalog: &[Track], query: &Que
             &album.id,
             &album.name,
             &album.artists,
+            &album.artist_refs,
             &album.cover,
             None,
             0,
@@ -303,6 +305,7 @@ fn albums_of(albums: &[Album], library: &[Track], catalog: &[Track], query: &Que
             id,
             &track.album,
             &track.artists,
+            &track.artist_refs,
             &track.cover,
             rank,
             track.popularity,
@@ -311,7 +314,7 @@ fn albums_of(albums: &[Album], library: &[Track], catalog: &[Track], query: &Que
 
     let mut scored: Vec<Scored> = Vec::new();
     let mut seen: Vec<&String> = Vec::new();
-    for (id, name, artists, cover, rank, popularity) in saved.chain(derived) {
+    for (id, name, artists, artist_refs, cover, rank, popularity) in saved.chain(derived) {
         let fields = [(TITLE, name.as_str()), (ARTIST, artists.as_str())];
         let Some(score) = fit(&fields, query).max(inherited(rank)) else {
             continue;
@@ -328,6 +331,7 @@ fn albums_of(albums: &[Album], library: &[Track], catalog: &[Track], query: &Que
                 id: id.clone(),
                 name: name.clone(),
                 artists: artists.clone(),
+                artist_refs: artist_refs.clone(),
                 cover: cover.clone(),
             }),
         });
@@ -339,46 +343,50 @@ fn albums_of(albums: &[Album], library: &[Track], catalog: &[Track], query: &Que
 fn artists(library: &[Track], catalog: &[Track], albums: &[Album], query: &Query) -> Vec<Scored> {
     let mut tallies: Vec<(u32, u32, ArtistHit)> = Vec::new();
 
-    let mut record = |name: &str, id, cover, score, popularity, mine| match tallies
-        .iter_mut()
-        .find(|(_, _, artist)| artist.name == name)
-    {
-        Some((best, top, artist)) => {
-            *best = (*best).max(score);
-            *top = (*top).max(popularity);
-            artist.saved += mine;
-            artist.id = artist.id.take().or(id);
-            artist.cover = artist.cover.take().or(cover);
+    let mut record = |artist: &ArtistRef, cover, score, popularity, mine| {
+        let name = &artist.name;
+        let id = artist.id.clone();
+        match tallies
+            .iter_mut()
+            .find(|(_, _, current)| match (&current.id, &id) {
+                (Some(current), Some(incoming)) => current == incoming,
+                (None, _) | (_, None) => current.name == *name,
+            }) {
+            Some((best, top, current)) => {
+                *best = (*best).max(score);
+                *top = (*top).max(popularity);
+                current.saved += mine;
+                current.id = current.id.take().or(id);
+                current.cover = current.cover.take().or(cover);
+            }
+            None => tallies.push((
+                score,
+                popularity,
+                ArtistHit {
+                    name: name.clone(),
+                    id,
+                    cover,
+                    saved: mine,
+                },
+            )),
         }
-        None => tallies.push((
-            score,
-            popularity,
-            ArtistHit {
-                name: name.to_owned(),
-                id,
-                cover,
-                saved: mine,
-            },
-        )),
     };
 
     for (track, rank) in sources(library, catalog) {
-        for name in track.artists.split(", ") {
-            let Some(score) = named(name, query).max(inherited(rank)) else {
+        for artist in &track.artist_refs {
+            let Some(score) = named(&artist.name, query).max(inherited(rank)) else {
                 continue;
             };
-            let primary = track.artists.starts_with(name);
-            let id = primary.then(|| track.artist_id.clone()).flatten();
             let mine = usize::from(rank.is_none());
-            record(name, id, track.cover.clone(), score, track.popularity, mine);
+            record(artist, track.cover.clone(), score, track.popularity, mine);
         }
     }
     for album in albums {
-        for name in album.artists.split(", ") {
-            let Some(score) = named(name, query) else {
+        for artist in &album.artist_refs {
+            let Some(score) = named(&artist.name, query) else {
                 continue;
             };
-            record(name, None, album.cover.clone(), score, 0, 0);
+            record(artist, album.cover.clone(), score, 0, 0);
         }
     }
 
@@ -492,7 +500,13 @@ mod tests {
             name: name.to_owned(),
             playable: true,
             artists: artists.to_owned(),
-            artist_id: None,
+            artist_refs: artists
+                .split(", ")
+                .map(|name| ArtistRef {
+                    name: name.to_owned(),
+                    id: None,
+                })
+                .collect(),
             album: album.to_owned(),
             album_id: Some(album.to_owned()),
             cover: None,
@@ -600,5 +614,25 @@ mod tests {
             panic!("expected an artist hit");
         };
         assert_eq!(artist.saved, 1);
+    }
+
+    #[test]
+    fn artists_with_the_same_name_keep_separate_ids() {
+        let mut first = track("One", "Echo", "First");
+        first.artist_refs[0].id = Some("artist-one".to_owned());
+        let mut second = track("Two", "Echo", "Second");
+        second.artist_refs[0].id = Some("artist-two".to_owned());
+
+        let hits = rank(&[], &[], &[first, second], "echo");
+        let ids: Vec<_> = hits
+            .iter()
+            .filter_map(|hit| match hit {
+                Hit::Artist(artist) => artist.id.as_deref(),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&"artist-one"));
+        assert!(ids.contains(&"artist-two"));
     }
 }

--- a/crates/ui/src/inline_links.rs
+++ b/crates/ui/src/inline_links.rs
@@ -1,0 +1,109 @@
+use std::rc::Rc;
+
+use gpui::prelude::*;
+use gpui::{App, Hsla, MouseButton, Pixels, SharedString, Window, div};
+
+#[derive(Clone, Debug)]
+pub struct InlineLink {
+    pub label: SharedString,
+    pub value: Option<SharedString>,
+}
+
+impl InlineLink {
+    pub fn new(label: impl Into<SharedString>, value: Option<SharedString>) -> Self {
+        Self {
+            label: label.into(),
+            value,
+        }
+    }
+}
+
+type ClickHandler = Rc<dyn Fn(SharedString, &mut App) + 'static>;
+
+#[derive(IntoElement)]
+pub struct InlineLinks {
+    id: SharedString,
+    items: Vec<InlineLink>,
+    fallback: SharedString,
+    color: Hsla,
+    text_size: Option<Pixels>,
+    on_click: Option<ClickHandler>,
+}
+
+impl InlineLinks {
+    pub fn new(
+        id: impl Into<SharedString>,
+        items: impl IntoIterator<Item = InlineLink>,
+        fallback: impl Into<SharedString>,
+        color: Hsla,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            items: items.into_iter().collect(),
+            fallback: fallback.into(),
+            color,
+            text_size: None,
+            on_click: None,
+        }
+    }
+
+    pub fn text_size(mut self, text_size: Pixels) -> Self {
+        self.text_size = Some(text_size);
+        self
+    }
+
+    pub fn on_click(mut self, handler: impl Fn(SharedString, &mut App) + 'static) -> Self {
+        self.on_click = Some(Rc::new(handler));
+        self
+    }
+}
+
+impl RenderOnce for InlineLinks {
+    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        let Self {
+            id,
+            items,
+            fallback,
+            color,
+            text_size,
+            on_click,
+        } = self;
+        let empty = items.is_empty();
+        let id = id.to_string();
+
+        div()
+            .flex()
+            .w_full()
+            .min_w_0()
+            .overflow_hidden()
+            .text_color(color)
+            .when_some(text_size, |this, text_size| this.text_size(text_size))
+            .when(empty, |this| this.child(fallback))
+            .when(!empty, |this| {
+                this.children(items.into_iter().enumerate().map(|(index, item)| {
+                    let InlineLink { label, value } = item;
+                    let item = div().id(SharedString::from(format!("{id}-{index}")));
+                    let item = match value {
+                        Some(value) => {
+                            let handler = on_click.clone();
+                            item.hover(|style| style.underline())
+                                .cursor_pointer()
+                                .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                                .when_some(handler, |this, handler| {
+                                    this.on_click(move |_, _, cx| handler(value.clone(), cx))
+                                })
+                                .child(label)
+                        }
+                        None => item.child(label),
+                    };
+
+                    div()
+                        .flex()
+                        .flex_none()
+                        .min_w_0()
+                        .when(index > 0, |this| this.child(", "))
+                        .child(item)
+                }))
+            })
+    }
+}

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -3,6 +3,7 @@ mod button;
 mod controls;
 mod explicit;
 mod grid;
+mod inline_links;
 mod menu;
 mod metrics;
 mod row;
@@ -20,6 +21,7 @@ pub use grid::{
     Cell, ColumnSpec, Grid, GridDelegate, GridEvent, GridSource, GridState, ROW_GROUP, Viewport,
     Width, grid,
 };
+pub use inline_links::{InlineLink, InlineLinks};
 pub use menu::{Menu, MenuItem};
 pub use metrics::{Metrics, Rounding, Text, snapped};
 pub use row::Row;

--- a/crates/views/src/artist.rs
+++ b/crates/views/src/artist.rs
@@ -4,17 +4,18 @@ use gpui::{
     Window, div, px,
 };
 
-use spotify::Track;
-use state::{Detail, Playback};
+use spotify::{ReleaseType, Track};
+use state::{ArtistDetail, Playback};
 use ui::ActiveTheme as _;
 use ui::{
-    Artwork, ColumnSpec, GridDelegate, GridEvent, GridState, Scrollbar, Text, Viewport, grid,
-    scrolled,
+    Artwork, Button, ColumnSpec, GridDelegate, GridEvent, GridState, Scrollbar, Text, Viewport,
+    grid, scrolled,
 };
+use workspace::{Searchable, Sidebar};
 
 use crate::cells;
+use crate::release_card::ReleaseCard;
 use crate::tracks::{PlaybackStatus, TrackField, TrackSource, Tracks, playback_status};
-use workspace::{Searchable, Sidebar};
 
 const FRAME: Pixels = px(1.);
 
@@ -22,9 +23,40 @@ fn reserved(inset: Pixels) -> Pixels {
     inset * 2. + px(2.)
 }
 
-struct DetailTracks(Entity<Detail>);
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ReleaseFilter {
+    All,
+    Albums,
+    Singles,
+    Eps,
+}
 
-impl Tracks for DetailTracks {
+impl ReleaseFilter {
+    const ALL: [Self; 4] = [Self::All, Self::Singles, Self::Albums, Self::Eps];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::All => "All",
+            Self::Albums => "Albums",
+            Self::Singles => "Singles",
+            Self::Eps => "EPs",
+        }
+    }
+
+    fn matches(self, kind: ReleaseType) -> bool {
+        self == Self::All
+            || matches!(
+                (self, kind),
+                (Self::Albums, ReleaseType::Album)
+                    | (Self::Singles, ReleaseType::Single)
+                    | (Self::Eps, ReleaseType::Ep)
+            )
+    }
+}
+
+struct ArtistTracks(Entity<ArtistDetail>);
+
+impl Tracks for ArtistTracks {
     fn tracks<'a>(&self, cx: &'a App) -> &'a [Track] {
         self.0.read(cx).tracks()
     }
@@ -34,35 +66,33 @@ impl Tracks for DetailTracks {
     }
 }
 
-pub(crate) struct DetailView {
-    detail: Entity<Detail>,
+pub(crate) struct ArtistView {
+    detail: Entity<ArtistDetail>,
     playback: Entity<Playback>,
     playback_status: PlaybackStatus,
+    release_filter: ReleaseFilter,
     sidebar: Entity<Sidebar>,
     width: Pixels,
     scrollbar: Entity<Scrollbar>,
     table: Entity<GridState<TrackSource>>,
 }
 
-impl DetailView {
+impl ArtistView {
     pub(crate) fn new(
-        detail: Entity<Detail>,
+        detail: Entity<ArtistDetail>,
         playback: Entity<Playback>,
         sidebar: Entity<Sidebar>,
         columns: &'static [ColumnSpec<TrackField>],
-        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let inset = cx.theme().metrics.inset;
-        let width =
-            cells::content_width(window, sidebar.read(cx).occupied_width(), reserved(inset));
-
+        let width = px(200.);
         let table = cx.new(|cx| {
-            let source = TrackSource::new(columns, DetailTracks(detail.clone()), playback.clone());
+            let source = TrackSource::new(columns, ArtistTracks(detail.clone()), playback.clone());
             GridState::new(GridDelegate::new(source, width, cx))
         });
 
         cx.observe(&detail, |this, _, cx| {
+            this.release_filter = ReleaseFilter::All;
             this.scrollbar
                 .read(cx)
                 .scroll()
@@ -71,9 +101,7 @@ impl DetailView {
             cx.notify();
         })
         .detach();
-
         cx.observe(&sidebar, |_, _, cx| cx.notify()).detach();
-
         let current_playback = playback_status(&playback, cx);
         cx.observe(&playback, |this, playback, cx| {
             let current = playback_status(&playback, cx);
@@ -84,7 +112,6 @@ impl DetailView {
             this.table.update(cx, |table, cx| table.refresh(cx));
         })
         .detach();
-
         cx.subscribe(&table, |this, _, event, cx| {
             let GridEvent::DoubleClicked(display) = event;
             this.play(*display, cx);
@@ -97,6 +124,7 @@ impl DetailView {
             detail,
             playback,
             playback_status: current_playback,
+            release_filter: ReleaseFilter::All,
             sidebar,
             width,
             scrollbar,
@@ -154,20 +182,10 @@ impl DetailView {
 
     fn header(&self, cx: &Context<Self>) -> AnyElement {
         let theme = cx.theme();
-        let muted = theme.muted_foreground;
-        let header = self.detail.read(cx).header();
-        let kind = header.map(|header| header.kind).unwrap_or_default();
-        let title = header
-            .map(|header| SharedString::from(header.title.clone()))
+        let artist = self.detail.read(cx).artist();
+        let title = artist
+            .map(|artist| SharedString::from(artist.name.clone()))
             .unwrap_or_default();
-        let artist = header.and_then(|header| header.artist.clone());
-        let artist_refs = header
-            .map(|header| header.artist_refs.clone())
-            .unwrap_or_default();
-        let meta = header
-            .map(|header| header.meta.clone())
-            .filter(|meta| !meta.is_empty());
-        let has_artist = artist.is_some();
 
         div()
             .flex()
@@ -176,8 +194,9 @@ impl DetailView {
             .gap_5()
             .pb_6()
             .child(
-                Artwork::new(header.and_then(|header| header.cover.clone()))
-                    .size(theme.metrics.cover),
+                Artwork::new(artist.and_then(|artist| artist.cover_large.clone()))
+                    .size(theme.metrics.cover)
+                    .circle(),
             )
             .child(
                 div()
@@ -188,9 +207,9 @@ impl DetailView {
                     .child(
                         div()
                             .text_size(theme.text(Text::Small))
-                            .text_color(muted)
+                            .text_color(theme.muted_foreground)
                             .font_weight(FontWeight::SEMIBOLD)
-                            .child(kind),
+                            .child("ARTIST"),
                     )
                     .child(
                         div()
@@ -198,35 +217,78 @@ impl DetailView {
                             .font_weight(FontWeight::BOLD)
                             .truncate()
                             .child(title),
-                    )
-                    .child(
-                        div()
-                            .flex()
-                            .min_w_0()
-                            .text_color(muted)
-                            .truncate()
-                            .when_some(artist, |this, artist| {
-                                this.child(cells::artist_links(
-                                    "detail-artist",
-                                    artist_refs,
-                                    artist,
-                                    muted,
-                                ))
-                            })
-                            .when_some(meta, |this, meta| {
-                                let meta = match has_artist {
-                                    true => format!(" • {meta}"),
-                                    false => meta,
-                                };
-                                this.child(meta)
-                            }),
                     ),
             )
             .into_any_element()
     }
+
+    fn releases(&self, cx: &Context<Self>) -> Option<AnyElement> {
+        let theme = *cx.theme();
+        let albums = self.detail.read(cx).albums();
+        if albums.is_empty() {
+            return None;
+        }
+
+        Some(
+            div()
+                .flex()
+                .flex_col()
+                .gap_3()
+                .pt_6()
+                .child(
+                    div()
+                        .text_size(theme.text(Text::Title))
+                        .font_weight(FontWeight::BOLD)
+                        .child("Releases"),
+                )
+                .child(
+                    div()
+                        .flex()
+                        .gap_1()
+                        .children(ReleaseFilter::ALL.map(|filter| {
+                            Button::new(SharedString::from(format!(
+                                "release-filter-{}",
+                                filter.label().to_lowercase()
+                            )))
+                            .label(filter.label())
+                            .small()
+                            .outline()
+                            .selected(self.release_filter == filter)
+                            .on_click(cx.listener(
+                                move |this, _, _, cx| {
+                                    this.release_filter = filter;
+                                    cx.notify();
+                                },
+                            ))
+                        })),
+                )
+                .child(
+                    div().flex().flex_wrap().gap_4().children(
+                        albums
+                            .iter()
+                            .filter(|album| self.release_filter.matches(album.release_type))
+                            .cloned()
+                            .enumerate()
+                            .map(|(index, album)| ReleaseCard::new(index, album)),
+                    ),
+                )
+                .into_any_element(),
+        )
+    }
+
+    fn failure(&self, cx: &Context<Self>) -> Option<AnyElement> {
+        let error = self.detail.read(cx).error()?.to_owned();
+        Some(
+            div()
+                .pb_4()
+                .text_color(cx.theme().danger)
+                .child(error)
+                .into_any_element(),
+        )
+    }
 }
 
-impl Render for DetailView {
+impl Render for ArtistView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = *cx.theme();
         let inset = theme.metrics.inset;
@@ -241,26 +303,38 @@ impl Render for DetailView {
             .size_full()
             .child(
                 div()
-                    .id("detail-page")
+                    .id("artist-page")
                     .size_full()
                     .overflow_y_scroll()
                     .track_scroll(&scroll)
                     .px(inset)
                     .pt(inset)
                     .pb(inset)
-                    .child(self.header(cx))
+                    .child(
+                        div()
+                            .child(self.header(cx))
+                            .children(self.failure(cx))
+                            .child(
+                                div()
+                                    .pb_3()
+                                    .text_size(theme.text(Text::Title))
+                                    .font_weight(FontWeight::BOLD)
+                                    .child("Popular"),
+                            ),
+                    )
                     .child(
                         grid(&self.table)
                             .rounded(theme.radius)
                             .border_1()
                             .border_color(theme.border),
-                    ),
+                    )
+                    .children(self.releases(cx)),
             )
             .child(self.scrollbar.clone())
     }
 }
 
-impl Searchable for DetailView {
+impl Searchable for ArtistView {
     fn search(&mut self, query: &str, cx: &mut Context<Self>) {
         self.table.update(cx, |table, cx| {
             table.delegate_mut().set_filter(query, cx);
@@ -270,6 +344,6 @@ impl Searchable for DetailView {
     }
 
     fn hint() -> &'static str {
-        "Filter album tracks"
+        "Filter popular tracks"
     }
 }

--- a/crates/views/src/cells.rs
+++ b/crates/views/src/cells.rs
@@ -3,9 +3,12 @@ use gpui::{
     AnyElement, App, Context, Div, Entity, Hsla, MouseButton, Pixels, SharedString, Window, div,
     px, svg,
 };
-use router::{Destination, Link as _};
+use router::{Destination, Link as _, navigate};
+use spotify::ArtistRef;
 use state::{Playback, PlaybackState};
-use ui::{ActiveTheme as _, Artwork, Cell, ExplicitBadge, ROW_GROUP, Theme};
+use ui::{
+    ActiveTheme as _, Artwork, Cell, ExplicitBadge, InlineLink, InlineLinks, ROW_GROUP, Theme,
+};
 
 const PLAY: &str = "icons/play.svg";
 const PLAYING: &str = "icons/music-2.svg";
@@ -185,6 +188,39 @@ pub(crate) fn link<F>(
         .hover(|style| style.underline())
         .link(to)
         .child(value.into())
+        .into_any_element()
+}
+
+pub(crate) fn artist_links(
+    id: impl Into<SharedString>,
+    artists: Vec<ArtistRef>,
+    fallback: impl Into<SharedString>,
+    color: Hsla,
+) -> InlineLinks {
+    InlineLinks::new(
+        id,
+        artists
+            .into_iter()
+            .map(|artist| InlineLink::new(artist.name, artist.id.map(Into::into))),
+        fallback,
+        color,
+    )
+    .on_click(|id, cx| navigate(Destination::Artist(id), cx))
+}
+
+pub(crate) fn artists<F>(
+    cell: &Cell<F>,
+    artists: Vec<ArtistRef>,
+    fallback: impl Into<SharedString>,
+    color: Hsla,
+) -> AnyElement {
+    cell.frame()
+        .child(artist_links(
+            SharedString::from(format!("artist-{}", cell.row)),
+            artists,
+            fallback,
+            color,
+        ))
         .into_any_element()
 }
 

--- a/crates/views/src/lib.rs
+++ b/crates/views/src/lib.rs
@@ -1,12 +1,15 @@
+mod artist;
 mod cells;
 mod detail;
 mod library;
 mod login;
+mod release_card;
 mod root;
 mod search;
 mod settings;
 mod tracks;
 
+use artist::ArtistView;
 use detail::DetailView;
 pub use library::LibraryView;
 pub use login::LoginView;

--- a/crates/views/src/library/albums.rs
+++ b/crates/views/src/library/albums.rs
@@ -154,7 +154,12 @@ impl GridSource for AlbumSource {
         match cell.field {
             AlbumField::Cover => cells::artwork(&cell, album.cover.clone()),
             AlbumField::Name => cells::text(&cell, album.name.clone()),
-            AlbumField::Artists => cells::dim(&cell, album.artists.clone(), muted),
+            AlbumField::Artists => cells::artists(
+                &cell,
+                album.artist_refs.clone(),
+                album.artists.clone(),
+                muted,
+            ),
             AlbumField::Year => cells::dim(&cell, year(album), muted),
             AlbumField::TrackCount => cells::dim(&cell, format!("{}", album.track_count), muted),
             AlbumField::Index => cells::blank(&cell),

--- a/crates/views/src/library/mod.rs
+++ b/crates/views/src/library/mod.rs
@@ -10,7 +10,7 @@ use ui::{GridDelegate, GridEvent, GridState, Scrollbar, Viewport, grid, scrolled
 use workspace::{Searchable, Sidebar};
 
 use crate::cells;
-use crate::tracks::{LIBRARY_COLUMNS, TrackSource, Tracks};
+use crate::tracks::{LIBRARY_COLUMNS, PlaybackStatus, TrackSource, Tracks, playback_status};
 use albums::AlbumSource;
 use playlists::PlaylistSource;
 
@@ -59,6 +59,7 @@ impl Tracks for LibraryTracks {
 pub struct LibraryView {
     library: Entity<Library>,
     playback: Entity<Playback>,
+    playback_status: PlaybackStatus,
     sidebar: Entity<Sidebar>,
     section: Section,
     width: Pixels,
@@ -103,7 +104,13 @@ impl LibraryView {
 
         cx.observe(&sidebar, |_, _, cx| cx.notify()).detach();
 
-        cx.observe(&playback, |this, _, cx| {
+        let current_playback = playback_status(&playback, cx);
+        cx.observe(&playback, |this, playback, cx| {
+            let current = playback_status(&playback, cx);
+            if this.playback_status == current {
+                return;
+            }
+            this.playback_status = current;
             this.tracks.update(cx, |table, cx| table.refresh(cx));
             this.albums.update(cx, |table, cx| table.refresh(cx));
             this.playlists.update(cx, |table, cx| table.refresh(cx));
@@ -133,6 +140,7 @@ impl LibraryView {
         Self {
             library,
             playback,
+            playback_status: current_playback,
             sidebar,
             section: Section::Tracks,
             width,

--- a/crates/views/src/release_card.rs
+++ b/crates/views/src/release_card.rs
@@ -1,0 +1,63 @@
+use gpui::prelude::*;
+use gpui::{App, FontWeight, SharedString, Window, div};
+use router::{Destination, Link as _};
+use spotify::Album;
+use ui::{ActiveTheme as _, Artwork, Text};
+
+#[derive(IntoElement)]
+pub(crate) struct ReleaseCard {
+    index: usize,
+    album: Album,
+}
+
+impl ReleaseCard {
+    pub(crate) fn new(index: usize, album: Album) -> Self {
+        Self { index, album }
+    }
+}
+
+impl RenderOnce for ReleaseCard {
+    fn render(self, _: &mut Window, cx: &mut App) -> impl IntoElement {
+        let theme = *cx.theme();
+        let cover = self
+            .album
+            .cover_large
+            .clone()
+            .or_else(|| self.album.cover.clone());
+        let release = self.album.release_type.label();
+        let metadata = match self.album.year > 0 {
+            true => format!("{} • {release}", self.album.year),
+            false => release.to_owned(),
+        };
+
+        div()
+            .id(("artist-release", self.index))
+            .w(theme.metrics.cover)
+            .flex()
+            .flex_col()
+            .gap_2()
+            .cursor_pointer()
+            .link(Destination::Album(self.album.id.into()))
+            .child(Artwork::new(cover).size(theme.metrics.cover))
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap_1()
+                    .child(
+                        div()
+                            .truncate()
+                            .line_height(theme.text(Text::Body))
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .child(SharedString::from(self.album.name)),
+                    )
+                    .child(
+                        div()
+                            .text_size(theme.text(Text::Small))
+                            .line_height(theme.text(Text::Small))
+                            .text_color(theme.muted_foreground)
+                            .child(metadata),
+                    ),
+            )
+    }
+}

--- a/crates/views/src/root.rs
+++ b/crates/views/src/root.rs
@@ -3,16 +3,18 @@ use gpui::{AnyView, Context, Entity, Render};
 use gpui::{Window, div};
 use input::{OpenSearch, OpenSettings};
 use router::{Destination, NavigationEvent, navigate};
-use state::{Detail, Io, Library, Playback, Queue, Search, Session, SessionState};
+use state::{ArtistDetail, Detail, Io, Library, Playback, Queue, Search, Session, SessionState};
 use ui::ActiveTheme as _;
 use workspace::{Filter, Sidebar, Workspace};
 
 use crate::search::SearchView;
 use crate::tracks::{ALBUM_COLUMNS, LIBRARY_COLUMNS};
-use crate::{DetailView, LibraryView, LoginView, SettingsView};
+use crate::{ArtistView, DetailView, LibraryView, LoginView, SettingsView};
 
 struct Screens {
     library: Entity<LibraryView>,
+    artist: Option<Entity<ArtistView>>,
+    artist_detail: Option<Entity<ArtistDetail>>,
     album: Entity<DetailView>,
     album_detail: Entity<Detail>,
     playlist: Entity<DetailView>,
@@ -28,6 +30,9 @@ enum Focus {
 
 pub struct Root {
     session: Entity<Session>,
+    playback: Entity<Playback>,
+    sidebar: Entity<Sidebar>,
+    io: Io,
     login: Entity<LoginView>,
     workspace: Entity<Workspace>,
     filter: Entity<Filter>,
@@ -101,17 +106,29 @@ impl Root {
 
         let filter = cx.new(Filter::new);
         let start = navigation.read(cx).current();
-        let workspace =
-            cx.new(|cx| Workspace::new(sidebar, playback, queue, library_view.clone().into(), cx));
+        let workspace = cx.new(|cx| {
+            Workspace::new(
+                sidebar.clone(),
+                playback.clone(),
+                queue,
+                library_view.clone().into(),
+                cx,
+            )
+        });
 
         let mut root = Self {
             session,
+            playback,
+            sidebar,
+            io,
             login,
             workspace,
             filter,
             pending: None,
             screens: Screens {
                 library: library_view,
+                artist: None,
+                artist_detail: None,
                 album,
                 album_detail,
                 playlist,
@@ -122,6 +139,26 @@ impl Root {
         };
         root.show(start, cx);
         root
+    }
+
+    fn artist(&mut self, cx: &mut Context<Self>) -> (Entity<ArtistView>, Entity<ArtistDetail>) {
+        if let (Some(view), Some(detail)) = (&self.screens.artist, &self.screens.artist_detail) {
+            return (view.clone(), detail.clone());
+        }
+
+        let detail = cx.new(|cx| ArtistDetail::new(self.session.clone(), self.io.clone(), cx));
+        let view = cx.new(|cx| {
+            ArtistView::new(
+                detail.clone(),
+                self.playback.clone(),
+                self.sidebar.clone(),
+                LIBRARY_COLUMNS,
+                cx,
+            )
+        });
+        self.screens.artist = Some(view.clone());
+        self.screens.artist_detail = Some(detail.clone());
+        (view, detail)
     }
 
     fn open_search(&mut self, cx: &mut Context<Self>) {
@@ -144,7 +181,10 @@ impl Root {
 
         let searchable = matches!(
             destination,
-            Destination::Library(_) | Destination::Album(_) | Destination::Playlist(_)
+            Destination::Library(_)
+                | Destination::Artist(_)
+                | Destination::Album(_)
+                | Destination::Playlist(_)
         );
 
         let content: AnyView = match destination {
@@ -173,6 +213,13 @@ impl Root {
                 self.filter
                     .update(cx, |filter, cx| filter.bind(&playlist, cx));
                 playlist.into()
+            }
+            Destination::Artist(id) => {
+                let (artist, detail) = self.artist(cx);
+                detail.update(cx, |artist, cx| artist.open(&id, cx));
+                self.filter
+                    .update(cx, |filter, cx| filter.bind(&artist, cx));
+                artist.into()
             }
             Destination::Search => self.screens.search.clone().into(),
             Destination::Settings => self.screens.settings.clone().into(),

--- a/crates/views/src/search.rs
+++ b/crates/views/src/search.rs
@@ -5,18 +5,21 @@ use gpui::{
 };
 use input::Input;
 use router::{Destination, navigate};
+
 use state::{Hit, Kind, Playback, Search};
 use ui::ActiveTheme as _;
 use ui::{Artwork, Row, Scrollbar, Text, clock};
 use workspace::Sidebar;
 
 use crate::cells;
+use crate::tracks::{PlaybackStatus, playback_status};
 
 const READABLE: Pixels = px(1180.);
 const COLUMNS: Pixels = px(720.);
 
 enum Press {
     Song(usize),
+    Artist(String),
     Album(String),
 }
 
@@ -24,6 +27,7 @@ pub(crate) struct SearchView {
     input: Entity<Input>,
     search: Entity<Search>,
     playback: Entity<Playback>,
+    playback_status: PlaybackStatus,
     sidebar: Entity<Sidebar>,
     songs: Entity<Scrollbar>,
     artists: Entity<Scrollbar>,
@@ -49,7 +53,15 @@ impl SearchView {
 
         cx.observe(&search, |_, _, cx| cx.notify()).detach();
         cx.observe(&sidebar, |_, _, cx| cx.notify()).detach();
-        cx.observe(&playback, |_, _, cx| cx.notify()).detach();
+        let current_playback = playback_status(&playback, cx);
+        cx.observe(&playback, |this, playback, cx| {
+            let current = playback_status(&playback, cx);
+            if this.playback_status != current {
+                this.playback_status = current;
+                cx.notify();
+            }
+        })
+        .detach();
 
         let asked = input.read(cx).text().to_owned();
         search.update(cx, |search, cx| search.ask(&asked, cx));
@@ -58,6 +70,7 @@ impl SearchView {
             input,
             search,
             playback,
+            playback_status: current_playback,
             sidebar,
             songs: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
             artists: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
@@ -91,26 +104,19 @@ impl SearchView {
             .cursor_pointer()
             .on_click(cx.listener(move |this, _, _, cx| match &target {
                 Press::Song(index) => this.play(*index, cx),
+                Press::Artist(id) => navigate(Destination::Artist(id.clone().into()), cx),
                 Press::Album(id) => navigate(Destination::Album(id.clone().into()), cx),
             }))
             .child(child)
             .into_any_element()
     }
 
-    fn playing(&self, cx: &Context<Self>) -> Option<String> {
-        self.playback
-            .read(cx)
-            .track()
-            .and_then(|current| current.id.clone())
-    }
-
     fn row(&self, hit: &Hit, place: usize, compact: bool, cx: &Context<Self>) -> AnyElement {
         let theme = *cx.theme();
-        let meta = meta(hit, compact);
 
         match hit {
             Hit::Song(track) => {
-                let tint = match track.id.is_some() && track.id == self.playing(cx) {
+                let tint = match track.id.is_some() && track.id == self.playback_status.0 {
                     true => theme.primary,
                     false => theme.foreground,
                 };
@@ -120,29 +126,59 @@ impl SearchView {
                     Row::new(track.name.clone())
                         .cover(track.cover.clone())
                         .tint(tint)
-                        .meta(meta)
+                        .meta(meta(hit, compact))
                         .when(track.explicit, |row| row.explicit())
                         .trailing(
                             div()
+                                .flex()
                                 .flex_none()
-                                .text_size(theme.text(Text::Small))
-                                .text_color(theme.muted_foreground)
-                                .child(clock(track.duration)),
+                                .items_center()
+                                .gap_3()
+                                .child(
+                                    cells::artist_links(
+                                        format!("song-artist-{place}"),
+                                        track.artist_refs.clone(),
+                                        track.artists.clone(),
+                                        theme.muted_foreground,
+                                    )
+                                    .text_size(theme.text(Text::Small)),
+                                )
+                                .child(
+                                    div()
+                                        .flex_none()
+                                        .text_size(theme.text(Text::Small))
+                                        .text_color(theme.muted_foreground)
+                                        .child(clock(track.duration)),
+                                ),
                         ),
                     cx,
                 )
             }
-            Hit::Artist(artist) => Row::new(artist.name.clone())
-                .cover(artist.cover.clone())
-                .circle()
-                .meta(meta)
-                .into_any_element(),
+            Hit::Artist(artist) => {
+                let row = Row::new(artist.name.clone())
+                    .cover(artist.cover.clone())
+                    .circle()
+                    .meta(meta(hit, compact));
+                match &artist.id {
+                    Some(id) => self.press(("artist", place), Press::Artist(id.clone()), row, cx),
+                    None => row.into_any_element(),
+                }
+            }
             Hit::Album(album) => self.press(
                 ElementId::Name(album.id.clone().into()),
                 Press::Album(album.id.clone()),
                 Row::new(album.name.clone())
                     .cover(album.cover.clone())
-                    .meta(meta),
+                    .meta(meta(hit, compact))
+                    .trailing(
+                        cells::artist_links(
+                            format!("album-artist-{place}"),
+                            album.artist_refs.clone(),
+                            album.artists.clone(),
+                            theme.muted_foreground,
+                        )
+                        .text_size(theme.text(Text::Small)),
+                    ),
                 cx,
             ),
         }
@@ -151,12 +187,23 @@ impl SearchView {
     fn best(&self, cx: &Context<Self>) -> Option<AnyElement> {
         let theme = *cx.theme();
         let hit = self.search.read(cx).best()?;
-        let (kind, title, target) = match hit {
-            Hit::Song(track) => (Kind::Song, track.name.clone(), Some(Press::Song(0))),
-            Hit::Artist(artist) => (Kind::Artist, artist.name.clone(), None),
+        let (kind, title, artists, target) = match hit {
+            Hit::Song(track) => (
+                Kind::Song,
+                track.name.clone(),
+                track.artist_refs.clone(),
+                Some(Press::Song(0)),
+            ),
+            Hit::Artist(artist) => (
+                Kind::Artist,
+                artist.name.clone(),
+                Vec::new(),
+                artist.id.clone().map(Press::Artist),
+            ),
             Hit::Album(album) => (
                 Kind::Album,
                 album.name.clone(),
+                album.artist_refs.clone(),
                 Some(Press::Album(album.id.clone())),
             ),
         };
@@ -193,10 +240,13 @@ impl SearchView {
                             .child(title),
                     )
                     .child(
-                        div()
-                            .text_color(theme.muted_foreground)
-                            .truncate()
-                            .child(meta(hit, false)),
+                        cells::artist_links(
+                            "best-artist-link",
+                            artists,
+                            meta(hit, false),
+                            theme.muted_foreground,
+                        )
+                        .text_size(theme.text(Text::Small)),
                     ),
             );
 
@@ -309,18 +359,21 @@ impl SearchView {
     }
 
     fn everything(&self, cx: &Context<Self>) -> AnyElement {
-        let mut place = 0;
+        let mut places = [0; 3];
         let rows = self
             .search
             .read(cx)
             .hits()
             .iter()
             .map(|hit| {
-                let at = place;
-                if matches!(hit, Hit::Song(_)) {
-                    place += 1;
-                }
-                self.row(hit, at, true, cx)
+                let slot = match hit {
+                    Hit::Song(_) => 0,
+                    Hit::Artist(_) => 1,
+                    Hit::Album(_) => 2,
+                };
+                let place = places[slot];
+                places[slot] += 1;
+                self.row(hit, place, true, cx)
             })
             .collect();
 

--- a/crates/views/src/settings.rs
+++ b/crates/views/src/settings.rs
@@ -49,7 +49,6 @@ impl SettingsView {
     ) -> Self {
         let settings = Spotty::global(cx).settings.clone();
         cx.observe(&session, |_, _, cx| cx.notify()).detach();
-        cx.observe(&playback, |_, _, cx| cx.notify()).detach();
         cx.observe(&settings, |_, _, cx| cx.notify()).detach();
         Self {
             session,

--- a/crates/views/src/tracks.rs
+++ b/crates/views/src/tracks.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+use std::rc::Rc;
 use ui::ActiveTheme as _;
 
 use gpui::{AnyElement, App, Entity, Hsla, TextAlign};
@@ -125,6 +126,14 @@ pub(crate) const ALBUM_COLUMNS: &[ColumnSpec<TrackField>] = &[
     },
 ];
 
+pub(crate) type PlaybackStatus = (Option<String>, PlaybackState);
+
+pub(crate) fn playback_status(playback: &Entity<Playback>, cx: &App) -> PlaybackStatus {
+    let playback = playback.read(cx);
+    let track = playback.track().and_then(|track| track.id.clone());
+    (track, playback.state().clone())
+}
+
 pub(crate) trait Tracks: 'static {
     fn tracks<'a>(&self, cx: &'a App) -> &'a [Track];
     fn is_loading(&self, cx: &App) -> bool;
@@ -132,7 +141,7 @@ pub(crate) trait Tracks: 'static {
 
 pub(crate) struct TrackSource {
     columns: &'static [ColumnSpec<TrackField>],
-    provider: Box<dyn Tracks>,
+    provider: Rc<dyn Tracks>,
     playback: Entity<Playback>,
 }
 
@@ -144,9 +153,18 @@ impl TrackSource {
     ) -> Self {
         Self {
             columns,
-            provider: Box::new(provider),
+            provider: Rc::new(provider),
             playback,
         }
+    }
+
+    fn artist_cell(&self, cell: &Cell<TrackField>, track: &Track, color: Hsla) -> AnyElement {
+        cells::artists(
+            cell,
+            track.artist_refs.clone(),
+            track.artists.clone(),
+            color,
+        )
     }
 
     fn album_cell(&self, cell: &Cell<TrackField>, track: &Track, color: Hsla) -> AnyElement {
@@ -168,10 +186,11 @@ impl TrackSource {
         let press = match track.playable {
             false => None,
             true => {
-                let queued = self.provider.tracks(cx).to_vec();
+                let provider = self.provider.clone();
                 let row = cell.row;
                 cells::toggle(&self.playback, state.clone(), move |playback, cx| {
-                    playback.start(queued.clone(), row, cx)
+                    let queued = provider.tracks(cx).to_vec();
+                    playback.start(queued, row, cx)
                 })
             }
         };
@@ -231,7 +250,7 @@ impl GridSource for TrackSource {
         match cell.field {
             TrackField::Cover => cells::artwork(&cell, track.cover.clone()),
             TrackField::Title => cells::title(&cell, track.name.clone(), title, track.explicit),
-            TrackField::Artists => cells::dim(&cell, track.artists.clone(), detail),
+            TrackField::Artists => self.artist_cell(&cell, track, detail),
             TrackField::Album => self.album_cell(&cell, track, detail),
             TrackField::Duration => cells::dim(&cell, clock(track.duration), detail),
             TrackField::Index => cells::blank(&cell),

--- a/crates/workspace/src/player_bar.rs
+++ b/crates/workspace/src/player_bar.rs
@@ -1,4 +1,4 @@
-use router::{Destination, Link};
+use router::{Destination, Link, navigate};
 use std::time::Duration;
 use ui::ActiveTheme as _;
 
@@ -7,7 +7,7 @@ use gpui::{Context, Entity, MouseMoveEvent, MouseUpEvent, Render, SharedString, 
 use gpui::{Window, div, px};
 use state::{Playback, PlaybackState, Queue};
 
-use ui::{Artwork, Button, Scrubber, ScrubberState, clock};
+use ui::{Artwork, Button, InlineLink, InlineLinks, Scrubber, ScrubberState, clock};
 
 const SEEK_MAX: f32 = 560.;
 const VOLUME_WIDTH: f32 = 110.;
@@ -163,12 +163,18 @@ impl PlayerBar {
                         })
                         .when_some(track, |this, track| {
                             this.child(
-                                div()
-                                    .child(SharedString::from(track.artists))
-                                    .w_full()
-                                    .text_color(muted)
-                                    .text_size(artists)
-                                    .truncate(),
+                                InlineLinks::new(
+                                    "now-playing-artist",
+                                    track.artist_refs.into_iter().map(|artist| {
+                                        InlineLink::new(artist.name, artist.id.map(Into::into))
+                                    }),
+                                    track.artists,
+                                    muted,
+                                )
+                                .text_size(artists)
+                                .on_click(|id, cx| {
+                                    navigate(Destination::Artist(id), cx);
+                                }),
                             )
                         }),
                 )


### PR DESCRIPTION
## Summary

- add lazy-loaded artist detail pages with popular tracks and filtered releases
- make every available artist credit independently clickable across tables, search, details, and the player bar
- add reusable inline links and release card components
- load complete artist and catalog album metadata with cancellable requests
- avoid expensive queue cloning and redundant playback-driven table refreshes

## Validation

- cargo check -p spotty
- cargo test --workspace
- git diff --check