### PR TITLE
fix(ui): crop artwork to square pixels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7485,6 +7485,7 @@ name = "ui"
 version = "0.1.0"
 dependencies = [
  "gpui",
+ "image",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ gpui_platform = { git = "https://github.com/zed-industries/zed", rev = "f25b256f
   "x11",
 ] }
 http = "1.3"
+image = { version = "0.25", default-features = false }
 jiff = { version = "0.2", default-features = false, features = ["std"] }
 log = "0.4"
 reqwest = { version = "0.12", default-features = false, features = [

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -5,4 +5,5 @@ edition.workspace = true
 
 [dependencies]
 gpui.workspace = true
+image.workspace = true
 serde.workspace = true

--- a/crates/ui/src/artwork.rs
+++ b/crates/ui/src/artwork.rs
@@ -2,12 +2,95 @@ use crate::skeleton::Skeleton;
 use crate::theme::ActiveTheme as _;
 use gpui::prelude::*;
 use gpui::{
-    App, Div, Hsla, Interactivity, Pixels, SharedString, SharedUri, StyleRefinement, Styled,
+    App, Asset, Div, Hsla, ImageCacheError, ImageSource, ImgResourceLoader, Interactivity,
+    ObjectFit, Pixels, RenderImage, Resource, SharedString, SharedUri, StyleRefinement, Styled,
     Window, div, img, px, svg,
 };
+use std::sync::Arc;
 
 const FALLBACK_ICON: &str = "icons/music.svg";
 const ROUNDED: Pixels = px(4.);
+
+#[derive(Clone)]
+enum SquareImageLoader {}
+
+impl Asset for SquareImageLoader {
+    type Source = Resource;
+    type Output = Result<Arc<RenderImage>, ImageCacheError>;
+
+    fn load(
+        source: Self::Source,
+        cx: &mut App,
+    ) -> impl Future<Output = Self::Output> + Send + 'static {
+        let (image, _) = cx.fetch_asset::<ImgResourceLoader>(&source);
+        async move { image.await.map(crop_square) }
+    }
+}
+
+fn crop_square(image: Arc<RenderImage>) -> Arc<RenderImage> {
+    if image.frame_count() == 0
+        || (0..image.frame_count()).all(|frame| {
+            let size = image.size(frame);
+            size.width == size.height
+        })
+    {
+        return image;
+    }
+
+    let frames = (0..image.frame_count())
+        .map(|frame| {
+            let size = image.size(frame);
+            let width = u32::from(size.width);
+            let height = u32::from(size.height);
+            let side = width.min(height);
+            let left = (width - side) / 2;
+            let top = (height - side) / 2;
+            let source = image
+                .as_bytes(frame)
+                .expect("render image frame should have pixel data");
+            let row_bytes = side as usize * 4;
+            let mut pixels = Vec::with_capacity(row_bytes * side as usize);
+
+            for row in 0..side {
+                let start = (((top + row) * width + left) * 4) as usize;
+                pixels.extend_from_slice(&source[start..start + row_bytes]);
+            }
+
+            let buffer = image::RgbaImage::from_raw(side, side, pixels)
+                .expect("square crop should contain one complete image");
+            image::Frame::from_parts(buffer, 0, 0, image.delay(frame))
+        })
+        .collect::<Vec<_>>();
+
+    Arc::new(RenderImage::new(frames))
+}
+
+#[derive(IntoElement)]
+pub struct Avatar {
+    url: Option<SharedString>,
+    size: Pixels,
+}
+
+impl Avatar {
+    #[track_caller]
+    pub fn new(url: Option<impl Into<SharedString>>) -> Self {
+        Self {
+            url: url.map(Into::into),
+            size: px(28.),
+        }
+    }
+
+    pub fn size(mut self, size: Pixels) -> Self {
+        self.size = size;
+        self
+    }
+}
+
+impl RenderOnce for Avatar {
+    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        Artwork::new(self.url).size(self.size).circle().flex_none()
+    }
+}
 
 #[derive(IntoElement)]
 pub struct Artwork {
@@ -67,20 +150,28 @@ impl RenderOnce for Artwork {
         let placeholder = move || blank(size, rounded, muted).into_any_element();
 
         match url {
-            Some(url) => refined(
-                img(SharedUri::from(url.to_string()))
-                    .size(size)
-                    .rounded(rounded)
-                    .with_loading(move || {
-                        Skeleton::new()
-                            .size(size)
-                            .rounded(rounded)
-                            .into_any_element()
-                    })
-                    .with_fallback(placeholder),
-                interactivity,
-            )
-            .into_any_element(),
+            Some(url) => {
+                let resource = Resource::Uri(SharedUri::from(url.to_string()));
+                let source = ImageSource::from(move |window: &mut Window, cx: &mut App| {
+                    window.use_asset::<SquareImageLoader>(&resource, cx)
+                });
+
+                refined(
+                    img(source)
+                        .size(size)
+                        .object_fit(ObjectFit::Cover)
+                        .rounded(rounded)
+                        .with_loading(move || {
+                            Skeleton::new()
+                                .size(size)
+                                .rounded(rounded)
+                                .into_any_element()
+                        })
+                        .with_fallback(placeholder),
+                    interactivity,
+                )
+                .into_any_element()
+            }
             None => refined(blank(size, rounded, muted), interactivity).into_any_element(),
         }
     }
@@ -108,4 +199,28 @@ fn blank(size: Pixels, rounded: Pixels, muted: Hsla) -> Div {
                 .size(size * 0.46)
                 .text_color(muted.opacity(0.5)),
         )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rectangular_images_are_center_cropped_to_square_pixels() {
+        let buffer =
+            image::RgbaImage::from_fn(4, 2, |x, y| image::Rgba([x as u8, y as u8, 0, 255]));
+        let source = Arc::new(RenderImage::new(vec![image::Frame::new(buffer)]));
+
+        let cropped = crop_square(source);
+        let size = cropped.size(0);
+        let red_channels = cropped
+            .as_bytes(0)
+            .unwrap()
+            .chunks_exact(4)
+            .map(|pixel| pixel[0])
+            .collect::<Vec<_>>();
+
+        assert_eq!((u32::from(size.width), u32::from(size.height)), (2, 2));
+        assert_eq!(red_channels, [1, 2, 1, 2]);
+    }
 }

