### PR TITLE
fix: correct the volume taper and scrubber thumb alignment

### DIFF
--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -16,15 +16,13 @@ use crate::{AppSettings, Io, Session, SessionEvent, join};
 const POSITION_INTERVAL: Duration = Duration::from_millis(500);
 const SKIP_DEBOUNCE: Duration = Duration::from_millis(250);
 const KEY_COOLDOWN: Duration = Duration::from_secs(6);
-const TAPER_DB: f32 = 60.;
-const CEILING_DB: f32 = 9.;
+const TAPER_DB: f32 = 50.;
 
 fn gain(level: f32) -> f32 {
-    let level = level.clamp(0., 1.);
-    if level <= 0. {
-        return 0.;
+    match level.clamp(0., 1.) {
+        level if level <= 0. => 0.,
+        level => 10f32.powf(TAPER_DB * (level - 1.) / 20.),
     }
-    10f32.powf((CEILING_DB - TAPER_DB * (1. - level)) / 20.)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -601,5 +599,41 @@ impl Playback {
         log::error!("playback: {problem}");
         self.state = PlaybackState::Failed(problem);
         cx.notify();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::gain;
+
+    #[test]
+    fn never_amplifies_past_unity() {
+        assert_eq!(gain(1.), 1.);
+        for step in 0..=100 {
+            assert!(gain(step as f32 / 100.) <= 1.);
+        }
+    }
+
+    #[test]
+    fn silences_a_closed_slider() {
+        assert_eq!(gain(0.), 0.);
+        assert_eq!(gain(-1.), 0.);
+        assert_eq!(gain(2.), 1.);
+    }
+
+    #[test]
+    fn rises_with_the_slider() {
+        let mut last = gain(0.);
+        for step in 1..=100 {
+            let next = gain(step as f32 / 100.);
+            assert!(next > last, "gain fell at {step}");
+            last = next;
+        }
+    }
+
+    #[test]
+    fn halves_the_slider_to_the_taper_midpoint() {
+        let expected = 10f32.powf(-super::TAPER_DB / 40.);
+        assert!((gain(0.5) - expected).abs() < 1e-6);
     }
 }

--- a/crates/ui/src/scrubber.rs
+++ b/crates/ui/src/scrubber.rs
@@ -56,15 +56,17 @@ impl ScrubberState {
         };
         reach
             .contains(&position)
-            .then(|| self.fraction_at(position.x))
+            .then(|| self.fraction_at(position.x, pad))
     }
 
-    fn fraction_at(&self, x: Pixels) -> f32 {
+    fn fraction_at(&self, x: Pixels, pad: Pixels) -> f32 {
         let bounds = self.bounds.get();
-        if bounds.size.width <= px(0.) {
+        let pin = thumb(pad);
+        let travel = bounds.size.width - pin;
+        if travel <= px(0.) {
             return 0.;
         }
-        ((x - bounds.origin.x) / bounds.size.width).clamp(0., 1.)
+        ((x - bounds.origin.x - pin / 2.) / travel).clamp(0., 1.)
     }
 }
 
@@ -174,7 +176,7 @@ impl RenderOnce for Scrubber {
             let on_move = on_move.clone();
             move |event: &MouseDownEvent, window: &mut Window, cx: &mut App| {
                 if let Some(handler) = on_move.as_ref() {
-                    handler(&state.fraction_at(event.position.x), window, cx);
+                    handler(&state.fraction_at(event.position.x, pad), window, cx);
                 }
             }
         };
@@ -188,7 +190,7 @@ impl RenderOnce for Scrubber {
                     return;
                 }
                 if let Some(handler) = on_move.as_ref() {
-                    handler(&state.fraction_at(event.event.position.x), window, cx);
+                    handler(&state.fraction_at(event.event.position.x, pad), window, cx);
                 }
             }
         };
@@ -198,6 +200,10 @@ impl RenderOnce for Scrubber {
                 handler(event, window, cx);
             }
         };
+
+        let width = bounds.get().size.width;
+        let travel = (width - pin).max(Pixels::ZERO);
+        let centered = enabled && width > Pixels::ZERO;
 
         div()
             .id(gpui::ElementId::Name(id.clone()))
