### PR TITLE
feat(ui): date added in library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7743,6 +7743,7 @@ version = "0.1.0"
 dependencies = [
  "gpui",
  "input",
+ "jiff",
  "router",
  "spotify",
  "state",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ gpui_platform = { git = "https://github.com/zed-industries/zed", rev = "f25b256f
   "x11",
 ] }
 http = "1.3"
+jiff = { version = "0.2", default-features = false, features = ["std"] }
 log = "0.4"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",

--- a/crates/spotify/src/collection.rs
+++ b/crates/spotify/src/collection.rs
@@ -12,37 +12,26 @@ use librespot_protocol::metadata::{
 use protobuf::{EnumOrUnknown, Message as _};
 
 use crate::models::{ArtistRef, Track};
-use crate::wire;
+use crate::{collection2, wire};
 
-const LIKED_SONGS: &str = "spotify:collection:tracks";
 const TRACK_PREFIX: &str = "spotify:track:";
 const UNKNOWN: &str = "Unknown";
 
 pub async fn saved_tracks(session: &Session, limit: u32) -> Result<Vec<Track>> {
-    let uris = liked_uris(session, limit as usize).await?;
-    if uris.is_empty() {
+    let items = collection2::saved_items(session, TRACK_PREFIX, limit as usize).await?;
+    if items.is_empty() {
         return Ok(Vec::new());
     }
 
+    let uris: Vec<_> = items.iter().map(|item| item.uri.clone()).collect();
     let mut known = metadata(session, &uris).await?;
-    Ok(uris.iter().filter_map(|uri| known.remove(uri)).collect())
-}
-
-async fn liked_uris(session: &Session, limit: usize) -> Result<Vec<String>> {
-    let context = session
-        .spclient()
-        .get_context(LIKED_SONGS)
-        .await
-        .context("cannot resolve the liked songs context")?;
-
-    Ok(context
-        .pages
-        .iter()
-        .flat_map(|page| page.tracks.iter())
-        .filter_map(|track| track.uri.as_deref())
-        .filter(|uri| uri.starts_with(TRACK_PREFIX))
-        .take(limit)
-        .map(str::to_owned)
+    Ok(items
+        .into_iter()
+        .filter_map(|item| {
+            let mut track = known.remove(&item.uri)?;
+            track.added_at = item.added_at;
+            Some(track)
+        })
         .collect())
 }
 
@@ -101,6 +90,7 @@ fn track_from(uri: &str, track: &TrackMessage) -> Track {
         album_id: track.album.as_ref().and_then(|album| base62(album.gid())),
         cover: track.album.as_ref().and_then(cover_url),
         duration: Duration::from_millis(track.duration.unwrap_or_default().max(0) as u64),
+        added_at: None,
         popularity: track.popularity.unwrap_or_default().clamp(0, 100) as u32,
         explicit: track.explicit.unwrap_or_default(),
     }

--- a/crates/spotify/src/collection2.rs
+++ b/crates/spotify/src/collection2.rs
@@ -19,14 +19,32 @@ const RESPONSE_ITEMS: u32 = 1;
 const RESPONSE_TOKEN: u32 = 2;
 
 const ITEM_URI: u32 = 1;
+const ITEM_ADDED_AT: u32 = 2;
 const ITEM_REMOVED: u32 = 3;
 
 struct Page {
-    uris: Vec<String>,
+    items: Vec<SavedItem>,
     next: String,
 }
 
+pub(crate) struct SavedItem {
+    pub(crate) uri: String,
+    pub(crate) added_at: Option<i64>,
+}
+
 pub async fn saved_uris(session: &Session, prefix: &str, limit: usize) -> Result<Vec<String>> {
+    Ok(saved_items(session, prefix, limit)
+        .await?
+        .into_iter()
+        .map(|item| item.uri)
+        .collect())
+}
+
+pub(crate) async fn saved_items(
+    session: &Session,
+    prefix: &str,
+    limit: usize,
+) -> Result<Vec<SavedItem>> {
     let mut headers = HeaderMap::new();
     headers.insert(CONTENT_TYPE, HeaderValue::from_static(CONTENT));
     headers.insert(ACCEPT, HeaderValue::from_static(CONTENT));
@@ -45,7 +63,11 @@ pub async fn saved_uris(session: &Session, prefix: &str, limit: usize) -> Result
 
         let page = response(&raw).context("cannot decode the collection page")?;
 
-        found.extend(page.uris.into_iter().filter(|uri| uri.starts_with(prefix)));
+        found.extend(
+            page.items
+                .into_iter()
+                .filter(|item| item.uri.starts_with(prefix)),
+        );
 
         token = page.next;
         if found.len() >= limit || token.is_empty() {
@@ -68,14 +90,14 @@ fn request(username: &str, token: &str) -> Vec<u8> {
 
 fn response(bytes: &[u8]) -> Result<Page> {
     let mut page = Page {
-        uris: Vec::new(),
+        items: Vec::new(),
         next: String::new(),
     };
     let mut reader = Reader::new(bytes);
 
     while let Some((field, value)) = reader.field()? {
         match (field, value) {
-            (RESPONSE_ITEMS, Value::Bytes(item)) => page.uris.extend(kept(item)?),
+            (RESPONSE_ITEMS, Value::Bytes(item)) => page.items.extend(kept(item)?),
             (RESPONSE_TOKEN, Value::Bytes(token)) => page.next = text(token)?,
             _ => (),
         }
@@ -84,18 +106,50 @@ fn response(bytes: &[u8]) -> Result<Page> {
     Ok(page)
 }
 
-fn kept(bytes: &[u8]) -> Result<Option<String>> {
+fn kept(bytes: &[u8]) -> Result<Option<SavedItem>> {
     let mut uri = None;
+    let mut added_at = None;
     let mut removed = false;
     let mut reader = Reader::new(bytes);
 
     while let Some((field, value)) = reader.field()? {
         match (field, value) {
             (ITEM_URI, Value::Bytes(raw)) => uri = Some(text(raw)?),
+            (ITEM_ADDED_AT, Value::Varint(raw)) => {
+                added_at = Some(raw as u32 as i32 as i64);
+            }
             (ITEM_REMOVED, Value::Varint(flag)) => removed = flag != 0,
             _ => (),
         }
     }
 
-    Ok(uri.filter(|_| !removed))
+    Ok(uri
+        .filter(|_| !removed)
+        .map(|uri| SavedItem { uri, added_at }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_saved_item_with_date() {
+        let mut writer = Writer::default();
+        writer.string(ITEM_URI, "spotify:track:abc");
+        writer.int32(ITEM_ADDED_AT, 1_725_552_000);
+
+        let item = kept(&writer.finish()).unwrap().unwrap();
+
+        assert_eq!(item.uri, "spotify:track:abc");
+        assert_eq!(item.added_at, Some(1_725_552_000));
+    }
+
+    #[test]
+    fn drops_removed_item() {
+        let mut writer = Writer::default();
+        writer.string(ITEM_URI, "spotify:track:abc");
+        writer.int32(ITEM_REMOVED, 1);
+
+        assert!(kept(&writer.finish()).unwrap().is_none());
+    }
 }

--- a/crates/spotify/src/models.rs
+++ b/crates/spotify/src/models.rs
@@ -23,6 +23,7 @@ pub struct Track {
     pub album_id: Option<String>,
     pub cover: Option<String>,
     pub duration: Duration,
+    pub added_at: Option<i64>,
     pub popularity: u32,
     pub explicit: bool,
 }

--- a/crates/state/src/search.rs
+++ b/crates/state/src/search.rs
@@ -577,6 +577,7 @@ mod tests {
             album_id: Some(album.to_owned()),
             cover: None,
             duration: Duration::ZERO,
+            added_at: None,
             popularity: 0,
             explicit: false,
         }

--- a/crates/ui/src/grid.rs
+++ b/crates/ui/src/grid.rs
@@ -140,6 +140,12 @@ impl<S: GridSource> GridDelegate<S> {
         &self.source
     }
 
+    pub fn with_sort(mut self, field: S::Field, direction: Sort, cx: &App) -> Self {
+        self.sort = Some((field, direction));
+        self.reorder(cx);
+        self
+    }
+
     pub fn set_width(&mut self, width: Pixels, cx: &App) {
         self.width = width;
         self.relayout(cx);

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -18,8 +18,8 @@ pub use button::Button;
 pub use controls::WindowControls;
 pub use explicit::ExplicitBadge;
 pub use grid::{
-    Cell, ColumnSpec, Grid, GridDelegate, GridEvent, GridSource, GridState, ROW_GROUP, Viewport,
-    Width, grid,
+    Cell, ColumnSpec, Grid, GridDelegate, GridEvent, GridSource, GridState, ROW_GROUP, Sort,
+    Viewport, Width, grid,
 };
 pub use inline_links::{InlineLink, InlineLinks};
 pub use menu::{Menu, MenuItem};

--- a/crates/views/Cargo.toml
+++ b/crates/views/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 gpui.workspace = true
+jiff.workspace = true
 spotify.workspace = true
 input.workspace = true
 router.workspace = true

--- a/crates/views/src/cells.rs
+++ b/crates/views/src/cells.rs
@@ -22,6 +22,7 @@ const HOVER_PRELOAD_DELAY: Duration = Duration::from_millis(200);
 
 pub(crate) const NUMBER: Pixels = px(44.);
 pub(crate) const TRAILING: Pixels = px(72.);
+pub(crate) const DATE: Pixels = px(112.);
 pub(crate) const YEAR: Pixels = px(64.);
 pub(crate) const HIT: Pixels = px(18.);
 

--- a/crates/views/src/library/mod.rs
+++ b/crates/views/src/library/mod.rs
@@ -6,11 +6,13 @@ use gpui::{App, Context, Entity, Pixels, Point, Render, ScrollHandle, Window, di
 use router::{Destination, LibraryTab, navigate};
 use spotify::Track;
 use state::{Library, LibraryState, Playback};
-use ui::{GridDelegate, GridEvent, GridState, Scrollbar, Viewport, grid, scrolled};
+use ui::{GridDelegate, GridEvent, GridState, Scrollbar, Sort, Viewport, grid, scrolled};
 use workspace::{Searchable, Sidebar};
 
 use crate::cells;
-use crate::tracks::{LIBRARY_COLUMNS, PlaybackStatus, TrackSource, Tracks, playback_status};
+use crate::tracks::{
+    LIBRARY_COLUMNS, PlaybackStatus, TrackField, TrackSource, Tracks, playback_status,
+};
 use albums::AlbumSource;
 use playlists::PlaylistSource;
 
@@ -85,7 +87,12 @@ impl LibraryView {
                 LibraryTracks(library.clone()),
                 playback.clone(),
             );
-            GridState::new(GridDelegate::new(source, width, cx))
+            let delegate = GridDelegate::new(source, width, cx).with_sort(
+                TrackField::AddedAt,
+                Sort::Descending,
+                cx,
+            );
+            GridState::new(delegate)
         });
         let albums = cx.new(|cx| {
             let source = AlbumSource::new(library.clone(), playback.clone());

--- a/crates/views/src/tracks.rs
+++ b/crates/views/src/tracks.rs
@@ -3,12 +3,13 @@ use std::rc::Rc;
 use ui::ActiveTheme as _;
 
 use gpui::{AnyElement, App, Entity, Hsla, TextAlign};
+use jiff::Timestamp;
 use router::Destination;
 use spotify::Track;
 use state::{Playback, PlaybackState};
 use ui::{Cell, ColumnSpec, GridSource, Width, clock};
 
-use crate::cells::{self, ALWAYS, NUMBER, ROOMY, SNUG, TRAILING, WIDE};
+use crate::cells::{self, ALWAYS, DATE, NUMBER, ROOMY, SNUG, TRAILING, WIDE};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TrackField {
@@ -17,6 +18,7 @@ pub(crate) enum TrackField {
     Title,
     Artists,
     Album,
+    AddedAt,
     Duration,
 }
 
@@ -67,6 +69,16 @@ pub(crate) const LIBRARY_COLUMNS: &[ColumnSpec<TrackField>] = &[
         header: "Album",
         align: TextAlign::Left,
         width: Width::Fill(0.29),
+        flush: false,
+        sortable: true,
+        hide_below: WIDE,
+    },
+    ColumnSpec {
+        field: TrackField::AddedAt,
+        key: "added-at",
+        header: "Date added",
+        align: TextAlign::Left,
+        width: Width::Fixed(DATE),
         flush: false,
         sortable: true,
         hide_below: WIDE,
@@ -258,6 +270,15 @@ impl GridSource for TrackSource {
             TrackField::Title => cells::title(&cell, track.name.clone(), title, track.explicit),
             TrackField::Artists => self.artist_cell(&cell, track, detail),
             TrackField::Album => self.album_cell(&cell, track, detail),
+            TrackField::AddedAt => cells::dim(
+                &cell,
+                track
+                    .added_at
+                    .and_then(|seconds| Timestamp::new(seconds, 0).ok())
+                    .map(|timestamp| timestamp.strftime("%b %-d, %Y").to_string())
+                    .unwrap_or_default(),
+                detail,
+            ),
             TrackField::Duration => cells::dim(&cell, clock(track.duration), detail),
             TrackField::Index => cells::blank(&cell),
         }
@@ -278,6 +299,10 @@ impl GridSource for TrackSource {
                 text(a, |track| &track.artists).cmp(&text(b, |track| &track.artists))
             }
             TrackField::Album => text(a, |track| &track.album).cmp(&text(b, |track| &track.album)),
+            TrackField::AddedAt => tracks
+                .get(a)
+                .and_then(|track| track.added_at)
+                .cmp(&tracks.get(b).and_then(|track| track.added_at)),
             TrackField::Duration => tracks
                 .get(a)
                 .map(|track| track.duration)


### PR DESCRIPTION
## Summary

- preserve each saved track's collection timestamp
- add a sortable **Date added** column to the library songs table
- sort library songs by date added, newest first, by default
- keep album and detail track tables unchanged

## Why

The library did not expose when songs were saved, even though Spotify's collection response includes that timestamp. This makes the saved-song list easier to scan and restores the expected newest-first library ordering.

## Validation

- `cargo check --workspace`
- `cargo test --workspace`
- parser tests for saved and removed collection items
- `git diff --check`

Note: `cargo fmt --all -- --check` reports a pre-existing formatting difference in an unrelated search test; changed files were formatted directly.
