### PR TITLE
Fix audio output sample format

### DIFF
--- a/crates/audio/src/sink.rs
+++ b/crates/audio/src/sink.rs
@@ -147,7 +147,7 @@ pub struct BlazingSink {
 }
 
 impl BlazingSink {
-    pub fn open(format: AudioFormat, flush: Flush, volume: Volume) -> Result<Self, SinkError> {
+    pub fn open(_format: AudioFormat, flush: Flush, volume: Volume) -> Result<Self, SinkError> {
         let host = cpal::default_host();
         let device = host
             .default_output_device()
@@ -175,7 +175,7 @@ impl BlazingSink {
         let mut stream = OutputStreamBuilder::default()
             .with_device(device)
             .with_config(&config.config())
-            .with_sample_format(sample_format(format))
+            .with_sample_format(config.sample_format())
             .open_stream()
             .map_err(|error| SinkError::ConnectionRefused(error.to_string()))?;
         stream.log_on_drop(false);
@@ -253,15 +253,5 @@ struct Silence;
 impl Sink for Silence {
     fn write(&mut self, _packet: AudioPacket, _converter: &mut Converter) -> SinkResult<()> {
         Ok(())
-    }
-}
-
-fn sample_format(format: AudioFormat) -> cpal::SampleFormat {
-    match format {
-        AudioFormat::F64 => cpal::SampleFormat::F64,
-        AudioFormat::F32 => cpal::SampleFormat::F32,
-        AudioFormat::S32 => cpal::SampleFormat::I32,
-        AudioFormat::S24 | AudioFormat::S24_3 => cpal::SampleFormat::I24,
-        AudioFormat::S16 => cpal::SampleFormat::I16,
     }
 }


### PR DESCRIPTION
## Summary
- use the output device configuration sample format when opening the stream
- remove the redundant audio format conversion helper

## Validation
- cargo check -p audio --offline
- staged diff check