### PR TITLE
Add an interactive playback queue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,379 @@
+# sonora
+
+A native Spotify client in Rust on [GPUI](https://github.com/zed-industries/zed) (Zed's UI
+framework), streaming through [librespot](https://github.com/librespot-org/librespot).
+Linux-only today. Cargo workspace, edition 2024, resolver 3.
+
+## Read this before writing code
+
+1. **A component probably already exists.** Check `crates/ui/src/lib.rs`, `crates/views/src/cells.rs`
+   and the tables below before writing a new element. See [Before you build a component](#before-you-build-a-component).
+2. **Never call the Spotify Web API.** There is no `reqwest` call to `api.spotify.com` anywhere and
+   there must not be one. All data comes from librespot's `spclient`. See [Backend](#backend-how-data-actually-arrives).
+3. **Never hardcode a color, radius, or size.** Everything comes from `cx.theme()`.
+   See [Theme and metrics](#theme-and-metrics).
+4. **Network work runs on the tokio runtime (`Io`), never on GPUI's executor.**
+   See [Async: two runtimes](#async-two-runtimes).
+5. **New assets must be registered in `crates/sonora/src/assets.rs`** or they silently fail to load.
+
+## Crate layout
+
+```
+crates/
+  sonora/     binary: main, window, actions, asset registry, HTTP client shim
+  views/      screens: home, library, detail, artist, search, settings, login
+  workspace/  app chrome: title bar, sidebar, player bar, filter/search field
+  state/      GPUI entities holding app state; owns all async orchestration
+  spotify/    Spotify data access over librespot spclient (no GPUI)
+  audio/      librespot playback engine + custom rodio sink (no GPUI)
+  ui/         design system: theme, metrics, and reusable elements (gpui only)
+  router/     Destination enum, navigation history, Link trait
+  input/      text input element + global actions and keybindings
+```
+
+Dependency direction is strict; do not create a back edge:
+
+```
+sonora → views → workspace → state → spotify
+                                   → audio
+         all ui-side crates → ui, router, input → ui → gpui
+```
+
+- `ui` depends only on `gpui` + `serde`. It must never know about `spotify`, `state`, or playback.
+- `spotify` and `audio` must never depend on `gpui`. They are plain async Rust.
+- `state` depends on `ui` only for `ThemeOverrides`, `MIN_FONT`, `MAX_FONT` (settings persistence).
+- Widgets that need app state (player bar, sidebar) live in `workspace`, not `ui`.
+
+## Building
+
+### Any platform: what the build needs
+
+The GPUI renderer is Vulkan-based, so a Vulkan ICD is a **runtime** requirement, not just a build
+one. Link-time deps: `vulkan-loader`, `wayland`, `libxkbcommon`, `libxcb`, `libx11`, `libxcursor`,
+`libxi`, `fontconfig`, `freetype`, `alsa-lib`, plus `pkg-config`.
+
+`.cargo/config.toml` passes `-fuse-ld=mold` for `x86_64-unknown-linux-gnu`, so **mold must be on
+PATH** for that target. If it isn't, either install mold or build with
+`RUSTFLAGS="" cargo build …` to drop the flag.
+
+### Nix (primary)
+
+```sh
+nix develop          # or: direnv allow  (.envrc runs `use flake`)
+cargo run --locked --package sonora
+nix run              # build + run the packaged binary
+nix build            # ./result/bin/sonora
+```
+
+The devShell supplies `rustc`, `rustfmt`, `rust-analyzer`, `mold`, `pkg-config`, `sccache` and the
+runtime libs via `LD_LIBRARY_PATH`. It does **not** ship `cargo` or `cargo-clippy` — those come from
+the ambient system profile here. If `cargo` is missing inside the shell, that's why.
+
+When `Cargo.lock` changes, `cargoHash` in `flake.nix` goes stale. Build once, take the `got:` hash
+from the failure, and paste it in.
+
+### Arch / CachyOS
+
+```sh
+sudo pacman -S --needed base-devel rust pkgconf alsa-lib fontconfig freetype2 \
+  libx11 libxcb libxcursor libxi libxkbcommon libxkbcommon-x11 wayland \
+  vulkan-icd-loader mold
+# plus a Vulkan driver: vulkan-radeon | vulkan-intel | nvidia-utils
+
+cargo run --locked --package sonora
+cargo build --release --locked --package sonora && ./target/release/sonora
+```
+
+### Debian/Ubuntu and Fedora
+
+Not exercised in this repo; package sets translated from the dependency list above.
+
+```sh
+# Debian/Ubuntu
+sudo apt install build-essential pkg-config mold libasound2-dev libfontconfig-1-dev \
+  libfreetype-dev libx11-dev libxcb1-dev libxcursor-dev libxi-dev \
+  libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev libvulkan-dev mesa-vulkan-drivers
+
+# Fedora
+sudo dnf install @development-tools pkgconf-pkg-config mold alsa-lib-devel fontconfig-devel \
+  freetype-devel libX11-devel libxcb-devel libXcursor-devel libXi-devel \
+  libxkbcommon-devel libxkbcommon-x11-devel wayland-devel vulkan-loader-devel mesa-vulkan-drivers
+```
+
+### macOS / Windows
+
+Unsupported as configured. `gpui_platform` is pinned to the `x11` + `wayland` features, the flake
+only declares `x86_64-linux`/`aarch64-linux`, and the mold linker flag targets Linux. Porting means
+changing feature flags and the linker config — do not attempt it as a side effect of another task.
+
+### Checks
+
+```sh
+cargo fmt                      # rustfmt.toml: edition 2024, style_edition 2024
+cargo check --workspace
+cargo test --workspace
+cargo clippy --workspace       # lib targets
+```
+
+The first build compiles GPUI from source; expect several minutes.
+
+`cargo clippy --workspace --all-targets` currently **fails**, on a deny-level
+`reversed_empty_ranges` from a deliberate `clamp_range("abc", &(2..1))` case in
+`crates/input/src/text.rs`. That failure predates your change; don't "fix" the test to silence it.
+The workspace also carries a handful of clippy warnings (complex types, a missing `Default`). Leave
+them unless the task is about them.
+
+### Runtime environment
+
+|                   |                                                                    |
+| ----------------- | ------------------------------------------------------------------ |
+| Settings          | `$XDG_CONFIG_HOME/sonora/settings.json`                            |
+| Credentials cache | `$XDG_CACHE_HOME/sonora/credentials.json`                          |
+| OAuth redirect    | `http://127.0.0.1:8989/login`, override with `SONORA_REDIRECT_URI` |
+| Logging           | `RUST_LOG`; default filter `warn,symphonia=error`                  |
+
+## Before you build a component
+
+Grep first. In order: `crates/ui/src/lib.rs` (exports), `crates/views/src/cells.rs` (grid cell
+renderers), `crates/workspace/src/` (chrome). Extend what's there — add a builder method to `Button`
+rather than writing `IconButton`.
+
+### `ui` — reusable elements
+
+| Item                                                                    | Use for                                                                                                                                |
+| ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `Button`                                                                | every button. Variants `.ghost() .outline() .primary() .danger()`, plus `.small() .icon() .label() .tint() .selected() .disabled()`    |
+| `Card`                                                                  | artwork + title + eyebrow + meta row/tile. `.art()` for tile mode, `.circle()`, `.loading()`, `.trailing()`, `.explicit()`, `.press()` |
+| `Artwork`                                                               | cover images with skeleton loading and a music-note fallback                                                                           |
+| `Skeleton`, `Initials`                                                  | pulsing loading placeholder; avatar initials                                                                                           |
+| `Grid`, `GridSource`, `GridDelegate`, `GridState`, `ColumnSpec`, `Cell` | every table. Virtualized, sortable, filterable, hideable columns, responsive `hide_below`                                              |
+| `Scroller` + `Scrollbar`                                                | any scrolling region. Do not use bare `overflow_y_scroll`                                                                              |
+| `Scrubber` + `ScrubberState`                                            | any draggable 0..1 track (seek bar, volume)                                                                                            |
+| `Menu`, `MenuItem`                                                      | dropdowns (deferred + occluded, with `on_dismiss`)                                                                                     |
+| `InlineLinks`, `InlineLink`                                             | comma-joined clickable artist lists                                                                                                    |
+| `eyebrow()`, `heading()`                                                | the two standard text styles                                                                                                           |
+| `ExplicitBadge`                                                         | the "E" badge                                                                                                                          |
+| `WindowControls`                                                        | minimize/maximize/close, honoring platform decorations                                                                                 |
+| `clock()`                                                               | `Duration` → `m:ss`                                                                                                                    |
+| `snapped()`                                                             | round a `Pixels` to the device pixel grid                                                                                              |
+
+Also available: `Input` (`input` crate — full text editing, IME, selection, clipboard) and
+`Link` (`router` — makes a `Stateful<Div>` navigate on click).
+
+### `views/src/cells.rs` — grid cell renderers
+
+`index` (play/pause/now-playing transport with hover preload), `artists`, `link`, `text`, `dim`,
+`title`, `artwork`, `blank`, `transport`, `toggle`, `artist_links`. Reuse these in any new
+`GridSource::cell`.
+
+### Element conventions
+
+New elements follow one shape — copy `ui/src/button.rs`:
+
+```rust
+#[derive(IntoElement)]
+pub struct Thing { base: Stateful<Div>, /* … */ }
+
+impl Thing {
+    #[track_caller]
+    pub fn new(id: impl Into<ElementId>) -> Self { … }
+    pub fn variant(mut self) -> Self { …; self }   // consuming builders
+}
+
+impl Styled for Thing { fn style(&mut self) -> &mut StyleRefinement { self.base.style() } }
+impl InteractiveElement for Thing { … }
+
+impl RenderOnce for Thing {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let overrides = std::mem::take(base.style());   // caller styles win
+        let mut thing = base./* defaults */;
+        thing.style().refine(&overrides);
+        thing
+    }
+}
+```
+
+The `mem::take` / `refine` dance is deliberate: it lets a call site override any default without
+the element re-applying it afterwards. Keep it.
+
+Stateful components (`Scrollbar`, `Input`, `GridState`) are `Render` entities instead, created with
+`cx.new(…)` and held by the parent.
+
+## Theme and metrics
+
+`ui/src/theme.rs` is the single source of every color, radius, and font size.
+
+```rust
+use ui::ActiveTheme as _;
+let theme = *cx.theme();          // Theme is Copy
+theme.foreground, theme.muted_foreground, theme.secondary_hover, theme.table_row_border, …
+theme.radius
+theme.text(Text::Small)           // Tiny Small Label Body Large Title Display
+theme.metrics.row / .header / .pad / .inset / .control / .field
+             .title_bar / .player_bar / .list_row / .thumb / .cover
+```
+
+- Every metric scales off the user's font size (`Metrics::new(base)`), so **never** hardcode a
+  height for a row, control, or bar — read it from `theme.metrics`.
+- A literal `px(…)` is acceptable only for a local, non-scaling detail, declared as a `const` at
+  module top (see `NUMBER`, `DATE`, `WIDE` in `views/src/cells.rs`).
+- Adding a color token means adding it to `Theme`, to every `Theme::*()` constructor, to
+  `ThemeOverrides`, and to the `apply_color!` list — all four, or overrides break.
+- Eight themes exist (`ThemeKind::ALL`). `ocean`/`rose`/`lavender`/`amber` are derived by mutating
+  `midnight()`/`dark()`; follow that pattern rather than writing a full palette.
+- Users can override any token via `settings.json`; `Theme::set` re-renders all windows.
+
+## Async: two runtimes
+
+GPUI has its own executor; librespot and `reqwest` need tokio. `state::Io` wraps a multi-thread
+tokio `Runtime` and is a GPUI global.
+
+```rust
+let io = Io::global(cx);
+self.task = Some(cx.spawn(async move |this, cx| {      // GPUI executor
+    let loaded = join(io.spawn(async move {            // tokio: all network work
+        client.album_tracks(&id).await
+    })).await;
+    this.update(cx, |this, cx| { /* apply, cx.notify() */ }).ok();
+}));
+```
+
+Rules:
+
+- Anything touching `SpotifyApi`, librespot, or sockets goes inside `io.spawn`.
+- Only mutate entity state inside `this.update`, and end with `cx.notify()`.
+- Store the returned `Task` in a field (`task`, `load`, `fetch`) — dropping it cancels the work,
+  which is how sign-out and navigation cancel in-flight loads. Never `.detach()` a data load.
+- `join(handle)` (crate-private in `state`) flattens `JoinHandle<Result<T>>`.
+- `cx.subscribe(…)` / `cx.observe(…)` **are** `.detach()`-ed, in the constructor.
+- Because `join` and `Io` plumbing live in `state`, new network-backed features belong in a `state`
+  entity — not in a view.
+
+## Backend: how data actually arrives
+
+### There is no Spotify Web API here
+
+`crates/spotify` talks to Spotify through `librespot_core::Session::spclient()` — the same internal
+endpoints the official client uses, returning protobuf or JSON. Consequences:
+
+- Do not add `reqwest` calls to `api.spotify.com`, do not add a client secret, do not add
+  `rspotify`. The only `reqwest` in the tree is `crates/sonora/src/http.rs`, a `gpui::HttpClient`
+  adapter that exists purely so GPUI can fetch cover images.
+- Auth is OAuth PKCE via `librespot-oauth` against **Spotify's own client id**
+  (`DEFAULT_CLIENT_ID` in `auth.rs`). A developer-app client id will be refused at session connect —
+  `auth::denied` documents this. Don't "fix" auth by swapping in a registered app id.
+
+### Module map
+
+| Module                    | Endpoint / mechanism                                                              |
+| ------------------------- | --------------------------------------------------------------------------------- |
+| `auth.rs`                 | OAuth login, credential cache, `restore` / `login` / `forget`                     |
+| `client.rs`               | `SpotifyApi` trait + `LibrespotClient`; the only type views/state see             |
+| `collection.rs`           | saved tracks; `metadata()` — batched `get_extended_metadata` (TRACK_V4)           |
+| `collection2.rs`          | `/collection/v2/paging` — hand-rolled protobuf, paged, honors tombstones          |
+| `albums.rs`, `artists.rs` | extended metadata for albums/artists, artist portraits                            |
+| `playlists.rs`            | `get_playlist` → `SelectedListContent` → uri list → `collection::metadata`        |
+| `search.rs`               | `get_context("spotify:search:…")` → track uris → `collection::metadata`           |
+| `radio.rs`                | `get_radio_for_track` → a generated playlist id → `playlist_tracks`               |
+| `profiles.rs`             | display-name lookups, fanned out over a `JoinSet`                                 |
+| `wire.rs`                 | protobuf → `models` conversion, `image_url` (file id → `i.scdn.co/image/<hex>`)   |
+| `pb.rs`                   | minimal protobuf `Reader`/`Writer` for endpoints with no generated schema         |
+| `models.rs`               | `Track`, `Album`, `AlbumDetail`, `Artist`, `ArtistRef`, `Playlist`, `UserProfile` |
+
+Working notes:
+
+- Prefer generated messages from `librespot-protocol`. `pb.rs` exists only because the collection-v2
+  paging schema isn't in that crate — don't hand-roll a new one if a generated type exists.
+- The recurring pattern is **uris → `collection::metadata` → `Track`**. A new track-listing endpoint
+  should resolve uris and reuse `metadata`, not re-parse track fields.
+- `Track::id` is `Option<String>` base62 (no `spotify:track:` prefix); the prefix is added at the
+  audio boundary. `Track::playable` is false for unavailable tracks — check it before playing.
+- New endpoints: add the method to the `SpotifyApi` trait, implement on `LibrespotClient` by
+  delegating to a focused module. The trait exists so `state` depends on an interface, not on
+  librespot directly.
+- Errors use `anyhow` with `.context("cannot …")` in lowercase.
+
+### Audio
+
+`crates/audio` owns `librespot_playback::Player` plus `BlazingSink`, a custom rodio sink with
+smooth gain ramping and flush-on-seek. `Engine::start(session, config)` returns
+`(Engine, AudioEvents)`; `AudioEvents::next()` yields the reduced `AudioEvent`
+(`Loading/Playing/Paused/Position/Ended/Unavailable`).
+
+Never drive librespot's `Player` from a view. Go through `state::Playback`, which owns the engine,
+pumps events into `PlaybackState`, and handles shuffle, repeat, skip debouncing, and the cooldown
+after an `Unavailable` track.
+
+### State entities
+
+`state::init` installs a `Sonora` global holding `session`, `library`, `playback`, `queue`,
+`settings`. Reach them with `Sonora::global(cx)`.
+
+| Entity                                     | Responsibility                                                                                                                                          |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Session`                                  | auth lifecycle; emits `SessionEvent::{SignedIn, SignedOut}`; hands out `Arc<dyn SpotifyApi>` and the raw librespot session                              |
+| `Library`                                  | saved tracks / playlists / albums; `LibraryState` is `Empty \| Loading \| Ready{..,problems} \| Failed` — partial failure is normal, surface `problems` |
+| `Playback`                                 | engine ownership, transport, shuffle/repeat, volume, `Origin` tracking                                                                                  |
+| `Queue`                                    | past / current / upcoming; `start`, `next`, `next_random`, `previous`, `rewind`                                                                         |
+| `Home`, `Detail`, `ArtistDetail`, `Search` | per-screen loaders, each owning its `Task`                                                                                                              |
+| `AppSettings`                              | debounced JSON persistence                                                                                                                              |
+
+Everything reacts to `SessionEvent`: signing out must clear derived state. If you add an entity that
+caches Spotify data, subscribe to `Session` and clear on `SignedOut`.
+
+## UI patterns
+
+**Navigation.** `router::Destination` is the route enum; `router::navigate(dest, cx)`, `back`,
+`forward`. `Root` subscribes to `NavigationEvent::Moved` and swaps the workspace content. For a
+clickable region, use the `Link` trait (`div().id(..).link(Destination::Album(id))`) instead of a
+manual click handler.
+
+**New screen checklist:** add a `Destination` variant → add a state entity if it loads data → add
+the view under `crates/views/src/` → construct it in `Root::new` and wire it in `Root::show` →
+add a sidebar entry in `workspace/src/sidebar.rs` if it's top-level.
+
+**Tables.** Implement `GridSource` (`columns`, `rows`, `cell`, and optionally `compare`, `matches`,
+`playing`, `is_loading`), define a `&'static [ColumnSpec<Field>]`, hold a
+`GridState<Source>` entity, render `grid(&state)`. Column widths use `Width::{Fixed, Fill, Thumb}`
+and `hide_below` for responsive dropping. Hidden columns persist through
+`AppSettings::{hidden_columns, set_hidden_columns}`.
+
+**Filtering.** Implement `workspace::Searchable` on the view; `Root` binds it to the shared `Filter`
+in the title bar. Don't build a second search box.
+
+**Actions and keys.** Declare actions in `crates/input/src/lib.rs` (`actions!` macro), bind them in
+`bindings()`, handle them with `cx.on_action` (global, in `sonora/src/actions.rs`) or
+`.on_action(cx.listener(…))` (scoped). Key contexts: `Workspace`, `Input`, `Grid`. Both `cmd-` and
+`ctrl-` bindings are registered for every shortcut.
+
+**Assets.** SVGs live in `assets/icons/`, are embedded with `include_bytes!`, and are referenced as
+`"icons/<name>.svg"`. Adding a file is not enough — add the stem to the `ICONS` list in
+`crates/sonora/src/assets.rs`, otherwise loading logs `assets: … is not registered` and renders
+nothing. Icons are Lucide (`assets/icons/LICENSE`); the UI font is Inter.
+
+## Code style
+
+- **Comments: essentially none.** The codebase has almost zero. Name things so they don't need one.
+  If a comment is unavoidable it is at most three lowercase words, no trailing period.
+- Names are short and domain-flavored: `Look`, `Metrics`, `Grab`, `Scored`, `wire`, `pb`, `clock`,
+  `snapped`. Prefer a noun that reads at the call site over a descriptive compound.
+- `use gpui::prelude::*;` then explicit imports; traits imported anonymously (`use ui::ActiveTheme as _;`).
+- Module shape: `use` block → `const`s in SCREAMING_SNAKE → types → impls → private free helpers at
+  the bottom.
+- Prefer combinator chaining over branching in render: `.when()`, `.when_some()`, `.when_else()`,
+  `.map()`. Prefer `match` over `if/else` for two-arm boolean choices — that's the house style
+  (`match small { true => …, false => … }`).
+- Use let-else for early exits; return early rather than nesting.
+- `anyhow::Result` at boundaries, `.context("cannot …")` lowercase; log with `log::warn!`/`error!`
+  prefixed by subsystem (`"playback: …"`, `"settings: …"`, `"assets: …"`).
+- Tests are `#[cfg(test)] mod tests` at the bottom of the file they cover — see
+  `spotify/src/{collection2,radio,search}.rs` and `input/src/text.rs`. They're pure-function tests;
+  there is no UI or network test harness.
+- Dependencies go in the root `[workspace.dependencies]`, then `dep.workspace = true` in the crate.
+  `gpui`/`gpui_platform` are pinned to one git rev — bump both together or the build breaks.
+
+## Commits
+
+Conventional Commits: `type(scope): description`, imperative, lowercase, no trailing period, no body.
+Scopes in use: `player`, `playback`, `views`, `ui`. Never add a `Co-Authored-By` trailer or any
+assistant attribution.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8728,6 +8728,7 @@ dependencies = [
  "gpui",
  "input",
  "router",
+ "spotify",
  "state",
  "ui",
 ]

--- a/assets/icons/list.svg
+++ b/assets/icons/list.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 5h.01"/><path d="M3 12h.01"/><path d="M3 19h.01"/><path d="M8 5h13"/><path d="M8 12h13"/><path d="M8 19h13"/></svg>

--- a/crates/input/src/lib.rs
+++ b/crates/input/src/lib.rs
@@ -69,6 +69,7 @@ pub fn bindings() -> Vec<KeyBinding> {
         KeyBinding::new("ctrl-,", OpenSettings, None),
         KeyBinding::new("cmd-,", OpenSettings, None),
         KeyBinding::new("space", TogglePlayback, Some(&away_from_text)),
+        KeyBinding::new("escape", Dismiss, Some(WORKSPACE_CONTEXT)),
         KeyBinding::new("backspace", Backspace, editing),
         KeyBinding::new("ctrl-backspace", BackspaceWord, editing),
         KeyBinding::new("delete", Delete, editing),

--- a/crates/sonora/src/assets.rs
+++ b/crates/sonora/src/assets.rs
@@ -44,6 +44,7 @@ const ICONS: &[(&str, &[u8])] = icons![
     "chevron-up",
     "house",
     "library-big",
+    "list",
     "log-out",
     "music",
     "music-2",

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -327,6 +327,28 @@ impl Playback {
         self.load_after(&track, SKIP_DEBOUNCE, cx);
     }
 
+    pub fn play_past(&mut self, index: usize, cx: &mut Context<Self>) {
+        self.fetch = None;
+        let Some(track) = self
+            .queue
+            .update(cx, |queue, cx| queue.play_past(index, cx))
+        else {
+            return;
+        };
+        self.load_after(&track, SKIP_DEBOUNCE, cx);
+    }
+
+    pub fn play_upcoming(&mut self, index: usize, cx: &mut Context<Self>) {
+        self.fetch = None;
+        let Some(track) = self
+            .queue
+            .update(cx, |queue, cx| queue.play_upcoming(index, cx))
+        else {
+            return;
+        };
+        self.load_after(&track, SKIP_DEBOUNCE, cx);
+    }
+
     pub fn resume(&mut self, cx: &mut Context<Self>) {
         if let Some(engine) = self.engine.as_ref() {
             engine.play();

--- a/crates/state/src/queue.rs
+++ b/crates/state/src/queue.rs
@@ -3,10 +3,68 @@ use std::collections::VecDeque;
 use gpui::Context;
 use spotify::Track;
 
+fn move_item<T>(items: &mut VecDeque<T>, from: usize, to: usize) -> bool {
+    if from >= items.len() || to >= items.len() || from == to {
+        return false;
+    }
+    let Some(item) = items.remove(from) else {
+        return false;
+    };
+    items.insert(to, item);
+    true
+}
+
+fn select_past<T>(
+    past: &mut Vec<T>,
+    current: &mut Option<T>,
+    upcoming: &mut VecDeque<T>,
+    index: usize,
+) -> bool {
+    if index >= past.len() {
+        return false;
+    }
+
+    let mut replay = VecDeque::from(past.split_off(index));
+    let selected = replay.pop_front().expect("past index was checked");
+    if let Some(playing) = current.replace(selected) {
+        replay.push_back(playing);
+    }
+    replay.append(upcoming);
+    *upcoming = replay;
+    true
+}
+
+fn select_upcoming<T>(
+    past: &mut Vec<T>,
+    current: &mut Option<T>,
+    upcoming: &mut VecDeque<T>,
+    index: usize,
+) -> bool {
+    let Some(selected) = upcoming.remove(index) else {
+        return false;
+    };
+
+    past.extend(current.replace(selected));
+    past.extend(upcoming.drain(..index));
+    true
+}
+
+/// Converts a gap between tracks into an insertion index for [`move_item`].
+///
+/// Gaps are numbered from 0 to `len`: gap 0 is before the first track, gap
+/// `len` is after the last one. When moving down, the removal of the dragged
+/// track shifts the target back by one. The gaps right around the dragged
+/// track map to its current index, keeping it in place.
+fn gap_target(from: usize, gap: usize, len: usize) -> usize {
+    let gap = gap.min(len);
+    if gap > from { gap - 1 } else { gap }
+}
+
 pub struct Queue {
     past: Vec<Track>,
     current: Option<Track>,
     upcoming: VecDeque<Track>,
+    revision: u64,
 }
 
 impl Default for Queue {
@@ -21,7 +79,21 @@ impl Queue {
             past: Vec::new(),
             current: None,
             upcoming: VecDeque::new(),
+            revision: 0,
         }
+    }
+
+    fn changed(&mut self, cx: &mut Context<Self>) {
+        self.revision = self.revision.wrapping_add(1);
+        cx.notify();
+    }
+
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    pub fn past(&self) -> impl ExactSizeIterator<Item = &Track> {
+        self.past.iter()
     }
 
     pub fn current(&self) -> Option<&Track> {
@@ -52,7 +124,7 @@ impl Queue {
         self.past.clear();
         self.current = None;
         self.upcoming.clear();
-        cx.notify();
+        self.changed(cx);
     }
 
     pub fn start(
@@ -69,13 +141,35 @@ impl Queue {
         self.upcoming = past.split_off(index + 1).into();
         self.current = past.pop();
         self.past = past;
-        cx.notify();
+        self.changed(cx);
         self.current.clone()
     }
 
     pub fn append(&mut self, track: Track, cx: &mut Context<Self>) {
         self.upcoming.push_back(track);
-        cx.notify();
+        self.changed(cx);
+    }
+
+    pub fn move_upcoming(&mut self, from: usize, to: usize, cx: &mut Context<Self>) {
+        if move_item(&mut self.upcoming, from, to) {
+            self.changed(cx);
+        }
+    }
+
+    /// Moves the upcoming track at `from` to the gap between tracks at `gap`.
+    ///
+    /// Gap 0 places the track at the front of the upcoming list, gap `len`
+    /// at the back. Dropping on the gaps directly around the dragged track
+    /// leaves it in place.
+    pub fn move_upcoming_to_gap(&mut self, from: usize, gap: usize, cx: &mut Context<Self>) {
+        let to = gap_target(from, gap, self.upcoming.len());
+        self.move_upcoming(from, to, cx);
+    }
+
+    pub fn remove_upcoming(&mut self, index: usize, cx: &mut Context<Self>) {
+        if self.upcoming.remove(index).is_some() {
+            self.changed(cx);
+        }
     }
 
     pub fn next(&mut self, cx: &mut Context<Self>) -> Option<Track> {
@@ -83,7 +177,7 @@ impl Queue {
         if let Some(played) = self.current.replace(next) {
             self.past.push(played);
         }
-        cx.notify();
+        self.changed(cx);
         self.current.clone()
     }
 
@@ -98,7 +192,7 @@ impl Queue {
         if let Some(played) = self.current.replace(next) {
             self.past.push(played);
         }
-        cx.notify();
+        self.changed(cx);
         self.current.clone()
     }
 
@@ -114,7 +208,133 @@ impl Queue {
         if let Some(playing) = self.current.replace(previous) {
             self.upcoming.push_front(playing);
         }
-        cx.notify();
+        self.changed(cx);
         self.current.clone()
+    }
+
+    pub fn play_past(&mut self, index: usize, cx: &mut Context<Self>) -> Option<Track> {
+        if !select_past(&mut self.past, &mut self.current, &mut self.upcoming, index) {
+            return None;
+        }
+        self.changed(cx);
+        self.current.clone()
+    }
+
+    pub fn play_upcoming(&mut self, index: usize, cx: &mut Context<Self>) -> Option<Track> {
+        if !select_upcoming(&mut self.past, &mut self.current, &mut self.upcoming, index) {
+            return None;
+        }
+        self.changed(cx);
+        self.current.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use super::{gap_target, move_item, select_past, select_upcoming};
+
+    #[test]
+    fn moves_items_in_both_directions() {
+        let mut items = VecDeque::from([1, 2, 3, 4]);
+
+        assert!(move_item(&mut items, 0, 2));
+        assert_eq!(items, [2, 3, 1, 4]);
+        assert!(move_item(&mut items, 3, 1));
+        assert_eq!(items, [2, 4, 3, 1]);
+    }
+
+    #[test]
+    fn ignores_invalid_moves() {
+        let mut items = VecDeque::from([1, 2, 3]);
+
+        assert!(!move_item(&mut items, 1, 1));
+        assert!(!move_item(&mut items, 3, 0));
+        assert!(!move_item(&mut items, 0, 3));
+        assert_eq!(items, [1, 2, 3]);
+    }
+
+    #[test]
+    fn selecting_past_rebuilds_the_queue_from_that_track() {
+        let mut past = vec![1, 2, 3];
+        let mut current = Some(4);
+        let mut upcoming = VecDeque::from([5, 6]);
+
+        assert!(select_past(&mut past, &mut current, &mut upcoming, 1));
+        assert_eq!(past, [1]);
+        assert_eq!(current, Some(2));
+        assert_eq!(upcoming, [3, 4, 5, 6]);
+    }
+
+    #[test]
+    fn selecting_invalid_past_track_keeps_the_queue() {
+        let mut past = vec![1, 2];
+        let mut current = Some(3);
+        let mut upcoming = VecDeque::from([4, 5]);
+
+        assert!(!select_past(&mut past, &mut current, &mut upcoming, 2));
+        assert_eq!(past, [1, 2]);
+        assert_eq!(current, Some(3));
+        assert_eq!(upcoming, [4, 5]);
+    }
+
+    #[test]
+    fn selecting_upcoming_moves_skipped_tracks_to_the_past() {
+        let mut past = vec![1];
+        let mut current = Some(2);
+        let mut upcoming = VecDeque::from([3, 4, 5]);
+
+        assert!(select_upcoming(&mut past, &mut current, &mut upcoming, 1));
+        assert_eq!(past, [1, 2, 3]);
+        assert_eq!(current, Some(4));
+        assert_eq!(upcoming, [5]);
+    }
+
+    #[test]
+    fn selecting_invalid_upcoming_track_keeps_the_queue() {
+        let mut past = vec![1];
+        let mut current = Some(2);
+        let mut upcoming = VecDeque::from([3, 4]);
+
+        assert!(!select_upcoming(&mut past, &mut current, &mut upcoming, 2));
+        assert_eq!(past, [1]);
+        assert_eq!(current, Some(2));
+        assert_eq!(upcoming, [3, 4]);
+    }
+
+    #[test]
+    fn converts_gaps_to_insertion_indices() {
+        // Moving down shifts the target back after removal.
+        assert_eq!(gap_target(0, 3, 4), 2);
+        assert_eq!(gap_target(0, 4, 4), 3);
+        // Moving up inserts at the gap as is.
+        assert_eq!(gap_target(3, 1, 4), 1);
+        assert_eq!(gap_target(2, 0, 4), 0);
+        // Gaps right around the dragged item keep it in place.
+        assert_eq!(gap_target(1, 1, 4), 1);
+        assert_eq!(gap_target(1, 2, 4), 1);
+        // Gaps past the end clamp to the last valid index.
+        assert_eq!(gap_target(0, 10, 4), 3);
+    }
+
+    #[test]
+    fn gap_moves_match_visual_positions() {
+        let mut items = VecDeque::from([1, 2, 3, 4]);
+
+        // Drag the first track below the third one.
+        let to = gap_target(0, 3, items.len());
+        assert!(move_item(&mut items, 0, to));
+        assert_eq!(items, [2, 3, 1, 4]);
+
+        // Drag the last track to the very front.
+        let to = gap_target(3, 0, items.len());
+        assert!(move_item(&mut items, 3, to));
+        assert_eq!(items, [4, 2, 3, 1]);
+
+        // Drop the track right where it already sits: no change.
+        let to = gap_target(1, 2, items.len());
+        assert!(!move_item(&mut items, 1, to));
+        assert_eq!(items, [4, 2, 3, 1]);
     }
 }

--- a/crates/state/src/queue.rs
+++ b/crates/state/src/queue.rs
@@ -49,12 +49,6 @@ fn select_upcoming<T>(
     true
 }
 
-/// Converts a gap between tracks into an insertion index for [`move_item`].
-///
-/// Gaps are numbered from 0 to `len`: gap 0 is before the first track, gap
-/// `len` is after the last one. When moving down, the removal of the dragged
-/// track shifts the target back by one. The gaps right around the dragged
-/// track map to its current index, keeping it in place.
 fn gap_target(from: usize, gap: usize, len: usize) -> usize {
     let gap = gap.min(len);
     if gap > from { gap - 1 } else { gap }
@@ -156,11 +150,6 @@ impl Queue {
         }
     }
 
-    /// Moves the upcoming track at `from` to the gap between tracks at `gap`.
-    ///
-    /// Gap 0 places the track at the front of the upcoming list, gap `len`
-    /// at the back. Dropping on the gaps directly around the dragged track
-    /// leaves it in place.
     pub fn move_upcoming_to_gap(&mut self, from: usize, gap: usize, cx: &mut Context<Self>) {
         let to = gap_target(from, gap, self.upcoming.len());
         self.move_upcoming(from, to, cx);
@@ -305,16 +294,12 @@ mod tests {
 
     #[test]
     fn converts_gaps_to_insertion_indices() {
-        // Moving down shifts the target back after removal.
         assert_eq!(gap_target(0, 3, 4), 2);
         assert_eq!(gap_target(0, 4, 4), 3);
-        // Moving up inserts at the gap as is.
         assert_eq!(gap_target(3, 1, 4), 1);
         assert_eq!(gap_target(2, 0, 4), 0);
-        // Gaps right around the dragged item keep it in place.
         assert_eq!(gap_target(1, 1, 4), 1);
         assert_eq!(gap_target(1, 2, 4), 1);
-        // Gaps past the end clamp to the last valid index.
         assert_eq!(gap_target(0, 10, 4), 3);
     }
 
@@ -322,17 +307,14 @@ mod tests {
     fn gap_moves_match_visual_positions() {
         let mut items = VecDeque::from([1, 2, 3, 4]);
 
-        // Drag the first track below the third one.
         let to = gap_target(0, 3, items.len());
         assert!(move_item(&mut items, 0, to));
         assert_eq!(items, [2, 3, 1, 4]);
 
-        // Drag the last track to the very front.
         let to = gap_target(3, 0, items.len());
         assert!(move_item(&mut items, 3, to));
         assert_eq!(items, [4, 2, 3, 1]);
 
-        // Drop the track right where it already sits: no change.
         let to = gap_target(1, 2, items.len());
         assert!(!move_item(&mut items, 1, to));
         assert_eq!(items, [4, 2, 3, 1]);

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -8,4 +8,5 @@ gpui.workspace = true
 state.workspace = true
 input.workspace = true
 router.workspace = true
+spotify.workspace = true
 ui.workspace = true

--- a/crates/workspace/src/lib.rs
+++ b/crates/workspace/src/lib.rs
@@ -1,4 +1,5 @@
 mod player_bar;
+mod queue_panel;
 mod searchable;
 mod sidebar;
 mod title_bar;
@@ -11,13 +12,15 @@ pub use title_bar::TitleBar;
 use gpui::prelude::*;
 use gpui::{AnyView, App, Context, Entity, FocusHandle, Render};
 use gpui::{Window, div};
-use input::WORKSPACE_CONTEXT;
+use input::{Dismiss, WORKSPACE_CONTEXT};
+use queue_panel::QueuePanel;
 use state::{Playback, Queue};
 
 pub struct Workspace {
     title_bar: Entity<TitleBar>,
     sidebar: Entity<Sidebar>,
     player_bar: Entity<PlayerBar>,
+    queue_panel: Entity<QueuePanel>,
     content: AnyView,
     focus: FocusHandle,
 }
@@ -31,12 +34,16 @@ impl Workspace {
         cx: &mut Context<Self>,
     ) -> Self {
         let title_bar = cx.new(|cx| TitleBar::new(sidebar.clone(), cx));
-        let player_bar = cx.new(|cx| PlayerBar::new(playback, queue, cx));
+        let queue_panel =
+            cx.new(|cx| QueuePanel::new(queue.clone(), playback.clone(), sidebar.clone(), cx));
+        let player_bar =
+            cx.new(|cx| PlayerBar::with_queue_panel(playback, queue, queue_panel.clone(), cx));
 
         Self {
             title_bar,
             sidebar,
             player_bar,
+            queue_panel,
             content,
             focus: cx.focus_handle(),
         }
@@ -63,6 +70,12 @@ impl Workspace {
     pub fn player_bar(&self) -> &Entity<PlayerBar> {
         &self.player_bar
     }
+
+    fn close_queue(&mut self, cx: &mut Context<Self>) {
+        if self.queue_panel.read(cx).is_open() {
+            self.queue_panel.update(cx, |panel, cx| panel.close(cx));
+        }
+    }
 }
 
 impl Render for Workspace {
@@ -76,6 +89,7 @@ impl Render for Workspace {
             .size_full()
             .key_context(WORKSPACE_CONTEXT)
             .track_focus(&self.focus)
+            .on_action(cx.listener(|this, _: &Dismiss, _, cx| this.close_queue(cx)))
             .child(self.title_bar.clone())
             .child(
                 div()
@@ -85,11 +99,13 @@ impl Render for Workspace {
                     .child(self.sidebar.clone())
                     .child(
                         div()
+                            .relative()
                             .flex()
                             .flex_col()
                             .flex_1()
                             .min_w_0()
-                            .child(self.content.clone()),
+                            .child(self.content.clone())
+                            .child(self.queue_panel.clone()),
                     ),
             )
             .child(self.player_bar.clone())

--- a/crates/workspace/src/player_bar.rs
+++ b/crates/workspace/src/player_bar.rs
@@ -9,6 +9,8 @@ use state::{Playback, PlaybackState, Queue, Repeat};
 
 use ui::{Artwork, Button, InlineLink, InlineLinks, Scrubber, ScrubberState, clock};
 
+use crate::queue_panel::QueuePanel;
+
 const SEEK_MAX: f32 = 560.;
 const VOLUME_WIDTH: f32 = 110.;
 const VOLUME_TIGHT: f32 = 72.;
@@ -20,6 +22,7 @@ const STEP: f32 = 0.004;
 pub struct PlayerBar {
     playback: Entity<Playback>,
     queue: Entity<Queue>,
+    queue_panel: Option<Entity<QueuePanel>>,
     seek: ScrubberState,
     volume: ScrubberState,
     pending: Option<f32>,
@@ -30,12 +33,34 @@ pub struct PlayerBar {
 
 impl PlayerBar {
     pub fn new(playback: Entity<Playback>, queue: Entity<Queue>, cx: &mut Context<Self>) -> Self {
+        Self::build(playback, queue, None, cx)
+    }
+
+    pub(crate) fn with_queue_panel(
+        playback: Entity<Playback>,
+        queue: Entity<Queue>,
+        queue_panel: Entity<QueuePanel>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        Self::build(playback, queue, Some(queue_panel), cx)
+    }
+
+    fn build(
+        playback: Entity<Playback>,
+        queue: Entity<Queue>,
+        queue_panel: Option<Entity<QueuePanel>>,
+        cx: &mut Context<Self>,
+    ) -> Self {
         cx.observe(&playback, |_, _, cx| cx.notify()).detach();
         cx.observe(&queue, |_, _, cx| cx.notify()).detach();
+        if let Some(queue_panel) = &queue_panel {
+            cx.observe(queue_panel, |_, _, cx| cx.notify()).detach();
+        }
 
         Self {
             playback,
             queue,
+            queue_panel,
             seek: ScrubberState::new("seek"),
             volume: ScrubberState::new("volume"),
             pending: None,
@@ -187,6 +212,24 @@ impl PlayerBar {
             .on_click(cx.listener(|this, _, _, cx| {
                 this.playback.update(cx, |playback, cx| playback.next(cx));
             }))
+    }
+
+    fn queue_button(&self, cx: &mut Context<Self>) -> Option<Button> {
+        let queue_panel = self.queue_panel.as_ref()?;
+        let open = queue_panel.read(cx).is_open();
+
+        Some(
+            Button::new("toggle-queue")
+                .ghost()
+                .small()
+                .icon("icons/list.svg")
+                .selected(open)
+                .on_click(cx.listener(|this, _, _, cx| {
+                    if let Some(queue_panel) = &this.queue_panel {
+                        queue_panel.update(cx, |panel, cx| panel.toggle(cx));
+                    }
+                })),
+        )
     }
 
     fn toggle(&self, cx: &mut Context<Self>) -> Button {
@@ -388,7 +431,8 @@ impl Render for PlayerBar {
                         .gap_3()
                         .w_full()
                         .child(div().flex_1().min_w_0().child(seek))
-                        .child(self.sound(px(VOLUME_TIGHT), cx)),
+                        .child(self.sound(px(VOLUME_TIGHT), cx))
+                        .when_some(self.queue_button(cx), |this, button| this.child(button)),
                 ),
             false => base
                 .items_center()
@@ -411,9 +455,11 @@ impl Render for PlayerBar {
                         .flex()
                         .items_center()
                         .justify_end()
+                        .gap_2()
                         .flex_1()
                         .min_w_0()
-                        .child(self.sound(px(VOLUME_WIDTH), cx)),
+                        .child(self.sound(px(VOLUME_WIDTH), cx))
+                        .when_some(self.queue_button(cx), |this, button| this.child(button)),
                 ),
         }
     }

--- a/crates/workspace/src/queue_panel.rs
+++ b/crates/workspace/src/queue_panel.rs
@@ -1,0 +1,490 @@
+use gpui::prelude::*;
+use gpui::{
+    Context, DragMoveEvent, Entity, FontWeight, MouseButton, MouseDownEvent, Pixels, Point, Render,
+    ScrollStrategy, SharedString, UniformListScrollHandle, Window, div, px, uniform_list,
+};
+use spotify::Track;
+use state::{Playback, Queue};
+use ui::{ActiveTheme as _, Card, Menu, MenuItem, snapped};
+
+use crate::Sidebar;
+
+const PANEL_WIDTH: f32 = 380.;
+const FULLSCREEN_BREAKPOINT: f32 = 680.;
+
+fn fills_content(width: Pixels) -> bool {
+    width < px(FULLSCREEN_BREAKPOINT)
+}
+
+#[derive(Clone)]
+struct DraggedTrack {
+    index: usize,
+    revision: u64,
+    name: SharedString,
+    position: Point<Pixels>,
+}
+
+impl DraggedTrack {
+    fn at(mut self, position: Point<Pixels>) -> Self {
+        self.position = position;
+        self
+    }
+}
+
+#[derive(Clone, Copy)]
+enum QueuePosition {
+    Past(usize),
+    Current,
+    Upcoming(usize),
+}
+
+/// Which edge of a row the drop indicator line is drawn at.
+#[derive(Clone, Copy)]
+enum DropLine {
+    Above,
+    Below,
+}
+
+#[derive(Clone, Copy)]
+enum MenuPlacement {
+    Above,
+    Below,
+}
+
+#[derive(Clone, Copy)]
+struct ContextMenuState {
+    index: usize,
+    revision: u64,
+    placement: MenuPlacement,
+}
+
+/// Transient per-row decorations.
+#[derive(Clone, Copy, Default)]
+struct RowState {
+    menu: Option<MenuPlacement>,
+    drop_line: Option<DropLine>,
+}
+
+impl QueuePosition {
+    fn past(self) -> Option<usize> {
+        match self {
+            Self::Past(index) => Some(index),
+            Self::Current | Self::Upcoming(_) => None,
+        }
+    }
+
+    fn upcoming(self) -> Option<usize> {
+        match self {
+            Self::Upcoming(index) => Some(index),
+            Self::Past(_) | Self::Current => None,
+        }
+    }
+
+    fn label(self) -> Option<&'static str> {
+        match self {
+            Self::Past(_) => None,
+            Self::Current => Some("Playing"),
+            Self::Upcoming(_) => None,
+        }
+    }
+}
+
+impl Render for DraggedTrack {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = *cx.theme();
+
+        div()
+            .pl(self.position.x + px(8.))
+            .pt(self.position.y + px(8.))
+            .child(
+                div()
+                    .max_w(px(240.))
+                    .px_2()
+                    .py_1()
+                    .rounded(theme.radius)
+                    .bg(theme.secondary)
+                    .text_color(theme.foreground)
+                    .truncate()
+                    .child(self.name.clone()),
+            )
+    }
+}
+
+pub(crate) struct QueuePanel {
+    queue: Entity<Queue>,
+    playback: Entity<Playback>,
+    sidebar: Entity<Sidebar>,
+    context_menu: Option<ContextMenuState>,
+    drop_gap: Option<usize>,
+    scroll: UniformListScrollHandle,
+    scroll_to_playing: bool,
+    open: bool,
+}
+
+impl QueuePanel {
+    pub(crate) fn new(
+        queue: Entity<Queue>,
+        playback: Entity<Playback>,
+        sidebar: Entity<Sidebar>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        cx.observe(&queue, |this, queue, cx| {
+            let revision = queue.read(cx).revision();
+            if this
+                .context_menu
+                .is_some_and(|menu| menu.revision != revision)
+            {
+                this.context_menu = None;
+            }
+            cx.notify();
+        })
+        .detach();
+        cx.observe(&sidebar, |_, _, cx| cx.notify()).detach();
+
+        Self {
+            queue,
+            playback,
+            sidebar,
+            context_menu: None,
+            drop_gap: None,
+            scroll: UniformListScrollHandle::new(),
+            scroll_to_playing: false,
+            open: false,
+        }
+    }
+
+    pub(crate) fn is_open(&self) -> bool {
+        self.open
+    }
+
+    pub(crate) fn toggle(&mut self, cx: &mut Context<Self>) {
+        self.open = !self.open;
+        self.scroll_to_playing = self.open;
+        cx.notify();
+    }
+
+    pub(crate) fn close(&mut self, cx: &mut Context<Self>) {
+        self.context_menu = None;
+        self.open = false;
+        cx.notify();
+    }
+
+    fn dismiss_menu(&mut self, cx: &mut Context<Self>) {
+        self.context_menu = None;
+        cx.notify();
+    }
+
+    fn row(
+        track: Track,
+        index: usize,
+        position: QueuePosition,
+        queue_revision: u64,
+        state: RowState,
+        window: &Window,
+        cx: &Context<Self>,
+    ) -> gpui::Stateful<gpui::Div> {
+        let theme = *cx.theme();
+        let height = snapped(theme.metrics.list_row, window);
+        let past_index = position.past();
+        let queue_index = position.upcoming();
+        let title = match position {
+            QueuePosition::Past(_) => theme.muted_foreground,
+            QueuePosition::Current => theme.primary,
+            QueuePosition::Upcoming(_) => theme.foreground,
+        };
+        let dragged = queue_index.map(|index| DraggedTrack {
+            index,
+            revision: queue_revision,
+            name: SharedString::from(track.name.clone()),
+            position: Point::default(),
+        });
+
+        let card = Card::new(("queue-track", index), SharedString::from(track.name))
+            .cover(track.cover)
+            .meta(SharedString::from(track.artists))
+            .weight(FontWeight::SEMIBOLD)
+            .tint(title)
+            .when(track.explicit, Card::explicit)
+            .when_some(position.label(), |this, label| {
+                this.trailing(
+                    div()
+                        .flex_none()
+                        .text_xs()
+                        .text_color(theme.muted_foreground)
+                        .child(label),
+                )
+            })
+            .when_some(past_index, |this, index| {
+                this.press(cx.listener(move |this, _, _, cx| {
+                    if this.queue.read(cx).revision() == queue_revision {
+                        this.playback
+                            .update(cx, |playback, cx| playback.play_past(index, cx));
+                    }
+                }))
+            })
+            .when_some(queue_index, |this, target| {
+                this.press(cx.listener(move |this, _, _, cx| {
+                    if this.queue.read(cx).revision() == queue_revision {
+                        this.playback
+                            .update(cx, |playback, cx| playback.play_upcoming(target, cx));
+                    }
+                }))
+                .on_drag_move(cx.listener(
+                    move |this, event: &DragMoveEvent<DraggedTrack>, _, cx| {
+                        let position = event.event.position;
+                        if !event.bounds.contains(&position) {
+                            return;
+                        }
+                        let gap = if position.y < event.bounds.center().y {
+                            target
+                        } else {
+                            target + 1
+                        };
+                        let dragged = event.drag(cx).index;
+                        let gap = (gap != dragged && gap != dragged + 1).then_some(gap);
+                        if this.drop_gap != gap {
+                            this.drop_gap = gap;
+                            cx.notify();
+                        }
+                    },
+                ))
+                .on_drop(cx.listener(move |this, dragged: &DraggedTrack, _, cx| {
+                    if let Some(gap) = this.drop_gap.take() {
+                        this.queue.update(cx, |queue, cx| {
+                            if queue.revision() == dragged.revision {
+                                queue.move_upcoming_to_gap(dragged.index, gap, cx);
+                            }
+                        });
+                    }
+                }))
+                .on_mouse_down(
+                    MouseButton::Right,
+                    cx.listener(move |this, event: &MouseDownEvent, window, cx| {
+                        let placement = if event.position.y > window.viewport_size().height / 2. {
+                            MenuPlacement::Above
+                        } else {
+                            MenuPlacement::Below
+                        };
+                        this.context_menu = Some(ContextMenuState {
+                            index: target,
+                            revision: queue_revision,
+                            placement,
+                        });
+                        cx.stop_propagation();
+                        cx.notify();
+                    }),
+                )
+            })
+            .when_some(dragged, |this, dragged| {
+                this.on_drag(dragged, |dragged, position, _, cx| {
+                    cx.new(|_| dragged.clone().at(position))
+                })
+            });
+
+        div()
+            .id(("queue-track-container", index))
+            .relative()
+            .min_w_0()
+            .child(card)
+            .when_some(state.drop_line, |this, edge| {
+                let line = div()
+                    .absolute()
+                    .left_2()
+                    .right_2()
+                    .h(px(2.))
+                    .rounded_full()
+                    .bg(theme.primary);
+                this.child(match edge {
+                    DropLine::Above => line.top_0(),
+                    DropLine::Below => line.bottom_0(),
+                })
+            })
+            .when_some(state.menu.zip(queue_index), |this, (placement, index)| {
+                this.child(
+                    Menu::new(("queue-track-menu", index))
+                        .right_2()
+                        .w(px(180.))
+                        .when_else(
+                            matches!(placement, MenuPlacement::Above),
+                            |menu| menu.bottom(height - px(4.)),
+                            |menu| menu.top(height - px(4.)),
+                        )
+                        .on_dismiss(cx.listener(|this, _, _, cx| this.dismiss_menu(cx)))
+                        .item(
+                            MenuItem::new(("remove-queued-track", index), "Remove from queue")
+                                .on_click(cx.listener(move |this, _, _, cx| {
+                                    this.queue.update(cx, |queue, cx| {
+                                        if queue.revision() == queue_revision {
+                                            queue.remove_upcoming(index, cx);
+                                        }
+                                    });
+                                    this.dismiss_menu(cx);
+                                })),
+                        ),
+                )
+            })
+    }
+}
+
+impl Render for QueuePanel {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if !self.open {
+            return div().into_any_element();
+        }
+
+        let theme = *cx.theme();
+        let content_width = window.viewport_size().width - self.sidebar.read(cx).occupied_width();
+        let fullscreen = fills_content(content_width);
+        let queue = self.queue.read(cx);
+        let past_count = queue.past().len();
+        let has_current = queue.current().is_some();
+        let current_count = usize::from(has_current);
+        let upcoming_count = queue.upcoming().len();
+        let total_count = past_count + current_count + upcoming_count;
+        let context_menu = self.context_menu;
+        let empty = total_count == 0;
+        if !cx.has_active_drag() {
+            self.drop_gap = None;
+        }
+        let drop_gap = self.drop_gap;
+
+        if self.scroll_to_playing && has_current {
+            self.scroll
+                .scroll_to_item(past_count, ScrollStrategy::Center);
+            self.scroll_to_playing = false;
+        }
+
+        div()
+            .id("queue-panel")
+            .occlude()
+            .on_drag_move(cx.listener(|this, _: &DragMoveEvent<DraggedTrack>, _, cx| {
+                if this.drop_gap.take().is_some() {
+                    cx.notify();
+                }
+            }))
+            .absolute()
+            .top_0()
+            .right_0()
+            .bottom_0()
+            .flex()
+            .flex_col()
+            .bg(theme.background)
+            .border_l_1()
+            .border_color(theme.border)
+            .when(fullscreen, |this| this.left_0())
+            .when(!fullscreen, |this| this.w(px(PANEL_WIDTH)))
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .flex_1()
+                    .min_h_0()
+                    .p_2()
+                    .when(!empty, |this| {
+                        let queue = self.queue.clone();
+                        this.child(
+                            uniform_list(
+                                "queue-tracks",
+                                total_count,
+                                cx.processor(
+                                    move |_, range: std::ops::Range<usize>, window, cx| {
+                                        let (revision, visible) = {
+                                            let queue = queue.read(cx);
+                                            let visible = queue
+                                                .past()
+                                                .cloned()
+                                                .enumerate()
+                                                .map(|(index, track)| {
+                                                    (track, QueuePosition::Past(index))
+                                                })
+                                                .chain(
+                                                    queue.current().cloned().map(|track| {
+                                                        (track, QueuePosition::Current)
+                                                    }),
+                                                )
+                                                .chain(queue.upcoming().cloned().enumerate().map(
+                                                    |(index, track)| {
+                                                        (track, QueuePosition::Upcoming(index))
+                                                    },
+                                                ))
+                                                .skip(range.start)
+                                                .take(range.len())
+                                                .collect::<Vec<_>>();
+                                            (queue.revision(), visible)
+                                        };
+                                        visible
+                                            .into_iter()
+                                            .enumerate()
+                                            .map(|(offset, (track, position))| {
+                                                let row_state = RowState {
+                                                    menu: position.upcoming().and_then(|index| {
+                                                        context_menu
+                                                            .filter(|menu| {
+                                                                menu.index == index
+                                                                    && menu.revision == revision
+                                                            })
+                                                            .map(|menu| menu.placement)
+                                                    }),
+                                                    drop_line: match (position.upcoming(), drop_gap)
+                                                    {
+                                                        (Some(index), Some(gap))
+                                                            if gap == index =>
+                                                        {
+                                                            Some(DropLine::Above)
+                                                        }
+                                                        (Some(index), Some(gap))
+                                                            if gap == upcoming_count
+                                                                && index + 1 == upcoming_count =>
+                                                        {
+                                                            Some(DropLine::Below)
+                                                        }
+                                                        _ => None,
+                                                    },
+                                                };
+                                                Self::row(
+                                                    track,
+                                                    range.start + offset,
+                                                    position,
+                                                    revision,
+                                                    row_state,
+                                                    window,
+                                                    cx,
+                                                )
+                                            })
+                                            .collect()
+                                    },
+                                ),
+                            )
+                            .track_scroll(&self.scroll)
+                            .flex_1()
+                            .min_h_0(),
+                        )
+                    })
+                    .when(empty, |this| {
+                        this.child(
+                            div()
+                                .flex()
+                                .flex_1()
+                                .items_center()
+                                .justify_center()
+                                .text_color(theme.muted_foreground)
+                                .child("Your queue is empty"),
+                        )
+                    }),
+            )
+            .into_any_element()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gpui::px;
+
+    use super::fills_content;
+
+    #[test]
+    fn fills_narrow_content_area() {
+        assert!(fills_content(px(679.)));
+        assert!(!fills_content(px(680.)));
+    }
+}


### PR DESCRIPTION
## Summary

- add a responsive, virtualized queue panel toggled from the player bar
- support playing previous and upcoming tracks, drag reordering, and right-click removal
- keep queue edits safe with revision guards and scroll to the playing track on open

## Testing

- cargo fmt --all -- --check
- cargo check --workspace --all-targets
- cargo test --workspace
- cargo clippy -p state --lib --no-deps -- -D warnings -A clippy::type-complexity
- cargo clippy -p workspace --all-targets --no-deps -- -D warnings -A clippy::type-complexity