### PR TITLE
refactor(playback): move shuffle into the queue

### DIFF
--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -65,7 +65,6 @@ pub struct Playback {
     settings: Entity<AppSettings>,
     level: f32,
     normalisation: bool,
-    shuffle: bool,
     repeat: Repeat,
     radio: bool,
     task: Option<Task<()>>,
@@ -108,7 +107,6 @@ impl Playback {
             settings,
             level,
             normalisation,
-            shuffle: false,
             repeat: Repeat::Off,
             radio: false,
             task: None,
@@ -283,15 +281,6 @@ impl Playback {
         cx.notify();
     }
 
-    pub fn shuffle(&self) -> bool {
-        self.shuffle
-    }
-
-    pub fn toggle_shuffle(&mut self, cx: &mut Context<Self>) {
-        self.shuffle = !self.shuffle;
-        cx.notify();
-    }
-
     pub fn repeat(&self) -> Repeat {
         self.repeat
     }
@@ -360,11 +349,7 @@ impl Playback {
     }
 
     fn follow_queue(&mut self, cx: &mut Context<Self>) {
-        let shuffle = self.shuffle;
-        let Some(track) = self.queue.update(cx, |queue, cx| match shuffle {
-            true => queue.next_random(cx),
-            false => queue.next(cx),
-        }) else {
+        let Some(track) = self.queue.update(cx, |queue, cx| queue.next(cx)) else {
             return;
         };
         self.load_after(&track, SKIP_DEBOUNCE, cx);

--- a/crates/state/src/queue.rs
+++ b/crates/state/src/queue.rs
@@ -1,7 +1,38 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 
 use gpui::Context;
 use spotify::Track;
+
+fn scramble(upcoming: &mut VecDeque<Track>) {
+    let mut tracks: Vec<Track> = upcoming.drain(..).collect();
+    fastrand::shuffle(&mut tracks);
+    *upcoming = tracks.into();
+}
+
+fn restore(upcoming: &mut VecDeque<Track>, source: &[Track]) {
+    let mut slots: HashMap<&str, VecDeque<usize>> = HashMap::new();
+    for (index, track) in source.iter().enumerate() {
+        if let Some(id) = track.id.as_deref() {
+            slots.entry(id).or_default().push_back(index);
+        }
+    }
+
+    let mut ranked: Vec<(usize, Track)> = upcoming
+        .drain(..)
+        .map(|track| {
+            let rank = track
+                .id
+                .as_deref()
+                .and_then(|id| slots.get_mut(id))
+                .and_then(|found| found.pop_front())
+                .unwrap_or(usize::MAX);
+            (rank, track)
+        })
+        .collect();
+
+    ranked.sort_by_key(|(rank, _)| *rank);
+    *upcoming = ranked.into_iter().map(|(_, track)| track).collect();
+}
 
 fn move_item<T>(items: &mut VecDeque<T>, from: usize, to: usize) -> bool {
     if from >= items.len() || to >= items.len() || from == to {
@@ -63,6 +94,7 @@ pub struct Queue {
     current: Option<Track>,
     upcoming: VecDeque<Track>,
     source: Vec<Track>,
+    shuffle: bool,
     revision: u64,
 }
 
@@ -79,8 +111,29 @@ impl Queue {
             current: None,
             upcoming: VecDeque::new(),
             source: Vec::new(),
+            shuffle: false,
             revision: 0,
         }
+    }
+
+    pub fn shuffle(&self) -> bool {
+        self.shuffle
+    }
+
+    pub fn set_shuffle(&mut self, on: bool, cx: &mut Context<Self>) {
+        if self.shuffle == on {
+            return;
+        }
+        self.shuffle = on;
+        match on {
+            true => scramble(&mut self.upcoming),
+            false => restore(&mut self.upcoming, &self.source),
+        }
+        self.changed(cx);
+    }
+
+    pub fn toggle_shuffle(&mut self, cx: &mut Context<Self>) {
+        self.set_shuffle(!self.shuffle, cx);
     }
 
     fn changed(&mut self, cx: &mut Context<Self>) {
@@ -173,6 +226,9 @@ impl Queue {
         self.source = tracks.clone();
         let mut past = tracks;
         self.upcoming = past.split_off(index + 1).into();
+        if self.shuffle {
+            scramble(&mut self.upcoming);
+        }
         self.current = past.pop();
         self.past = past;
         self.changed(cx);
@@ -203,21 +259,6 @@ impl Queue {
 
     pub fn next(&mut self, cx: &mut Context<Self>) -> Option<Track> {
         let next = self.upcoming.pop_front()?;
-        if let Some(played) = self.current.replace(next) {
-            self.past.push(played);
-        }
-        self.changed(cx);
-        self.current.clone()
-    }
-
-    pub fn next_random(&mut self, cx: &mut Context<Self>) -> Option<Track> {
-        if self.upcoming.is_empty() {
-            return None;
-        }
-
-        let next = self
-            .upcoming
-            .remove(fastrand::usize(..self.upcoming.len()))?;
         if let Some(played) = self.current.replace(next) {
             self.past.push(played);
         }
@@ -261,8 +302,95 @@ impl Queue {
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
+    use std::time::Duration;
 
-    use super::{gap_target, in_order, move_item, select_past, select_upcoming};
+    use spotify::Track;
+
+    use super::{gap_target, in_order, move_item, restore, scramble, select_past, select_upcoming};
+
+    fn track(id: &str) -> Track {
+        Track {
+            id: Some(id.to_owned()),
+            name: id.to_owned(),
+            playable: true,
+            artists: String::new(),
+            artist_refs: Vec::new(),
+            album: String::new(),
+            album_id: None,
+            cover: None,
+            duration: Duration::from_secs(180),
+            added_at: None,
+            playcount: None,
+            popularity: 0,
+            explicit: false,
+            track_number: 0,
+            disc_number: 0,
+            tags: Vec::new(),
+            languages: Vec::new(),
+            credits: Vec::new(),
+        }
+    }
+
+    fn ids(tracks: &VecDeque<Track>) -> Vec<String> {
+        tracks
+            .iter()
+            .map(|track| track.name.clone())
+            .collect::<Vec<_>>()
+    }
+
+    fn listing(count: usize) -> Vec<Track> {
+        (0..count).map(|index| track(&index.to_string())).collect()
+    }
+
+    #[test]
+    fn scrambling_keeps_every_track() {
+        let source = listing(20);
+        let mut upcoming: VecDeque<Track> = source.iter().cloned().collect();
+
+        scramble(&mut upcoming);
+
+        let mut seen = ids(&upcoming);
+        let mut expected = ids(&source.iter().cloned().collect());
+        seen.sort();
+        expected.sort();
+        assert_eq!(seen, expected);
+    }
+
+    #[test]
+    fn restoring_returns_the_source_order() {
+        let source = listing(20);
+        let mut upcoming: VecDeque<Track> = source.iter().cloned().collect();
+
+        scramble(&mut upcoming);
+        restore(&mut upcoming, &source);
+
+        assert_eq!(ids(&upcoming), ids(&source.iter().cloned().collect()));
+    }
+
+    #[test]
+    fn restoring_puts_unknown_tracks_last() {
+        let source = vec![track("a"), track("b"), track("c")];
+        let mut upcoming = VecDeque::from(vec![
+            track("queued-one"),
+            track("c"),
+            track("queued-two"),
+            track("a"),
+        ]);
+
+        restore(&mut upcoming, &source);
+
+        assert_eq!(ids(&upcoming), ["a", "c", "queued-one", "queued-two"]);
+    }
+
+    #[test]
+    fn restoring_keeps_both_copies_of_a_repeated_track() {
+        let source = vec![track("a"), track("b"), track("a")];
+        let mut upcoming = VecDeque::from(vec![track("a"), track("a"), track("b")]);
+
+        restore(&mut upcoming, &source);
+
+        assert_eq!(ids(&upcoming), ["a", "b", "a"]);
+    }
 
     #[test]
     fn spots_a_reordered_queue() {

--- a/crates/workspace/src/player_bar.rs
+++ b/crates/workspace/src/player_bar.rs
@@ -102,7 +102,7 @@ impl PlayerBar {
 
     fn shuffle(&self, cx: &mut Context<Self>) -> Button {
         let theme = *cx.theme();
-        let on = self.playback.read(cx).shuffle();
+        let on = self.queue.read(cx).shuffle();
 
         Button::new("shuffle")
             .ghost()
@@ -113,8 +113,7 @@ impl PlayerBar {
                 false => theme.muted_foreground,
             })
             .on_click(cx.listener(|this, _, _, cx| {
-                this.playback
-                    .update(cx, |playback, cx| playback.toggle_shuffle(cx));
+                this.queue.update(cx, |queue, cx| queue.toggle_shuffle(cx));
             }))
     }
 


### PR DESCRIPTION
## What changed

- Move the shuffle flag and its behaviour from `Playback` into `Queue`.
- Permute `upcoming` when shuffle is enabled and restore source order when it is disabled, instead of picking a random track at each advance.
- Apply the shuffle mode to a freshly started queue so the first advance is already shuffled.
- Drop `Queue::next_random`, `Playback::shuffle` and `Playback::toggle_shuffle`; advancing is now always `Queue::next`.

## Why

Shuffle is a property of queue ordering, and `Queue` already owns the original `source`, `reordered()`
and `reset()`. Holding the flag in `Playback` meant the queue could not reason about its own order, so
shuffle was implemented as a random pick at advance time: the queue panel listed tracks in their
original order while playback jumped somewhere else, and toggling the button never notified the queue
so the panel did not even re-render.

## User impact

The queue panel now shows the real upcoming order under shuffle, turning shuffle off puts the
remaining tracks back into their original order, and enabling shuffle before starting an album or
playlist takes effect from the first advance rather than the second.

## Notes

Restoring order is a stable sort by position in `source`, keyed on track id, so manually queued and
radio-appended tracks settle at the end in their existing relative order and repeated tracks keep
every copy.

Two deliberate consequences: `reset()` goes through `start()`, so pressing Reset while shuffle is on
reshuffles from the full source rather than forcing source order; and `reordered()` compares against
`source`, so it reports true whenever shuffle is on, leaving the Reset button enabled throughout.

The two `fastrand::shuffle` calls left in `playback.rs` scramble fetched radio candidates before they
are queued and are unrelated to the toggle.

## Validation

- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace`

Four new tests cover scrambling preserving the track set, restore round-tripping after a scramble,
unknown tracks sorting last, and repeated tracks keeping both copies. The app was not run, so the
on-screen behaviour of the queue panel under shuffle is unverified.
