### PR TITLE
feat(navigation): support mouse side buttons

### DIFF
--- a/crates/views/src/root.rs
+++ b/crates/views/src/root.rs
@@ -1,8 +1,8 @@
 use gpui::prelude::*;
-use gpui::{AnyView, Context, Entity, Render};
+use gpui::{AnyView, Context, Entity, MouseButton, NavigationDirection, Render};
 use gpui::{Window, div};
 use input::{OpenFilter, OpenSearch, OpenSettings};
-use router::{Destination, NavigationEvent, navigate};
+use router::{Destination, NavigationEvent, back, forward, navigate};
 use state::{
     ArtistDetail, Detail, Home, Io, Library, Playback, Queue, Search, Session, SessionState,
 };
@@ -277,6 +277,14 @@ impl Render for Root {
             .size_full()
             .bg(theme.background)
             .text_color(theme.foreground)
+            .on_mouse_down(
+                MouseButton::Navigate(NavigationDirection::Back),
+                |_, _, cx| back(cx),
+            )
+            .on_mouse_down(
+                MouseButton::Navigate(NavigationDirection::Forward),
+                |_, _, cx| forward(cx),
+            )
             .on_action(cx.listener(|this, _: &OpenFilter, window, cx| this.open_filter(window, cx)))
             .on_action(cx.listener(|this, _: &OpenSearch, _, cx| this.open_search(cx)))
             .on_action(cx.listener(|this, _: &OpenSettings, _, cx| this.open_settings(cx)))


### PR DESCRIPTION
## What changed

- bind the mouse back side button (Mouse4) to the router's back history action
- bind the mouse forward side button (Mouse5) to the router's forward history action
- register both handlers at the root view so they work across every application screen

## Why

Users with mice that provide browser-style side buttons expect them to navigate application history just like the existing title-bar controls.

## User impact

Mouse4 and Mouse5 now move backward and forward through Spotty's navigation history when those destinations are available. At either end of the history, the existing router safely leaves the current destination unchanged.

## Validation

- `cargo check --workspace`
- `cargo test --workspace --no-fail-fast` (20 tests passed)
- `rustfmt --check --edition 2024 crates/views/src/root.rs`
- `git diff --check`

`cargo fmt --all -- --check` also identified an unrelated pre-existing formatting difference in `crates/state/src/search.rs`; that file is not changed by this PR.
