### PR TITLE
feat: song details page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,8 +256,10 @@ Rules:
 
 - **Measure against `Chrome::content`, never `window.viewport_size().width`.** A raw viewport width
   ignores both side panels, so tables overflow under the queue and grids pick a column count that
-  does not fit. The only legitimate viewport-width consumers are elements that genuinely span the
-  window: `PlayerBar` and `TitleBar`.
+  does not fit. Raw viewport width is legitimate in exactly two places: chrome that spans the whole
+  window (`PlayerBar`, `TitleBar`, and `Menu`'s submenu flip), and a side panel deciding *its own*
+  size — `Sidebar` and `QueuePanel` subtract only the other panel, because asking `Chrome` for a
+  width they are themselves a term in would be circular.
 - `Workspace::render` publishes the widths every frame via `Chrome::publish`; it notifies only when
   a width actually changed, so it cannot loop.
 - **A view whose layout depends on width must observe the chrome**, or it will not repaint when a

--- a/crates/ui/src/card.rs
+++ b/crates/ui/src/card.rs
@@ -257,7 +257,7 @@ impl RenderOnce for Card {
                     .flex_col()
                     .flex_1()
                     .min_w_0()
-                    .when(match_art_height, |this| this.h(art))
+                    .when(match_art_height, |this| this.h(art).justify_between())
                     .when(listed, |this| this.min_w(TITLE))
                     .when_some(spacing, |this, spacing| this.gap(spacing))
                     .when_else(
@@ -306,12 +306,7 @@ impl RenderOnce for Card {
                                         .child(meta),
                                 }
                             }))
-                            .children(footer.map(|footer| {
-                                div()
-                                    .pt_1()
-                                    .when(match_art_height, |this| this.mt_auto())
-                                    .child(footer)
-                            }))
+                            .children(footer.map(|footer| div().pt_1().child(footer)))
                         },
                     ),
             )

--- a/crates/views/src/artist.rs
+++ b/crates/views/src/artist.rs
@@ -113,6 +113,7 @@ impl ArtistView {
             }
             this.playback_status = current;
             this.table.update(cx, |table, cx| table.refresh(cx));
