### PR TITLE
fix(views): queue tracks in the order shown

### DIFF
--- a/crates/views/src/artist.rs
+++ b/crates/views/src/artist.rs
@@ -90,6 +90,7 @@ impl ArtistView {
                 playback.clone(),
                 playlist_scrollbar,
             );
+            let source = source.table(cx.weak_entity());
             GridState::new(GridDelegate::new(source, width, cx), cx).follow(scroll)
         });
 

--- a/crates/views/src/detail.rs
+++ b/crates/views/src/detail.rs
@@ -60,6 +60,7 @@ impl DetailView {
                 playback.clone(),
                 playlist_scrollbar,
             );
+            let source = source.table(cx.weak_entity());
             GridState::new(GridDelegate::new(source, width, cx), cx).follow(scroll)
         });
 

--- a/crates/views/src/library/mod.rs
+++ b/crates/views/src/library/mod.rs
@@ -13,7 +13,7 @@ use workspace::{Chrome, Searchable};
 
 use crate::cells;
 use crate::tracks::{
-    LIBRARY_COLUMNS, PlaybackStatus, TrackField, TrackSource, Tracks, playback_status,
+    self, LIBRARY_COLUMNS, PlaybackStatus, TrackField, TrackSource, Tracks, playback_status,
 };
 use albums::AlbumSource;
 use playlists::PlaylistSource;
@@ -111,6 +111,7 @@ impl LibraryView {
                 playback.clone(),
                 playlist_scrollbar,
             );
+            let source = source.table(cx.weak_entity());
             let mut delegate = GridDelegate::new(source, width, cx).with_sort(
                 TrackField::AddedAt,
                 Sort::Descending,
@@ -279,13 +280,7 @@ impl LibraryView {
     }
 
     fn play(&mut self, display: usize, cx: &mut Context<Self>) {
-        let queued = {
-            let state = self.tracks.read(cx);
-            let delegate = state.delegate();
-            (0..delegate.row_count())
-                .filter_map(|row| delegate.source().at(delegate.row(row), cx))
-                .collect::<Vec<_>>()
-        };
+        let queued = tracks::ordered(&self.tracks, cx);
         self.playback
             .update(cx, |playback, cx| playback.start(queued, display, cx));
     }

--- a/crates/views/src/page.rs
+++ b/crates/views/src/page.rs
@@ -4,7 +4,7 @@ use state::Playback;
 use ui::{GridState, Viewport, scrolled};
 
 use crate::cells;
-use crate::tracks::TrackSource;
+use crate::tracks::{self, TrackSource};
 
 const FRAME: Pixels = px(1.);
 
@@ -18,13 +18,7 @@ pub(crate) fn play(
     display: usize,
     cx: &mut App,
 ) {
-    let queued = {
-        let state = table.read(cx);
-        let delegate = state.delegate();
-        (0..delegate.row_count())
-            .filter_map(|row| delegate.source().at(delegate.row(row), cx))
-            .collect::<Vec<_>>()
-    };
+    let queued = tracks::ordered(table, cx);
     playback.update(cx, |playback, cx| playback.start(queued, display, cx));
 }
 

--- a/crates/views/src/tracks.rs
+++ b/crates/views/src/tracks.rs
@@ -2,12 +2,14 @@ use std::cmp::Ordering;
 use std::rc::Rc;
 use ui::ActiveTheme as _;
 
-use gpui::{AnyElement, App, ClipboardItem, Entity, Hsla, Styled as _, TextAlign};
+use gpui::{AnyElement, App, ClipboardItem, Entity, Hsla, Styled as _, TextAlign, WeakEntity};
 use jiff::Timestamp;
 use router::{Destination, navigate};
 use spotify::Track;
 use state::{LibraryState, Playback, PlaybackState, Sonora};
-use ui::{Cell, ColumnSpec, GridSource, Menu, MenuItem, Scrollbar, SubmenuState, Width, clock};
+use ui::{
+    Cell, ColumnSpec, GridSource, GridState, Menu, MenuItem, Scrollbar, SubmenuState, Width, clock,
+};
 
 use crate::cells::{self, ALWAYS, DATE, NUMBER, ROOMY, SNUG, TRAILING, WIDE};
 
@@ -265,11 +267,21 @@ impl TrackMenu {
     }
 }
 
+pub(crate) fn ordered(table: &Entity<GridState<TrackSource>>, cx: &App) -> Vec<Track> {
+    let state = table.read(cx);
+    let delegate = state.delegate();
+
+    (0..delegate.row_count())
+        .filter_map(|display| delegate.source().at(delegate.row(display), cx))
+        .collect()
+}
+
 pub(crate) struct TrackSource {
     columns: &'static [ColumnSpec<TrackField>],
     provider: Rc<dyn Tracks>,
     playback: Entity<Playback>,
     menu: TrackMenu,
+    table: Option<WeakEntity<GridState<TrackSource>>>,
 }
 
 impl TrackSource {
@@ -284,7 +296,13 @@ impl TrackSource {
             provider: Rc::new(provider),
             playback,
             menu: TrackMenu::new(playlist_scrollbar),
+            table: None,
         }
+    }
+
+    pub(crate) fn table(mut self, table: WeakEntity<GridState<TrackSource>>) -> Self {
+        self.table = Some(table);
+        self
     }
 
     fn artist_cell(&self, cell: &Cell<TrackField>, track: &Track, color: Hsla) -> AnyElement {
@@ -321,11 +339,18 @@ impl TrackSource {
                     playback.update(cx, |playback, _| playback.preload(&preload_track));
                 }));
                 let provider = self.provider.clone();
+                let table = self.table.clone();
                 let row = cell.row;
-                let press = cells::toggle(&self.playback, state.clone(), move |playback, cx| {
-                    let queued = provider.tracks(cx).to_vec();
-                    playback.start(queued, row, cx)
-                });
+                let display = cell.display;
+                let press =
+                    cells::toggle(
+                        &self.playback,
+                        state.clone(),
+                        move |playback, cx| match table.as_ref().and_then(|table| table.upgrade()) {
+                            Some(table) => playback.start(ordered(&table, cx), display, cx),
+                            None => playback.start(provider.tracks(cx).to_vec(), row, cx),
+                        },
+                    );
                 (preload, press)
             }
         };


### PR DESCRIPTION
## What changed

- Play buttons in track tables queue rows in the order shown, honoring the active sort and filter.
- Share one ordering helper between the row play button and the double-click path.

## Why

Double-clicking a row queued the displayed order, but the row's play button queued the raw source order and started at the source index. Library → Songs sorts by date added by default, so the two never agreed.

## User impact

Playing a song from Library → Songs continues with the songs listed below it instead of an unrelated sequence. Album, playlist, and artist tables behave the same way when sorted.

## Validation

- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace`