### PR TITLE
feat(search): split local and global shortcuts

### DIFF
--- a/crates/input/src/lib.rs
+++ b/crates/input/src/lib.rs
@@ -11,6 +11,7 @@ actions!(
         SignOut,
         RefreshLibrary,
         TogglePlayback,
+        OpenFilter,
         OpenSearch,
         OpenSettings
     ]
@@ -56,8 +57,10 @@ pub fn bindings() -> Vec<KeyBinding> {
         KeyBinding::new("ctrl-q", Quit, None),
         KeyBinding::new("cmd-r", RefreshLibrary, None),
         KeyBinding::new("ctrl-r", RefreshLibrary, None),
-        KeyBinding::new("cmd-f", OpenSearch, None),
-        KeyBinding::new("ctrl-f", OpenSearch, None),
+        KeyBinding::new("cmd-f", OpenFilter, None),
+        KeyBinding::new("ctrl-f", OpenFilter, None),
+        KeyBinding::new("shift-cmd-f", OpenSearch, None),
+        KeyBinding::new("shift-ctrl-f", OpenSearch, None),
         KeyBinding::new("ctrl-,", OpenSettings, None),
         KeyBinding::new("cmd-,", OpenSettings, None),
         KeyBinding::new("space", TogglePlayback, Some(&away_from_text)),

--- a/crates/views/src/root.rs
+++ b/crates/views/src/root.rs
@@ -1,7 +1,7 @@
 use gpui::prelude::*;
 use gpui::{AnyView, Context, Entity, Render};
 use gpui::{Window, div};
-use input::{OpenSearch, OpenSettings};
+use input::{OpenFilter, OpenSearch, OpenSettings};
 use router::{Destination, NavigationEvent, navigate};
 use state::{ArtistDetail, Detail, Io, Library, Playback, Queue, Search, Session, SessionState};
 use ui::ActiveTheme as _;
@@ -167,6 +167,11 @@ impl Root {
         cx.notify();
     }
 
+    fn open_filter(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.filter
+            .update(cx, |filter, cx| filter.focus(window, cx));
+    }
+
     fn open_settings(&mut self, cx: &mut Context<Self>) {
         navigate(Destination::Settings, cx);
         self.pending = Some(Focus::Workspace);
@@ -266,6 +271,7 @@ impl Render for Root {
             .size_full()
             .bg(theme.background)
             .text_color(theme.foreground)
+            .on_action(cx.listener(|this, _: &OpenFilter, window, cx| this.open_filter(window, cx)))
             .on_action(cx.listener(|this, _: &OpenSearch, _, cx| this.open_search(cx)))
             .on_action(cx.listener(|this, _: &OpenSettings, _, cx| this.open_settings(cx)))
             .when_else(

--- a/crates/workspace/src/searchable.rs
+++ b/crates/workspace/src/searchable.rs
@@ -65,6 +65,10 @@ impl Filter {
     }
 
     pub fn focus(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.apply.is_none() {
+            return;
+        }
+
         self.open = true;
         self.input.update(cx, |input, cx| input.focus(window, cx));
         cx.notify();


### PR DESCRIPTION
## What changed

- bind `Ctrl+F` and `Cmd+F` to the current page's filter
- bind `Ctrl+Shift+F` and `Cmd+Shift+F` to global search
- route the local-filter action through the active workspace filter
- ignore the local-filter action on pages that do not support filtering

## Why

The existing find shortcut always navigated to global search even though library, album, playlist, and artist pages already expose page-specific filtering.

## User impact

Users can now search within the current page using the familiar find shortcut and explicitly open Spotify-wide search with the shifted shortcut.

## Root cause

The application only defined one search action, and both find shortcuts were bound to it. The page filter was only reachable through its toolbar button.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace --no-fail-fast` (19 tests passed)
- `git diff --check`

Strict Clippy remains blocked by pre-existing warnings in the untouched `ui` and `input` code.
