### PR TITLE
perf(playback): preload tracks before playback

### DIFF
--- a/crates/audio/src/lib.rs
+++ b/crates/audio/src/lib.rs
@@ -77,11 +77,15 @@ impl Engine {
     }
 
     pub fn load(&self, track_id: &str) -> Result<()> {
-        let uri = SpotifyUri::from_uri(&format!("{TRACK_PREFIX}{track_id}"))
-            .with_context(|| format!("{track_id} is not a track id"))?;
+        let uri = track_uri(track_id)?;
 
         self.flush.request();
         self.player.load(uri, true, 0);
+        Ok(())
+    }
+
+    pub fn preload(&self, track_id: &str) -> Result<()> {
+        self.player.preload(track_uri(track_id)?);
         Ok(())
     }
 
@@ -105,6 +109,11 @@ impl Engine {
     pub fn is_broken(&self) -> bool {
         self.player.is_invalid()
     }
+}
+
+fn track_uri(track_id: &str) -> Result<SpotifyUri> {
+    SpotifyUri::from_uri(&format!("{TRACK_PREFIX}{track_id}"))
+        .with_context(|| format!("{track_id} is not a track id"))
 }
 
 fn translate(event: PlayerEvent) -> Option<AudioEvent> {

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -109,6 +109,22 @@ impl Playback {
         self.load_after(track, Duration::ZERO, cx);
     }
 
+    pub fn preload(&self, track: &Track) {
+        let Some(engine) = self.engine.as_ref() else {
+            return;
+        };
+        let Some(id) = track.id.as_deref() else {
+            return;
+        };
+        if !track.playable || self.track.as_ref().and_then(|track| track.id.as_deref()) == Some(id)
+        {
+            return;
+        }
+        if let Err(error) = engine.preload(id) {
+            log::warn!("playback: cannot preload {}: {error:#}", track.name);
+        }
+    }
+
     fn load_after(&mut self, track: &Track, debounce: Duration, cx: &mut Context<Self>) {
         if self.engine.is_none() {
             return;

--- a/crates/views/src/cells.rs
+++ b/crates/views/src/cells.rs
@@ -1,7 +1,11 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::Duration;
+
 use gpui::prelude::*;
 use gpui::{
-    AnyElement, App, Context, Div, Entity, Hsla, MouseButton, Pixels, SharedString, Window, div,
-    px, svg,
+    AnyElement, App, Context, Div, Entity, Hsla, MouseButton, Pixels, SharedString, Task, Window,
+    div, px, svg,
 };
 use router::{Destination, Link as _, navigate};
 use spotify::ArtistRef;
@@ -14,6 +18,7 @@ const PLAY: &str = "icons/play.svg";
 const PLAYING: &str = "icons/music-2.svg";
 const PAUSE: &str = "icons/pause.svg";
 const UNAVAILABLE: &str = "icons/play-off.svg";
+const HOVER_PRELOAD_DELAY: Duration = Duration::from_millis(200);
 
 pub(crate) const NUMBER: Pixels = px(44.);
 pub(crate) const TRAILING: Pixels = px(72.);
@@ -144,6 +149,8 @@ pub(crate) fn transport<F>(cell: &Cell<F>, resting: AnyElement, hover: Transport
         press,
     } = hover;
     let enabled = press.is_some();
+    let preload = preload.map(Rc::<dyn Fn(&mut App)>::from);
+    let hover_task = Rc::new(RefCell::new(None::<Task<()>>));
 
     cell.frame()
         .h_full()
@@ -152,11 +159,27 @@ pub(crate) fn transport<F>(cell: &Cell<F>, resting: AnyElement, hover: Transport
         .justify_center()
         .child(
             div()
+                .id(("transport-hit", cell.row))
                 .relative()
                 .flex()
                 .items_center()
                 .justify_center()
                 .size(HIT)
+                .when_some(preload.clone(), |this, preload| {
+                    let hover_task = hover_task.clone();
+                    this.on_hover(move |hovered: &bool, _, cx| {
+                        let mut task = hover_task.borrow_mut();
+                        *task = if *hovered {
+                            let preload = preload.clone();
+                            Some(cx.spawn(async move |cx| {
+                                cx.background_executor().timer(HOVER_PRELOAD_DELAY).await;
+                                cx.update(|cx| preload(cx));
+                            }))
+                        } else {
+                            None
+                        };
+                    })
+                })
                 .child(
                     div()
                         .flex()
@@ -183,8 +206,10 @@ pub(crate) fn transport<F>(cell: &Cell<F>, resting: AnyElement, hover: Transport
                             |this| this.cursor_not_allowed(),
                         )
                         .when_some(press, |this, press| {
+                            let hover_task = hover_task.clone();
                             this.on_mouse_down(MouseButton::Left, move |_, _, cx| {
                                 cx.stop_propagation();
+                                hover_task.borrow_mut().take();
                                 if let Some(preload) = preload.as_ref() {
                                     preload(cx);
                                 }

--- a/crates/views/src/cells.rs
+++ b/crates/views/src/cells.rs
@@ -61,6 +61,7 @@ pub(crate) fn index<F>(
     cell: &Cell<F>,
     state: Option<PlaybackState>,
     playable: bool,
+    preload: Option<Box<dyn Fn(&mut App)>>,
     press: Option<Box<dyn Fn(&mut App)>>,
     cx: &App,
 ) -> AnyElement {
@@ -97,7 +98,16 @@ pub(crate) fn index<F>(
         false => theme.muted_foreground,
     };
 
-    transport(cell, resting, Transport { icon, color, press })
+    transport(
+        cell,
+        resting,
+        Transport {
+            icon,
+            color,
+            preload,
+            press,
+        },
+    )
 }
 
 pub(crate) fn toggle<F>(
@@ -122,11 +132,17 @@ where
 pub(crate) struct Transport {
     pub(crate) icon: &'static str,
     pub(crate) color: Hsla,
+    pub(crate) preload: Option<Box<dyn Fn(&mut App)>>,
     pub(crate) press: Option<Box<dyn Fn(&mut App)>>,
 }
 
 pub(crate) fn transport<F>(cell: &Cell<F>, resting: AnyElement, hover: Transport) -> AnyElement {
-    let Transport { icon, color, press } = hover;
+    let Transport {
+        icon,
+        color,
+        preload,
+        press,
+    } = hover;
     let enabled = press.is_some();
 
     cell.frame()
@@ -167,8 +183,13 @@ pub(crate) fn transport<F>(cell: &Cell<F>, resting: AnyElement, hover: Transport
                             |this| this.cursor_not_allowed(),
                         )
                         .when_some(press, |this, press| {
-                            this.on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
-                                .on_click(move |_, _, cx| press(cx))
+                            this.on_mouse_down(MouseButton::Left, move |_, _, cx| {
+                                cx.stop_propagation();
+                                if let Some(preload) = preload.as_ref() {
+                                    preload(cx);
+                                }
+                            })
+                            .on_click(move |_, _, cx| press(cx))
                         }),
                 ),
         )

--- a/crates/views/src/library/albums.rs
+++ b/crates/views/src/library/albums.rs
@@ -103,7 +103,7 @@ impl AlbumSource {
             playback.play_album(&id, cx)
         });
 
-        cells::index(cell, state, true, press, cx)
+        cells::index(cell, state, true, None, press, cx)
     }
 
     pub(super) fn at(&self, row: usize, cx: &App) -> Option<Album> {

--- a/crates/views/src/library/playlists.rs
+++ b/crates/views/src/library/playlists.rs
@@ -88,7 +88,7 @@ impl PlaylistSource {
             playback.play_playlist(&id, cx)
         });
 
-        cells::index(cell, state, true, press, cx)
+        cells::index(cell, state, true, None, press, cx)
     }
 
     pub(super) fn at(&self, row: usize, cx: &App) -> Option<Playlist> {

--- a/crates/views/src/tracks.rs
+++ b/crates/views/src/tracks.rs
@@ -183,19 +183,25 @@ impl TrackSource {
 
     fn index_cell(&self, cell: &Cell<TrackField>, track: &Track, cx: &App) -> AnyElement {
         let state = self.now_playing(track, cx);
-        let press = match track.playable {
-            false => None,
+        let (preload, press) = match track.playable {
+            false => (None, None),
             true => {
+                let playback = self.playback.clone();
+                let preload_track = track.clone();
+                let preload: Option<Box<dyn Fn(&mut App)>> = Some(Box::new(move |cx| {
+                    playback.update(cx, |playback, _| playback.preload(&preload_track));
+                }));
                 let provider = self.provider.clone();
                 let row = cell.row;
-                cells::toggle(&self.playback, state.clone(), move |playback, cx| {
+                let press = cells::toggle(&self.playback, state.clone(), move |playback, cx| {
                     let queued = provider.tracks(cx).to_vec();
                     playback.start(queued, row, cx)
-                })
+                });
+                (preload, press)
             }
         };
 
-        cells::index(cell, state, track.playable, press, cx)
+        cells::index(cell, state, track.playable, preload, press, cx)
     }
 
     fn now_playing(&self, track: &Track, cx: &App) -> Option<PlaybackState> {


### PR DESCRIPTION
## What changed

- preload a playable track through librespot when its row play button is pressed
- preload after the pointer rests on the transport hitbox for 200 ms
- cancel a pending hover preload when the pointer leaves, while mouse-down preloads immediately
- reuse the same validated Spotify track URI parsing for preload and playback

## Why

Track playback currently begins on mouse-up/click. Starting the network preload on an earlier intent signal reduces the perceived delay without interrupting the currently playing track or changing when the queue and playback state are committed.

## User impact

Tracks can begin playing sooner after clicking their play button. Passing briefly over controls does not preload because the hover path waits 200 ms.

## Root cause

The player previously called librespot's combined load-and-play operation only after click handling. It did not expose or invoke librespot's dedicated preload path during pointer interaction.

## Validation

- `cargo check --workspace`
- `cargo test --workspace --no-fail-fast` (19 tests passed)
- `git diff --check`
