### PR TITLE
feat(player): add queue controls

### DIFF
--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -69,6 +69,7 @@ pub struct Playback {
     normalisation: bool,
     shuffle: bool,
     repeat: Repeat,
+    radio: bool,
     task: Option<Task<()>>,
     load: Option<Task<()>>,
     fetch: Option<Task<()>>,
@@ -111,6 +112,7 @@ impl Playback {
             normalisation,
             shuffle: false,
             repeat: Repeat::Off,
+            radio: false,
             task: None,
             load: None,
             fetch: None,
@@ -271,14 +273,16 @@ impl Playback {
 
     pub fn next(&mut self, cx: &mut Context<Self>) {
         self.fetch = None;
-        let shuffle = self.shuffle;
-        let Some(track) = self.queue.update(cx, |queue, cx| match shuffle {
-            true => queue.next_random(cx),
-            false => queue.next(cx),
-        }) else {
-            return;
-        };
-        self.load_after(&track, SKIP_DEBOUNCE, cx);
+        self.follow_queue(cx);
+    }
+
+    pub fn radio(&self) -> bool {
+        self.radio
+    }
+
+    pub fn toggle_radio(&mut self, cx: &mut Context<Self>) {
+        self.radio = !self.radio;
+        cx.notify();
     }
 
     pub fn shuffle(&self) -> bool {
@@ -315,8 +319,57 @@ impl Playback {
                     self.load_after(&track, SKIP_DEBOUNCE, cx);
                 }
             }
+            _ if self.radio && !self.queue.read(cx).has_next() => {
+                match ended.or_else(|| self.track.clone()) {
+                    Some(seed) => self.extend_radio(&seed, cx),
+                    None => self.next(cx),
+                }
+            }
             _ => self.next(cx),
         }
+    }
+
+    fn extend_radio(&mut self, seed: &Track, cx: &mut Context<Self>) {
+        let (Some(id), Some(client)) = (seed.id.clone(), self.session.read(cx).client()) else {
+            return self.next(cx);
+        };
+
+        let io = Io::global(cx);
+        let heard = seed.id.clone();
+        self.fetch = Some(cx.spawn(async move |this, cx| {
+            let loaded = join(io.spawn(async move {
+                let mut tracks = client.track_radio(&id).await?;
+                tracks.retain(|track| track.id != heard && track.playable);
+                fastrand::shuffle(&mut tracks);
+                anyhow::Ok(tracks)
+            }))
+            .await;
+
+            this.update(cx, |this, cx| match loaded {
+                Ok(tracks) if !tracks.is_empty() => {
+                    this.queue.update(cx, |queue, cx| {
+                        for track in tracks {
+                            queue.append(track, cx);
+                        }
+                    });
+                    this.follow_queue(cx);
+                }
+                Ok(_) => log::warn!("playback: radio returned no tracks"),
+                Err(error) => log::warn!("playback: cannot extend radio: {error:#}"),
+            })
+            .ok();
+        }));
+    }
+
+    fn follow_queue(&mut self, cx: &mut Context<Self>) {
+        let shuffle = self.shuffle;
+        let Some(track) = self.queue.update(cx, |queue, cx| match shuffle {
+            true => queue.next_random(cx),
+            false => queue.next(cx),
+        }) else {
+            return;
+        };
+        self.load_after(&track, SKIP_DEBOUNCE, cx);
     }
 
     pub fn previous(&mut self, cx: &mut Context<Self>) {

--- a/crates/state/src/queue.rs
+++ b/crates/state/src/queue.rs
@@ -114,6 +114,14 @@ impl Queue {
         !self.past.is_empty()
     }
 
+    pub fn clear_upcoming(&mut self, cx: &mut Context<Self>) {
+        if self.upcoming.is_empty() {
+            return;
+        }
+        self.upcoming.clear();
+        self.changed(cx);
+    }
+
     pub fn clear(&mut self, cx: &mut Context<Self>) {
         self.past.clear();
         self.current = None;

--- a/crates/state/src/queue.rs
+++ b/crates/state/src/queue.rs
@@ -49,6 +49,10 @@ fn select_upcoming<T>(
     true
 }
 
+fn in_order<'a, T: PartialEq + 'a>(sequence: impl Iterator<Item = &'a T>, source: &[T]) -> bool {
+    sequence.eq(source.iter())
+}
+
 fn gap_target(from: usize, gap: usize, len: usize) -> usize {
     let gap = gap.min(len);
     if gap > from { gap - 1 } else { gap }
@@ -58,6 +62,7 @@ pub struct Queue {
     past: Vec<Track>,
     current: Option<Track>,
     upcoming: VecDeque<Track>,
+    source: Vec<Track>,
     revision: u64,
 }
 
@@ -73,6 +78,7 @@ impl Queue {
             past: Vec::new(),
             current: None,
             upcoming: VecDeque::new(),
+            source: Vec::new(),
             revision: 0,
         }
     }
@@ -126,7 +132,32 @@ impl Queue {
         self.past.clear();
         self.current = None;
         self.upcoming.clear();
+        self.source.clear();
         self.changed(cx);
+    }
+
+    pub fn reordered(&self) -> bool {
+        let sequence = self
+            .past
+            .iter()
+            .chain(self.current.as_ref())
+            .chain(self.upcoming.iter());
+
+        !self.source.is_empty() && !in_order(sequence, &self.source)
+    }
+
+    pub fn reset(&mut self, cx: &mut Context<Self>) -> Option<Track> {
+        if self.source.is_empty() {
+            return None;
+        }
+
+        let index = self
+            .current
+            .as_ref()
+            .and_then(|current| self.source.iter().position(|track| track == current))
+            .unwrap_or_default();
+        let source = self.source.clone();
+        self.start(source, index, cx)
     }
 
     pub fn start(
@@ -139,6 +170,7 @@ impl Queue {
             return None;
         }
 
+        self.source = tracks.clone();
         let mut past = tracks;
         self.upcoming = past.split_off(index + 1).into();
         self.current = past.pop();
@@ -230,7 +262,17 @@ impl Queue {
 mod tests {
     use std::collections::VecDeque;
 
-    use super::{gap_target, move_item, select_past, select_upcoming};
+    use super::{gap_target, in_order, move_item, select_past, select_upcoming};
+
+    #[test]
+    fn spots_a_reordered_queue() {
+        let source = [1, 2, 3, 4];
+
+        assert!(in_order([1, 2, 3, 4].iter(), &source));
+        assert!(!in_order([1, 3, 2, 4].iter(), &source));
+        assert!(!in_order([1, 2, 3].iter(), &source));
+        assert!(!in_order([1, 2, 3, 4, 5].iter(), &source));
+    }
 
     #[test]
     fn moves_items_in_both_directions() {

--- a/crates/workspace/src/queue_panel.rs
+++ b/crates/workspace/src/queue_panel.rs
@@ -466,15 +466,32 @@ impl QueuePanel {
             .border_color(theme.border)
             .child(eyebrow("QUEUE", cx))
             .child(
-                Button::new("clear-queue")
-                    .ghost()
-                    .small()
-                    .label("Clear")
-                    .tint(theme.muted_foreground)
-                    .disabled(sections.upcoming == 0)
-                    .on_click(cx.listener(|this, _, _, cx| {
-                        this.queue.update(cx, |queue, cx| queue.clear_upcoming(cx));
-                    })),
+                div()
+                    .flex()
+                    .items_center()
+                    .gap_1()
+                    .child(
+                        Button::new("reset-queue")
+                            .ghost()
+                            .small()
+                            .label("Reset")
+                            .tint(theme.muted_foreground)
+                            .disabled(!self.queue.read(cx).reordered())
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.queue.update(cx, |queue, cx| queue.reset(cx));
+                            })),
+                    )
+                    .child(
+                        Button::new("clear-queue")
+                            .ghost()
+                            .small()
+                            .label("Clear")
+                            .tint(theme.muted_foreground)
+                            .disabled(sections.upcoming == 0)
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.queue.update(cx, |queue, cx| queue.clear_upcoming(cx));
+                            })),
+                    ),
             )
     }
 

--- a/crates/workspace/src/queue_panel.rs
+++ b/crates/workspace/src/queue_panel.rs
@@ -10,7 +10,7 @@ use gpui::{
 };
 use spotify::Track;
 use state::{AppSettings, Playback, Queue, Sonora};
-use ui::{ActiveTheme as _, Card, Menu, MenuItem, Room, Scrollbar, eyebrow, snapped};
+use ui::{ActiveTheme as _, Button, Card, Menu, MenuItem, Room, Scrollbar, eyebrow, snapped};
 
 use crate::Sidebar;
 
@@ -451,6 +451,33 @@ impl QueuePanel {
         )
     }
 
