### PR TITLE
feat(home): add quick picks carousel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6554,6 +6554,7 @@ dependencies = [
  "anyhow",
  "audio",
  "dirs",
+ "fastrand",
  "gpui",
  "librespot-core",
  "log",
@@ -7741,6 +7742,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "views"
 version = "0.1.0"
 dependencies = [
+ "fastrand",
  "gpui",
  "input",
  "router",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ bytes = "1"
 cpal = "0.16"
 dirs = "6.0"
 env_logger = "0.11"
+fastrand = "2.5"
 gpui = { git = "https://github.com/zed-industries/zed", rev = "f25b256f2c10e1b638031a3d8d5a524056ebf268" }
 gpui_platform = { git = "https://github.com/zed-industries/zed", rev = "f25b256f2c10e1b638031a3d8d5a524056ebf268", features = [
   "font-kit",

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -15,6 +15,7 @@ pub enum LibraryTab {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Destination {
+    Home,
     Library(LibraryTab),
     Album(SharedString),
     Playlist(SharedString),

--- a/crates/spotify/src/client.rs
+++ b/crates/spotify/src/client.rs
@@ -5,7 +5,7 @@ use librespot_protocol::playlist4_external::SelectedListContent as RootList;
 use protobuf::Message as _;
 
 use crate::models::{Album, AlbumDetail, Artist, Playlist, Track, UserProfile};
-use crate::{albums, artists, collection, playlists, profiles, search, wire};
+use crate::{albums, artists, collection, playlists, profiles, radio, search, wire};
 
 #[async_trait]
 pub trait SpotifyApi: Send + Sync {
@@ -17,6 +17,7 @@ pub trait SpotifyApi: Send + Sync {
     async fn album(&self, album_id: &str) -> Result<AlbumDetail>;
     async fn album_tracks(&self, album_id: &str) -> Result<Vec<Track>>;
     async fn playlist_tracks(&self, playlist_id: &str) -> Result<Vec<Track>>;
+    async fn track_radio(&self, track_id: &str) -> Result<Vec<Track>>;
     async fn search(&self, query: &str) -> Result<Vec<Track>>;
 }
 
@@ -73,6 +74,10 @@ impl SpotifyApi for LibrespotClient {
 
     async fn playlist_tracks(&self, playlist_id: &str) -> Result<Vec<Track>> {
         playlists::playlist_tracks(&self.session, playlist_id).await
+    }
+
+    async fn track_radio(&self, track_id: &str) -> Result<Vec<Track>> {
+        radio::track_radio(&self.session, track_id).await
     }
 
     async fn search(&self, query: &str) -> Result<Vec<Track>> {

--- a/crates/spotify/src/lib.rs
+++ b/crates/spotify/src/lib.rs
@@ -9,6 +9,7 @@ mod models;
 mod pb;
 mod playlists;
 mod profiles;
+mod radio;
 mod search;
 mod wire;
 

--- a/crates/spotify/src/radio.rs
+++ b/crates/spotify/src/radio.rs
@@ -1,0 +1,59 @@
+use anyhow::{Context as _, Result};
+use librespot_core::{Session, SpotifyUri};
+use serde::Deserialize;
+
+use crate::models::Track;
+use crate::playlists;
+
+const TRACK_PREFIX: &str = "spotify:track:";
+const PLAYLIST_PREFIX: &str = "spotify:playlist:";
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RadioResponse {
+    media_items: Vec<MediaItem>,
+}
+
+#[derive(Deserialize)]
+struct MediaItem {
+    uri: String,
+}
+
+pub async fn track_radio(session: &Session, track_id: &str) -> Result<Vec<Track>> {
+    let uri =
+        SpotifyUri::from_uri(&format!("{TRACK_PREFIX}{track_id}")).context("invalid track ID")?;
+    let body = session
+        .spclient()
+        .get_radio_for_track(&uri)
+        .await
+        .context("cannot build track radio")?;
+    let response: RadioResponse =
+        serde_json::from_slice(&body).context("cannot decode track radio response")?;
+    let playlist_id =
+        radio_playlist_id(&response).context("track radio response did not contain a playlist")?;
+
+    playlists::playlist_tracks(session, playlist_id).await
+}
+
+fn radio_playlist_id(response: &RadioResponse) -> Option<&str> {
+    response
+        .media_items
+        .iter()
+        .find_map(|item| item.uri.strip_prefix(PLAYLIST_PREFIX))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RadioResponse, radio_playlist_id};
+
+    #[test]
+    fn extracts_playlist_from_radio_response() {
+        let response: RadioResponse = serde_json::from_value(serde_json::json!({
+            "total": 1,
+            "mediaItems": [{ "uri": "spotify:playlist:radio-playlist" }]
+        }))
+        .unwrap();
+
+        assert_eq!(radio_playlist_id(&response), Some("radio-playlist"));
+    }
+}

--- a/crates/spotty/src/main.rs
+++ b/crates/spotty/src/main.rs
@@ -8,7 +8,7 @@ use gpui::{
     App, AppContext as _, Bounds, Entity, TitlebarOptions, WindowBounds, WindowOptions, point, px,
     size,
 };
-use router::{Destination, LibraryTab};
+use router::Destination;
 use state::{Library, Playback, Queue, Session, Spotty};
 use ui::ActiveTheme as _;
 use views::Root;
@@ -34,7 +34,7 @@ fn main() {
         .with_http_client(Arc::new(http::Client::new(io.handle())))
         .run(move |cx: &mut App| {
             state::init(cx, io);
-            router::init(Destination::Library(LibraryTab::Songs), cx);
+            router::init(Destination::Home, cx);
             let (look, overrides) = {
                 let settings = Spotty::global(cx).settings.read(cx);
                 (

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 anyhow.workspace = true
 audio.workspace = true
 dirs.workspace = true
+fastrand.workspace = true
 gpui.workspace = true
 librespot-core.workspace = true
 log.workspace = true

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -45,6 +45,7 @@ pub enum PlaybackEvent {
 pub enum Origin {
     Album(String),
     Playlist(String),
+    Radio(String),
 }
 
 pub struct Playback {
@@ -146,7 +147,29 @@ impl Playback {
     }
 
     pub fn start(&mut self, tracks: Vec<Track>, index: usize, cx: &mut Context<Self>) {
+        self.fetch = None;
         self.begin(tracks, index, None, cx);
+    }
+
+    pub fn play_radio(&mut self, seed: &Track, cx: &mut Context<Self>) {
+        let Some(id) = seed.id.clone() else {
+            return self.failed(format!("{} has no track id", seed.name), cx);
+        };
+        if !seed.playable {
+            return self.failed(format!("{} is not available to stream", seed.name), cx);
+        }
+
+        let origin = Origin::Radio(id.clone());
+        let seed = seed.clone();
+        self.gather(origin, cx, move |client| {
+            Box::pin(async move {
+                let mut tracks = client.track_radio(&id).await?;
+                tracks.retain(|track| track.id != seed.id && track.playable);
+                fastrand::shuffle(&mut tracks);
+                tracks.insert(0, seed);
+                Ok(tracks)
+            })
+        });
     }
 
     pub fn play_album(&mut self, album: &str, cx: &mut Context<Self>) {
@@ -199,14 +222,19 @@ impl Playback {
         };
 
         let io = Io::global(cx);
-        self.state = PlaybackState::Loading;
-        cx.notify();
+        if !self.has_active_playback() {
+            self.state = PlaybackState::Loading;
+            cx.notify();
+        }
 
         self.fetch = Some(cx.spawn(async move |this, cx| {
             let loaded = join(io.spawn(async move { tracks(client).await })).await;
 
             this.update(cx, |this, cx| match loaded {
                 Ok(tracks) => this.begin(tracks, 0, Some(origin), cx),
+                Err(error) if this.has_active_playback() => {
+                    log::error!("playback: cannot load context: {error:#}");
+                }
                 Err(error) => this.failed(format!("{error:#}"), cx),
             })
             .ok();
@@ -214,6 +242,7 @@ impl Playback {
     }
 
     pub fn next(&mut self, cx: &mut Context<Self>) {
+        self.fetch = None;
         let Some(track) = self.queue.update(cx, |queue, cx| queue.next(cx)) else {
             return;
         };
@@ -221,6 +250,7 @@ impl Playback {
     }
 
     pub fn previous(&mut self, cx: &mut Context<Self>) {
+        self.fetch = None;
         let Some(track) = self.queue.update(cx, |queue, cx| queue.previous(cx)) else {
             return;
         };
@@ -295,6 +325,14 @@ impl Playback {
 
     pub fn is_loading(&self) -> bool {
         matches!(self.state, PlaybackState::Loading)
+    }
+
+    fn has_active_playback(&self) -> bool {
+        self.track.is_some()
+            && matches!(
+                self.state,
+                PlaybackState::Playing | PlaybackState::Paused | PlaybackState::Loading
+            )
     }
 
     pub fn volume(&self) -> f32 {

--- a/crates/views/Cargo.toml
+++ b/crates/views/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+fastrand.workspace = true
 gpui.workspace = true
 spotify.workspace = true
 input.workspace = true

--- a/crates/views/src/home.rs
+++ b/crates/views/src/home.rs
@@ -1,0 +1,256 @@
+use std::collections::HashSet;
+use std::rc::Rc;
+
+use gpui::prelude::*;
+use gpui::{App, Context, Entity, Render, Window, div};
+use spotify::Track;
+use state::{Library, LibraryState, Playback};
+use ui::ActiveTheme as _;
+use workspace::Sidebar;
+
+use crate::quick_picks::{QuickPicks, column_count, page_count};
+use crate::tracks::{PlaybackStatus, playback_status};
+
+const GROUP_SIZE: usize = 12;
+const LIMIT: usize = GROUP_SIZE * 3;
+
+pub(crate) struct HomeView {
+    playback: Entity<Playback>,
+    playback_status: PlaybackStatus,
+    quick_picks: Rc<Vec<Track>>,
+    quick_picks_columns: usize,
+    quick_picks_page: usize,
+    quick_picks_seed: u64,
+    sidebar: Entity<Sidebar>,
+}
+
+impl HomeView {
+    pub(crate) fn new(
+        library: Entity<Library>,
+        playback: Entity<Playback>,
+        sidebar: Entity<Sidebar>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let quick_picks_seed = session_seed();
+        let quick_picks = picks(&library, quick_picks_seed, cx);
+
+        cx.observe(&library, |this, library, cx| {
+            this.quick_picks = picks(&library, this.quick_picks_seed, cx);
+            this.quick_picks_page = 0;
+            cx.notify();
+        })
+        .detach();
+        cx.observe(&sidebar, |_, _, cx| cx.notify()).detach();
+
+        let current_playback = playback_status(&playback, cx);
+        cx.observe(&playback, |this, playback, cx| {
+            let current = playback_status(&playback, cx);
+            if this.playback_status != current {
+                this.playback_status = current;
+                cx.notify();
+            }
+        })
+        .detach();
+
+        Self {
+            playback,
+            playback_status: current_playback,
+            quick_picks,
+            quick_picks_columns: 0,
+            quick_picks_page: 0,
+            quick_picks_seed,
+            sidebar,
+        }
+    }
+}
+
+impl Render for HomeView {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = *cx.theme();
+        let available = window.viewport_size().width
+            - self.sidebar.read(cx).occupied_width()
+            - theme.metrics.inset * 2.;
+        let columns = column_count(available);
+        if self.quick_picks_columns != columns {
+            self.quick_picks_columns = columns;
+            self.quick_picks_page = 0;
+        }
+
+        let pages = page_count(self.quick_picks.len(), available);
+        self.quick_picks_page = self.quick_picks_page.min(pages.saturating_sub(1));
+        let page = self.quick_picks_page;
+
+        div()
+            .id("home-page")
+            .size_full()
+            .overflow_y_scroll()
+            .p(theme.metrics.inset)
+            .child(
+                div().flex().flex_col().gap_6().child(
+                    QuickPicks::new(
+                        self.quick_picks.clone(),
+                        self.playback.clone(),
+                        self.playback_status.0.clone(),
+                        available,
+                        page,
+                    )
+                    .on_previous(cx.listener(|this, _, _, cx| {
+                        this.quick_picks_page = this.quick_picks_page.saturating_sub(1);
+                        cx.notify();
+                    }))
+                    .on_next(cx.listener(move |this, _, _, cx| {
+                        this.quick_picks_page =
+                            (this.quick_picks_page + 1).min(pages.saturating_sub(1));
+                        cx.notify();
+                    })),
+                ),
+            )
+    }
+}
+
+fn picks(library: &Entity<Library>, seed: u64, cx: &App) -> Rc<Vec<Track>> {
+    let tracks = match library.read(cx).state() {
+        LibraryState::Ready { tracks, .. } => mixed_tracks(tracks, seed),
+        _ => Vec::new(),
+    };
+    Rc::new(tracks)
+}
+
+fn mixed_tracks(tracks: &[Track], seed: u64) -> Vec<Track> {
+    let mut random = fastrand::Rng::with_seed(seed);
+    let mut selected = tracks
+        .iter()
+        .enumerate()
+        .filter(|(_, track)| track.playable && track.id.is_some())
+        .map(|(index, _)| index)
+        .take(GROUP_SIZE)
+        .collect::<Vec<_>>();
+    let recent = selected.iter().copied().collect::<HashSet<_>>();
+    let mut remaining = tracks
+        .iter()
+        .enumerate()
+        .filter(|(index, track)| track.playable && track.id.is_some() && !recent.contains(index))
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    random.shuffle(&mut remaining);
+
+    let random_count = GROUP_SIZE.min(remaining.len());
+    selected.extend(remaining.drain(..random_count));
+
+    let mut artists = selected
+        .iter()
+        .map(|index| artist_key(&tracks[*index]))
+        .collect::<HashSet<_>>();
+    let mut fallback = Vec::new();
+    let mut diverse_count = 0;
+    for index in remaining {
+        if diverse_count < GROUP_SIZE && artists.insert(artist_key(&tracks[index])) {
+            selected.push(index);
+            diverse_count += 1;
+        } else {
+            fallback.push(index);
+        }
+    }
+
+    selected.extend(fallback.into_iter().take(LIMIT - selected.len()));
+    let mut mixed = selected
+        .into_iter()
+        .map(|index| tracks[index].clone())
+        .collect::<Vec<_>>();
+    random.shuffle(&mut mixed);
+    mixed
+}
+
+fn artist_key(track: &Track) -> &str {
+    track
+        .artist_refs
+        .first()
+        .map(|artist| artist.id.as_deref().unwrap_or(&artist.name))
+        .unwrap_or(&track.artists)
+}
+
+fn session_seed() -> u64 {
+    fastrand::u64(..)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::time::Duration;
+
+    use spotify::{ArtistRef, Track};
+
+    use super::{GROUP_SIZE, LIMIT, mixed_tracks};
+
+    fn track(index: usize, artist: usize, playable: bool) -> Track {
+        Track {
+            id: Some(format!("track-{index}")),
+            name: format!("Track {index}"),
+            playable,
+            artists: format!("Artist {artist}"),
+            artist_refs: vec![ArtistRef {
+                name: format!("Artist {artist}"),
+                id: Some(format!("artist-{artist}")),
+            }],
+            album: String::new(),
+            album_id: None,
+            cover: None,
+            duration: Duration::from_secs(180),
+            popularity: 0,
+            explicit: false,
+        }
+    }
+
+    #[test]
+    fn mixed_selection_is_stable_and_has_no_duplicates() {
+        let tracks = (0..60)
+            .map(|index| track(index, index, true))
+            .collect::<Vec<_>>();
+
+        let first = mixed_tracks(&tracks, 42);
+        let second = mixed_tracks(&tracks, 42);
+        let ids = first
+            .iter()
+            .filter_map(|track| track.id.as_ref())
+            .collect::<HashSet<_>>();
+
+        assert_eq!(first, second);
+        assert_eq!(first.len(), LIMIT);
+        assert_eq!(ids.len(), LIMIT);
+        for index in 0..GROUP_SIZE {
+            let expected = format!("track-{index}");
+            assert!(
+                first
+                    .iter()
+                    .any(|track| track.id.as_deref() == Some(expected.as_str()))
+            );
+        }
+    }
+
+    #[test]
+    fn mixed_selection_excludes_unavailable_tracks() {
+        let tracks = (0..50)
+            .map(|index| track(index, index, index % 2 == 0))
+            .collect::<Vec<_>>();
+
+        let selected = mixed_tracks(&tracks, 7);
+
+        assert_eq!(selected.len(), 25);
+        assert!(selected.iter().all(|track| track.playable));
+    }
+
+    #[test]
+    fn mixed_selection_adds_artist_variety() {
+        let tracks = (0..64)
+            .map(|index| track(index, index.saturating_sub(23), true))
+            .collect::<Vec<_>>();
+
+        let selected = mixed_tracks(&tracks, 99);
+        let artists = selected
+            .iter()
+            .map(|track| &track.artists)
+            .collect::<HashSet<_>>();
+
+        assert!(artists.len() > GROUP_SIZE);
+    }
+}

--- a/crates/views/src/lib.rs
+++ b/crates/views/src/lib.rs
@@ -1,8 +1,10 @@
 mod artist;
 mod cells;
 mod detail;
+mod home;
 mod library;
 mod login;
+mod quick_picks;
 mod release_card;
 mod root;
 mod search;
@@ -11,6 +13,7 @@ mod tracks;
 
 use artist::ArtistView;
 use detail::DetailView;
+use home::HomeView;
 pub use library::LibraryView;
 pub use login::LoginView;
 pub use root::Root;

--- a/crates/views/src/quick_picks.rs
+++ b/crates/views/src/quick_picks.rs
@@ -1,0 +1,311 @@
+use std::rc::Rc;
+
+use gpui::prelude::*;
+use gpui::{App, ClickEvent, Entity, FontWeight, Pixels, SharedString, Window, div};
+use spotify::Track;
+use state::Playback;
+use ui::{ActiveTheme as _, Artwork, Button, ExplicitBadge, Skeleton, Text, snapped};
+
+use crate::cells;
+
+const ROWS_PER_COLUMN: usize = 6;
+const MAX_COLUMNS: usize = 3;
+const MIN_COLUMN_WIDTH: Pixels = gpui::px(280.);
+
+type ClickHandler = Rc<dyn Fn(&ClickEvent, &mut Window, &mut App)>;
+
+pub(crate) fn column_count(width: Pixels) -> usize {
+    ((width / MIN_COLUMN_WIDTH).floor().max(1.) as usize).min(MAX_COLUMNS)
+}
+
+pub(crate) fn page_count(track_count: usize, width: Pixels) -> usize {
+    track_count
+        .div_ceil(column_count(width) * ROWS_PER_COLUMN)
+        .max(1)
+}
+
+#[derive(IntoElement)]
+pub(crate) struct QuickPicks {
+    tracks: Rc<Vec<Track>>,
+    playback: Entity<Playback>,
+    active: Option<String>,
+    width: Pixels,
+    page: usize,
+    on_previous: Option<ClickHandler>,
+    on_next: Option<ClickHandler>,
+}
+
+impl QuickPicks {
+    pub(crate) fn new(
+        tracks: Rc<Vec<Track>>,
+        playback: Entity<Playback>,
+        active: Option<String>,
+        width: Pixels,
+        page: usize,
+    ) -> Self {
+        Self {
+            tracks,
+            playback,
+            active,
+            width,
+            page,
+            on_previous: None,
+            on_next: None,
+        }
+    }
+
+    pub(crate) fn on_previous(
+        mut self,
+        handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_previous = Some(Rc::new(handler));
+        self
+    }
+
+    pub(crate) fn on_next(
+        mut self,
+        handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_next = Some(Rc::new(handler));
+        self
+    }
+}
+
+impl RenderOnce for QuickPicks {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let theme = *cx.theme();
+        let columns = column_count(self.width);
+        let page_size = columns * ROWS_PER_COLUMN;
+        let pages = page_count(self.tracks.len(), self.width);
+        let page = self.page.min(pages.saturating_sub(1));
+        let start = page * page_size;
+        let end = (start + page_size).min(self.tracks.len());
+        let tracks = self.tracks;
+        let empty = tracks.is_empty();
+        let on_previous = self.on_previous;
+        let on_next = self.on_next;
+
+        div()
+            .w_full()
+            .flex()
+            .flex_col()
+            .overflow_hidden()
+            .rounded(theme.radius)
+            .border_1()
+            .border_color(theme.border)
+            .child(
+                div()
+                    .flex()
+                    .items_end()
+                    .justify_between()
+                    .gap_4()
+                    .px_3()
+                    .py_2()
+                    .border_b_1()
+                    .border_color(theme.border)
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap_0p5()
+                            .child(
+                                div()
+                                    .text_xs()
+                                    .font_weight(FontWeight::SEMIBOLD)
+                                    .text_color(theme.muted_foreground)
+                                    .child("START FROM A SONG"),
+                            )
+                            .child(
+                                div()
+                                    .text_size(theme.text(Text::Title))
+                                    .font_weight(FontWeight::BOLD)
+                                    .child("Quick picks"),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .gap_1()
+                            .child(
+                                Button::new("quick-picks-previous")
+                                    .small()
+                                    .outline()
+                                    .icon("icons/chevron-left.svg")
+                                    .disabled(empty || page == 0)
+                                    .when_some(on_previous, |button, handler| {
+                                        button.on_click(move |event, window, cx| {
+                                            handler(event, window, cx)
+                                        })
+                                    }),
+                            )
+                            .child(
+                                Button::new("quick-picks-next")
+                                    .small()
+                                    .outline()
+                                    .icon("icons/chevron-right.svg")
+                                    .disabled(empty || page + 1 >= pages)
+                                    .when_some(on_next, |button, handler| {
+                                        button.on_click(move |event, window, cx| {
+                                            handler(event, window, cx)
+                                        })
+                                    }),
+                            ),
+                    ),
+            )
+            .child(div().flex().gap_2().p_2().when_else(
+                empty,
+                |this| {
+                    this.children((0..columns).map(|column| {
+                        column_shell(column, theme.border)
+                            .children((0..ROWS_PER_COLUMN).map(|_| skeleton(window, cx)))
+                    }))
+                },
+                |this| {
+                    this.children(tracks[start..end].chunks(ROWS_PER_COLUMN).enumerate().map(
+                        |(column, column_tracks)| {
+                            column_shell(column, theme.border).children(
+                                column_tracks.iter().enumerate().map(|(row, track)| {
+                                    let place = start + column * ROWS_PER_COLUMN + row;
+                                    pick(
+                                        track,
+                                        place,
+                                        tracks.clone(),
+                                        self.playback.clone(),
+                                        self.active.as_deref(),
+                                        window,
+                                        cx,
+                                    )
+                                }),
+                            )
+                        },
+                    ))
+                },
+            ))
+    }
+}
+
+fn column_shell(column: usize, border: gpui::Hsla) -> gpui::Div {
+    div()
+        .flex()
+        .flex_1()
+        .min_w_0()
+        .flex_col()
+        .gap_1()
+        .when(column > 0, |this| {
+            this.border_l_1().border_color(border).pl_2()
+        })
+}
+
+fn skeleton(window: &Window, cx: &App) -> impl IntoElement {
+    let theme = cx.theme();
+    let height = snapped(theme.metrics.list_row, window);
+    let artwork = height - theme.metrics.pad * 2.;
+
+    div()
+        .flex()
+        .items_center()
+        .h(height)
+        .gap_3()
+        .px_2()
+        .child(Skeleton::new().size(artwork))
+        .child(
+            div()
+                .flex()
+                .flex_col()
+                .gap_2()
+                .child(Skeleton::new().w(gpui::px(140.)).h(gpui::px(11.)))
+                .child(Skeleton::new().w(gpui::px(90.)).h(gpui::px(9.))),
+        )
+}
+
+fn pick(
+    track: &Track,
+    place: usize,
+    tracks: Rc<Vec<Track>>,
+    playback: Entity<Playback>,
+    active: Option<&str>,
+    window: &Window,
+    cx: &App,
+) -> impl IntoElement {
+    let theme = *cx.theme();
+    let height = snapped(theme.metrics.list_row, window);
+    let artwork = height - theme.metrics.pad * 2.;
+    let tint = match track.id.as_deref() == active {
+        true => theme.primary,
+        false => theme.foreground,
+    };
+
+    div()
+        .id(("quick-pick", place))
+        .flex()
+        .items_center()
+        .min_w_0()
+        .h(height)
+        .gap_3()
+        .px_2()
+        .rounded(theme.radius)
+        .cursor_pointer()
+        .hover(move |style| style.bg(theme.table_hover))
+        .on_click(move |_, _, cx| {
+            playback.update(cx, |playback, cx| playback.play_radio(&tracks[place], cx));
+        })
+        .child(Artwork::new(track.cover.clone()).size(artwork))
+        .child(
+            div()
+                .flex()
+                .flex_1()
+                .min_w_0()
+                .flex_col()
+                .child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap_1p5()
+                        .min_w_0()
+                        .text_color(tint)
+                        .child(
+                            div()
+                                .min_w_0()
+                                .truncate()
+                                .font_weight(FontWeight::SEMIBOLD)
+                                .child(SharedString::from(track.name.clone())),
+                        )
+                        .when(track.explicit, |this| {
+                            this.child(div().flex_none().child(ExplicitBadge::new()))
+                        }),
+                )
+                .child(
+                    cells::artist_links(
+                        SharedString::from(format!("quick-pick-artist-{place}")),
+                        track.artist_refs.clone(),
+                        track.artists.clone(),
+                        theme.muted_foreground,
+                    )
+                    .text_size(theme.text(Text::Small)),
+                ),
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use gpui::px;
+
+    use super::{column_count, page_count};
+
+    #[test]
+    fn columns_follow_width_and_stop_at_three() {
+        assert_eq!(column_count(px(279.)), 1);
+        assert_eq!(column_count(px(560.)), 2);
+        assert_eq!(column_count(px(840.)), 3);
+        assert_eq!(column_count(px(2_000.)), 3);
+    }
+
+    #[test]
+    fn pages_include_every_track() {
+        assert_eq!(page_count(36, px(279.)), 6);
+        assert_eq!(page_count(36, px(560.)), 3);
+        assert_eq!(page_count(36, px(840.)), 2);
+        assert_eq!(page_count(0, px(840.)), 1);
+    }
+}

--- a/crates/views/src/root.rs
+++ b/crates/views/src/root.rs
@@ -9,9 +9,10 @@ use workspace::{Filter, Sidebar, Workspace};
 
 use crate::search::SearchView;
 use crate::tracks::{ALBUM_COLUMNS, LIBRARY_COLUMNS};
-use crate::{ArtistView, DetailView, LibraryView, LoginView, SettingsView};
+use crate::{ArtistView, DetailView, HomeView, LibraryView, LoginView, SettingsView};
 
 struct Screens {
+    home: Entity<HomeView>,
     library: Entity<LibraryView>,
     artist: Option<Entity<ArtistView>>,
     artist_detail: Option<Entity<ArtistDetail>>,
@@ -72,6 +73,9 @@ impl Root {
             )
         });
 
+        let home =
+            cx.new(|cx| HomeView::new(library.clone(), playback.clone(), sidebar.clone(), cx));
+
         let io = Io::global(cx);
         let search_library = library.clone();
         let album_detail =
@@ -126,6 +130,7 @@ impl Root {
             filter,
             pending: None,
             screens: Screens {
+                home,
                 library: library_view,
                 artist: None,
                 artist_detail: None,
@@ -188,6 +193,7 @@ impl Root {
         );
 
         let content: AnyView = match destination {
+            Destination::Home => self.screens.home.clone().into(),
             Destination::Library(tab) => {
                 self.screens
                     .library

--- a/crates/workspace/src/sidebar.rs
+++ b/crates/workspace/src/sidebar.rs
@@ -8,7 +8,7 @@ use router::{Destination, LibraryTab, Link as _, Navigation};
 use state::{AppSettings, Spotty};
 
 const NAV: [(&str, &str, Option<Destination>); 4] = [
-    ("Home", "icons/house.svg", None),
+    ("Home", "icons/house.svg", Some(Destination::Home)),
     ("Search", "icons/search.svg", Some(Destination::Search)),
     (
         "Your Library",


### PR DESCRIPTION
## Summary
- add a dedicated Home route with a responsive Quick picks carousel
- build a mixed 36-track selection from recent, random, and artist-diverse saved tracks
- lazily create and shuffle Spotify Radio queues only after a track is selected
- add loading skeletons, adaptive pagination, and previous/next controls
- guard playback against stale context requests and unavailable tracks

## Validation
- cargo fmt --all -- --check
- cargo check --workspace
- cargo test --workspace
- cargo clippy -p spotify -p state -p views -p router -p workspace -p spotty --no-deps -- -D warnings -A clippy::type-complexity
- git diff --check