--- a/crates/ui/src/card.rs
+++ b/crates/ui/src/card.rs
@@ -5,7 +5,7 @@ use gpui::{
 };
 
 use crate::ExplicitBadge;
-use crate::artwork::Artwork;
+use crate::artwork::{Artwork, Avatar};
 use crate::metrics::{Text, snapped};
 use crate::skeleton::Skeleton;
 use crate::theme::ActiveTheme as _;
@@ -199,10 +199,8 @@ impl RenderOnce for Card {
                 .size(art)
                 .when(circle, Skeleton::circle)
                 .into_any_element(),
-            false => Artwork::new(cover)
-                .size(art)
-                .when(circle, Artwork::circle)
-                .into_any_element(),
+            false if circle => Avatar::new(cover).size(art).into_any_element(),
+            false => Artwork::new(cover).size(art).into_any_element(),
         };
 
         let mut card = base

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -16,7 +16,7 @@ mod skeleton;
 mod theme;
 mod time;
 
-pub use artwork::Artwork;
+pub use artwork::{Artwork, Avatar};
 pub use button::Button;
 pub use card::Card;
 pub use controls::WindowControls;


### PR DESCRIPTION
## Summary

- center-crop decoded artwork bitmaps to square pixels before GPUI lays them out
- add a shared `Avatar` component for circular artist artwork
- keep square artwork sizing consistent across cards and detail views
- add a regression test for rectangular source images

## Why

GPUI restores an image's intrinsic aspect ratio after it loads. Non-square artist images therefore became ellipses even when the UI requested equal width and height. Cropping the decoded bitmap first gives GPUI a genuinely square source and makes the circular mask reliable.

## Impact

Artist artwork now renders as a true circle, while album and playlist artwork consistently uses a centered 1:1 crop.

## Validation

- `cargo test -p ui rectangular_images_are_center_cropped_to_square_pixels`
- `cargo check`