+            cx.notify();
         })
         .detach();
         cx.subscribe(&table, |this, _, event, cx| {

--- a/crates/views/src/cells.rs
+++ b/crates/views/src/cells.rs
@@ -305,22 +305,25 @@ pub(crate) fn title<F>(
     explicit: bool,
     song_id: Option<String>,
 ) -> AnyElement {
-    let content = line(cell, color)
-        .flex()
-        .items_center()
-        .gap_1p5()
-        .child(div().min_w_0().truncate().child(value.into()))
-        .when(explicit, |this| {
-            this.child(div().flex_none().child(ExplicitBadge::new()))
-        });
-    match song_id {
-        Some(id) => content
+    let text = div().min_w_0().truncate().child(value.into());
+    let text = match song_id {
+        Some(id) => text
             .id(("song", cell.row))
             .hover(|style| style.underline())
             .link(Destination::Song(id.into()))
             .into_any_element(),
-        None => content.into_any_element(),
-    }
+        None => text.into_any_element(),
+    };
+
+    line(cell, color)
+        .flex()
+        .items_center()
+        .gap_1p5()
+        .child(text)
+        .when(explicit, |this| {
+            this.child(div().flex_none().child(ExplicitBadge::new()))
+        })
+        .into_any_element()
 }
 
 pub(crate) fn artwork<F>(cell: &Cell<F>, url: Option<String>) -> AnyElement {

--- a/crates/views/src/detail.rs
+++ b/crates/views/src/detail.rs
@@ -84,6 +84,7 @@ impl DetailView {
             }
             this.playback_status = current;
             this.table.update(cx, |table, cx| table.refresh(cx));
+            cx.notify();
         })
         .detach();
 

--- a/crates/views/src/hero.rs
+++ b/crates/views/src/hero.rs
@@ -1,7 +1,7 @@
 use gpui::prelude::*;
 use gpui::{AnyElement, App, ElementId, Entity, FontWeight, SharedString, Window, div};
 use spotify::Track;
-use state::Playback;
+use state::{Playback, PlaybackState};
 use ui::{ActiveTheme as _, Button, Card, Text};
 
 pub(crate) fn release_date_label(value: &str) -> String {
@@ -98,22 +98,42 @@ impl HeroPlayButton {
 }
 
 impl RenderOnce for HeroPlayButton {
-    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
         let first_playable = self.tracks.iter().position(|track| track.playable);
-        let disabled = first_playable.is_none();
+        let state = {
+            let playback = self.playback.read(cx);
+            let current = playback.track().and_then(|track| track.id.as_deref());
+            current
+                .filter(|current| {
+                    self.tracks
+                        .iter()
+                        .any(|track| track.id.as_deref() == Some(*current))
+                })
+                .map(|_| playback.state().clone())
+        };
+        let (label, icon, blocked) = match &state {
+            Some(PlaybackState::Playing) => ("Pause".into(), "icons/pause.svg", false),
+            Some(PlaybackState::Paused) => ("Resume".into(), "icons/play.svg", false),
+            Some(PlaybackState::Loading) => ("Loading…".into(), "icons/play.svg", true),
+            _ => (self.label, "icons/play.svg", false),
+        };
+        let disabled = first_playable.is_none() || blocked;
         let first_playable = first_playable.unwrap_or_default();
         let tracks = self.tracks;
         let playback = self.playback;
 
         div().flex().child(
             Button::new(self.id)
-                .label(self.label)
-                .icon("icons/play.svg")
+                .label(label)
+                .icon(icon)
                 .primary()
                 .disabled(disabled)
                 .on_click(move |_, _, cx| {
-                    playback.update(cx, |playback, cx| {
-                        playback.start(tracks.clone(), first_playable, cx)
+                    playback.update(cx, |playback, cx| match &state {
+                        Some(PlaybackState::Playing) => playback.pause(cx),
+                        Some(PlaybackState::Paused) => playback.resume(cx),
+                        Some(PlaybackState::Loading) => {}
+                        _ => playback.start(tracks.clone(), first_playable, cx),
                     });
                 }),
         )

--- a/crates/views/src/hero.rs
+++ b/crates/views/src/hero.rs
@@ -55,18 +55,23 @@ impl RenderOnce for HeroMetaStrip {
         let theme = *cx.theme();
         let mut strip = div()
             .flex()
+            .flex_wrap()
             .items_center()
             .min_w_0()
-            .gap_2()
-            .truncate()
+            .gap_1()
             .text_size(theme.text(Text::Small))
             .text_color(theme.muted_foreground);
 
         for (index, item) in self.items.into_iter().enumerate() {
-            if index > 0 {
-                strip = strip.child(div().flex_none().child("•"));
-            }
-            strip = strip.child(div().min_w_0().truncate().child(item));
+            strip = strip.child(
+                div()
+                    .flex()
+                    .flex_none()
+                    .items_center()
+                    .gap_1()
+                    .when(index > 0, |this| this.child("•"))
+                    .child(item),
+            );
         }
 
         strip
@@ -209,7 +214,6 @@ impl RenderOnce for PageHero {
             .size(Text::Display)
             .weight(FontWeight::BOLD)
             .explicit_gap(theme.metrics.pad * 1.5)
-            .spacing(theme.metrics.pad)
             .flat()
             .flex_none()
             .items_end()

--- a/crates/views/src/song.rs
+++ b/crates/views/src/song.rs
@@ -1,7 +1,5 @@
 use gpui::prelude::*;
-use gpui::{
-    AnyElement, Context, Entity, FontWeight, Render, SharedString, Window, div, px, relative,
-};
+use gpui::{AnyElement, Context, Entity, FontWeight, Render, SharedString, Window, div, px};
 use router::{Destination, Link as _};
 use spotify::{Credit, Track};
 use state::{Playback, SongDetail};
@@ -33,6 +31,7 @@ impl SongView {
             "tr" => "Turkish",
             "uk" => "Ukrainian",
             "zh" => "Chinese",
+            "zxx" => "No linguistic content",
             _ => code,
         }
     }
@@ -94,6 +93,7 @@ impl SongView {
     fn fact(
         label: impl Into<SharedString>,
         value: impl Into<SharedString>,
+        index: usize,
         cx: &Context<Self>,
     ) -> AnyElement {
         let theme = *cx.theme();
@@ -102,7 +102,12 @@ impl SongView {
             .items_center()
             .justify_between()
             .gap_4()
-            .py_1()
+            .px(theme.metrics.pad)
+            .py(theme.metrics.pad / 2.)
+            .rounded(theme.radius)
+            .when(index % 2 == 1, |this| {
+                this.bg(theme.table_hover.opacity(0.35))
+            })
             .child(div().text_color(theme.muted_foreground).child(label.into()))
             .child(
                 div()
@@ -200,37 +205,17 @@ impl SongView {
             div()
                 .flex()
                 .flex_col()
-                .child(Self::fact("Album", album_name, cx))
-                .child(Self::fact("Released", release, cx))
-                .child(Self::fact("Streams", streams, cx))
-                .child(Self::fact("Position", number, cx))
-                .child(Self::fact("Label", label, cx))
-                .child(
-                    div()
-                        .flex()
-                        .flex_col()
-                        .gap_2()
-                        .pt_2()
-                        .child(Self::fact(
-                            "Popularity",
-                            format!("{} / 100", track.popularity),
-                            cx,
-                        ))
-                        .child(
-                            div()
-                                .w_full()
-                                .h(px(4.))
-                                .rounded_full()
-                                .bg(cx.theme().muted)
-                                .child(
-                                    div()
-                                        .h_full()
-                                        .w(relative(track.popularity.min(100) as f32 / 100.))
-                                        .rounded_full()
-                                        .bg(cx.theme().progress_bar),
-                                ),
-                        ),
-                ),
+                .child(Self::fact("Album", album_name, 0, cx))
+                .child(Self::fact("Released", release, 1, cx))
+                .child(Self::fact("Streams", streams, 2, cx))
+                .child(Self::fact("Position", number, 3, cx))
+                .child(Self::fact("Label", label, 4, cx))
+                .child(Self::fact(
+                    "Popularity",
+                    format!("{}%", track.popularity),
+                    5,
+                    cx,
+                )),
             true,
             cx,
         )
@@ -267,19 +252,27 @@ impl SongView {
                         None => Initials::new(credit.name.clone(), theme.metrics.thumb)
                             .into_any_element(),
                     };
-                    let row = div().flex().items_center().gap_3().child(avatar).child(
-                        div()
-                            .flex()
-                            .flex_col()
-                            .gap_0p5()
-                            .child(div().font_weight(FontWeight::MEDIUM).child(credit.name))
-                            .child(
-                                div()
-                                    .text_size(theme.text(Text::Small))
-                                    .text_color(theme.muted_foreground)
-                                    .child(credit.role),
-                            ),
-                    );
+                    let row = div()
+                        .flex()
+                        .items_center()
+                        .gap_3()
+                        .px(theme.metrics.pad)
+                        .py(theme.metrics.pad / 2.)
+                        .rounded(theme.radius)
+                        .child(avatar)
+                        .child(
+                            div()
+                                .flex()
+                                .flex_col()
+                                .gap_0p5()
+                                .child(div().font_weight(FontWeight::MEDIUM).child(credit.name))
+                                .child(
+                                    div()
+                                        .text_size(theme.text(Text::Small))
+                                        .text_color(theme.muted_foreground)
+                                        .child(credit.role),
+                                ),
+                        );
 
                     match credit.id {
                         Some(id) => row
@@ -316,36 +309,52 @@ impl SongView {
                 .flex()
                 .flex_col()
                 .gap_1()
-                .child(div().flex().flex_wrap().gap_2().when_else(
+                .child(div().when_else(
                     tags.is_empty(),
-                    |this| this.child(Self::fact("Genres", "Not available", cx)),
+                    |this| this.child(Self::fact("Genres", "Not available", 0, cx)),
                     |this| {
                         this.child(
                             div()
                                 .flex()
-                                .flex_wrap()
-                                .justify_end()
-                                .w_full()
-                                .gap_2()
-                                .py_1()
-                                .children(tags.into_iter().map(|tag| {
+                                .items_start()
+                                .justify_between()
+                                .gap_4()
+                                .px(theme.metrics.pad)
+                                .py(theme.metrics.pad / 2.)
+                                .child(
                                     div()
-                                        .px_3()
-                                        .py_1()
-                                        .rounded_full()
-                                        .bg(theme.secondary)
-                                        .border_1()
-                                        .border_color(theme.border)
-                                        .text_size(theme.text(Text::Small))
-                                        .child(tag)
-                                })),
+                                        .flex_none()
+                                        .text_color(theme.muted_foreground)
+                                        .child("Genres"),
+                                )
+                                .child(
+                                    div()
+                                        .flex()
+                                        .flex_1()
+                                        .min_w_0()
+                                        .flex_wrap()
+                                        .justify_end()
+                                        .gap_2()
+                                        .children(tags.into_iter().map(|tag| {
+                                            div()
+                                                .px_3()
+                                                .py_1()
+                                                .rounded_full()
+                                                .bg(theme.secondary)
+                                                .border_1()
+                                                .border_color(theme.border)
+                                                .text_size(theme.text(Text::Small))
+                                                .child(tag)
+                                        })),
+                                ),
                         )
                     },
                 ))
-                .child(Self::fact("Language", languages, cx))
+                .child(Self::fact("Language", languages, 1, cx))
                 .child(Self::fact(
                     "Content",
                     if track.explicit { "Explicit" } else { "Clean" },
+                    2,
                     cx,
                 )),
             false,

--- a/crates/views/src/song.rs
+++ b/crates/views/src/song.rs
@@ -420,8 +420,7 @@ impl SongView {
                     div()
                         .flex_none()
                         .text_size(theme.text(Text::Small))
-                        .font_weight(FontWeight::MEDIUM)
-                        .child("View artist  →"),
+                        .font_weight(FontWeight::MEDIUM),
                 )
                 .into_any_element(),
         )


### PR DESCRIPTION
## What changed

- Add a navigable song details page with cover art, credits, release metadata, genres/tags, language, popularity, copyright, and artist profile.
- Expose richer track, album, credit, and artist biography metadata from the Spotify layer.
- Make song titles open the new detail route.
- Introduce shared detail hero, metadata strip, and play-button components for songs, albums, and playlists.
- Add contextual play controls and total durations to album and playlist heroes.
- Normalize HTML-formatted artist biographies into readable text.
- Align hero artwork styling, metadata formatting, explicit badges, and actions across detail views.

## Why

Songs previously had no dedicated information surface, and album, playlist, and song headers used separate layout and interaction patterns. This adds the missing page while consolidating common presentation and playback behavior so future changes remain consistent.

## User impact

Users can open any song title to inspect detailed metadata, play it, navigate to its album or artist, and use matching play controls on album and playlist pages.

## Validation

- `cargo check`
- `cargo test --quiet`
- Post-rebase test suite passes against the latest `main`.