+    fn header(&self, sections: Sections, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = *cx.theme();
+
+        div()
+            .flex()
+            .flex_none()
+            .items_center()
+            .justify_between()
+            .gap_2()
+            .h(theme.metrics.header)
+            .px_2()
+            .border_b_1()
+            .border_color(theme.border)
+            .child(eyebrow("QUEUE", cx))
+            .child(
+                Button::new("clear-queue")
+                    .ghost()
+                    .small()
+                    .label("Clear")
+                    .tint(theme.muted_foreground)
+                    .disabled(sections.upcoming == 0)
+                    .on_click(cx.listener(|this, _, _, cx| {
+                        this.queue.update(cx, |queue, cx| queue.clear_upcoming(cx));
+                    })),
+            )
+    }
+
     fn pin(&mut self, sections: Sections, window: &Window, cx: &Context<Self>) {
         let Some(index) = sections.current_index() else {
             self.anchor = false;
@@ -568,6 +595,7 @@ impl Render for QueuePanel {
             .when(!fullscreen, |this| {
                 this.flex_none().w(self.width).child(self.grip(cx))
             })
+            .child(self.header(sections, cx))
             .child(
                 div()
                     .flex()

--- a/crates/workspace/src/queue_panel.rs
+++ b/crates/workspace/src/queue_panel.rs
@@ -471,6 +471,20 @@ impl QueuePanel {
                     .items_center()
                     .gap_1()
                     .child(
+                        Button::new("toggle-radio")
+                            .ghost()
+                            .small()
+                            .icon("icons/radio.svg")
+                            .tint(match self.playback.read(cx).radio() {
+                                true => theme.primary,
+                                false => theme.muted_foreground,
+                            })
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.playback
+                                    .update(cx, |playback, cx| playback.toggle_radio(cx));
+                            })),
+                    )
+                    .child(
                         Button::new("reset-queue")
                             .ghost()
                             .small()


### PR DESCRIPTION
## What changed

- Add a queue panel header with radio, reset, and clear actions.
- Clear empties Up Next, leaving the current track and history untouched.
- Reset restores the queue to the order it started in, anchored at the current track.
- Continue with radio-generated tracks when the queue runs out and radio is on.

## Why

The queue could be reordered and drained but never repaired or emptied, and playback stopped dead at the end of a queue. Repeat already covered replaying a finite queue; radio covers the open-ended case.

## User impact

Users can clear Up Next without interrupting what is playing, undo drag-reordering and removals in one click, and keep listening past the end of a queue with related tracks.

## Notes

- Reset restores from the original list, so it also undoes removals and drops appended tracks.
- Repeat takes precedence over radio: `One` replays, `All` rewinds, radio fills only the `Off` case.
- Quick picks is unchanged and still radio-seeded via `play_radio`.

## Validation

- `cargo check --workspace`
- `cargo test --workspace` (adds a queue-ordering unit test)
- `cargo clippy --workspace`