@@ -222,15 +228,15 @@ impl RenderOnce for Scrubber {
                     .bg(empty)
                     .child(
                         div()
-                            .w(relative(fraction))
                             .h_full()
                             .rounded_full()
-                            .bg(filled),
+                            .bg(filled)
+                            .map(|this| match centered {
+                                true => this.w(pin / 2. + travel * fraction),
+                                false => this.w(relative(fraction)),
+                            }),
                     )
                     .when(enabled, |this| {
-                        let width = bounds.get().size.width;
-                        let travel = (width - pin).max(Pixels::ZERO);
-
                         this.child(
                             div()
                                 .absolute()
@@ -257,7 +263,10 @@ impl RenderOnce for Scrubber {
                                         this.top(Pixels::ZERO - lift)
                                     }
                                 })
-                                .left(relative(at))
+                                .map(|this| match centered {
+                                    true => this.left(pin / 2. + travel * at),
+                                    false => this.left(relative(at)),
+                                })
                                 .ml(Pixels::ZERO - bubble_width / 2.)
                                 .w(bubble_width)
                                 .flex()
@@ -281,5 +290,56 @@ impl RenderOnce for Scrubber {
                             .size_full(),
                     ),
             )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gpui::{Bounds, point, px, size};
+
+    use super::{ScrubberState, thumb};
+
+    const PAD: gpui::Pixels = px(8.);
+    const ORIGIN: f32 = 20.;
+    const WIDTH: f32 = 300.;
+
+    fn measured() -> ScrubberState {
+        let state = ScrubberState::new("test");
+        state.bounds.set(Bounds {
+            origin: point(px(ORIGIN), px(0.)),
+            size: size(px(WIDTH), px(4.)),
+        });
+        state
+    }
+
+    #[test]
+    fn the_thumb_lands_under_the_pointer() {
+        let state = measured();
+        let pin = thumb(PAD);
+        let travel = px(WIDTH) - pin;
+
+        for step in 0..=100 {
+            let fraction = step as f32 / 100.;
+            let center = px(ORIGIN) + pin / 2. + travel * fraction;
+            let read = state.fraction_at(center, PAD);
+            assert!((read - fraction).abs() < 1e-4, "{fraction} read as {read}");
+        }
+    }
+
+    #[test]
+    fn the_ends_clamp() {
+        let state = measured();
+
+        assert_eq!(state.fraction_at(px(0.), PAD), 0.);
+        assert_eq!(state.fraction_at(px(ORIGIN), PAD), 0.);
+        assert_eq!(state.fraction_at(px(ORIGIN + WIDTH), PAD), 1.);
+        assert_eq!(state.fraction_at(px(9999.), PAD), 1.);
+    }
+
+    #[test]
+    fn an_unmeasured_track_reads_zero() {
+        let state = ScrubberState::new("test");
+
+        assert_eq!(state.fraction_at(px(50.), PAD), 0.);
     }
 }


### PR DESCRIPTION
## What changed

- Cap the volume taper at unity gain so the top of the slider no longer amplifies past 0 dB.
- Map the scrubber's pointer position onto the thumb's actual travel range instead of the full track width.
- Anchor the scrubber's fill and hover bubble to the thumb centre so all three agree.

## Why

The volume curve carried a `CEILING_DB = 9.` term, putting full slider at +9 dB (a gain of 2.82x).
The sink applies gain as a bare multiply with no limiter, so everything above 85% of the slider
clipped. Separately, the scrubber positioned its thumb over `width - thumb` of travel but derived
the pointer fraction from the full width; the two only agreed at the midpoint and drifted by up to
half a thumb width at the ends, so the pin never sat under the cursor.

## User impact

The volume slider now runs from silent to unity across its full length without distorting at the
top, and the seek and volume scrubbers track the pointer exactly — the thumb lands where you click
and stays under the cursor while dragging, at both ends of the bar.

## Notes

The volume taper is now 50 dB. That keeps the quiet end where it was (the old floor was -51 dB) while
bringing the ceiling down to unity, which makes mid-slider about 4 dB quieter than before. `TAPER_DB`
is the single knob if that balance needs adjusting.

## Validation

- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace`

Added four tests for the gain curve (unity ceiling, input clamping, monotonicity, taper midpoint) and
three for the scrubber (pointer/thumb round-trip across the range, end clamping, unmeasured track).
The audible result of the new taper and the on-screen thumb alignment were not verified by hand.
