### PR TITLE
feat(i18n): localize the interface with fluent and add ru, uk and pl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ crates/
   ui/         design system: theme, metrics, and reusable elements (gpui only)
   router/     Destination enum, navigation history, Link trait
   input/      text input element + global actions and keybindings
+  i18n/       Fluent localization: the `t!` macro, locale selection, embedded .ftl
 ```
 
 Dependency direction is strict; do not create a back edge:
@@ -37,12 +38,16 @@ Dependency direction is strict; do not create a back edge:
 sonora → views → workspace → state → spotify
                                    → audio
          all ui-side crates → ui, router, input → ui → gpui
+         every ui-side crate → i18n → gpui
 ```
 
-- `ui` depends only on `gpui` + `serde`. It must never know about `spotify`, `state`, or playback.
+- `ui` depends only on `gpui`, `serde` and `i18n`. It must never know about `spotify`, `state`, or
+  playback.
 - `spotify` and `audio` must never depend on `gpui`. They are plain async Rust.
 - `state` depends on `ui` only for `ThemeOverrides`, `MIN_FONT`, `MAX_FONT` (settings persistence).
 - Widgets that need app state (player bar, sidebar) live in `workspace`, not `ui`.
+- `i18n` is a leaf: it depends on `fluent-bundle`, `unic-langid`, `sys-locale` and `gpui` (for
+  `SharedString`) and on nothing else in the workspace.
 
 ## Building
 
@@ -223,6 +228,35 @@ theme.metrics.row / .header / .pad / .inset / .control / .field
 - Eight themes exist (`ThemeKind::ALL`). `ocean`/`rose`/`lavender`/`amber` are derived by mutating
   `midnight()`/`dark()`; follow that pattern rather than writing a full palette.
 - Users can override any token via `settings.json`; `Theme::set` re-renders all windows.
+
+## Localization
+
+Every user-facing string comes from Fluent. **Never render a bare English literal**; add a key to
+`assets/i18n/en-US/main.ftl` and translate it in `ru`, `uk` and `pl` — a test in `crates/i18n`
+fails if the key sets diverge.
+
+```rust
+use i18n::t;
+
+t!("song-credits")                                   // -> SharedString
+t!("song-disc-track", disc = disc, track = number)   // named args, any number or &str
+i18n::lookup(key, None)                              // when the key is a runtime &str
+```
+
+- The `.ftl` files are embedded with `include_str!` in `crates/i18n/src/language.rs`, so they do
+  **not** go through `crates/sonora/src/assets.rs`.
+- Keys are scoped by area: `nav-`, `column-`, `menu-`, `queue-`, `player-`, `search-`, `song-`,
+  `settings-`, `theme-`, `common-`. Values stay natural case — `ui::eyebrow()` / `ui::upper()`
+  do the shouting.
+- Counts use Fluent selectors (`{ $count -> [one] … [few] … *[other] … }`), never string
+  concatenation; ru/uk/pl need `one`/`few`/`other` to be right.
+- Dates are assembled from `month-1`..`month-12` plus `date-full`, never `strftime`.
+- A missing key logs `i18n: … is missing` and falls back to English, then to the key itself.
+- `ColumnSpec::header` and `Slot::Header` hold a **key**, not a label; call `ColumnSpec::label()`.
+- Developer-facing text — `.context("cannot …")`, `log::warn!`, `PlaybackState::Failed` — stays
+  in English. So do wire values in `crates/spotify`.
+- The language lives in `settings.json` (`language`, default `"auto"`). Changing it calls
+  `i18n::set` then `cx.refresh_windows()`, the same way `Theme::set` repaints.
 
 ## Breakpoints and content width
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,7 +1857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1990,6 +1990,41 @@ name = "float_next_after"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+
+[[package]]
+name = "fluent-bundle"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01203cb8918f5711e73891b347816d932046f95f54207710bda99beaeb423bf4"
+dependencies = [
+ "fluent-langneg",
+ "fluent-syntax",
+ "intl-memoizer",
+ "intl_pluralrules",
+ "rustc-hash 2.1.3",
+ "self_cell",
+ "smallvec",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-langneg"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.19",
+]
 
 [[package]]
 name = "flume"
@@ -2374,7 +2409,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.19",
- "windows 0.54.0",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -3056,6 +3091,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "i18n"
+version = "0.1.0"
+dependencies = [
+ "fluent-bundle",
+ "gpui",
+ "log",
+ "sys-locale",
+ "unic-langid",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3272,6 +3318,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "intl-memoizer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f"
+dependencies = [
+ "type-map",
+ "unic-langid",
+]
+
+[[package]]
+name = "intl_pluralrules"
+version = "7.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
+dependencies = [
+ "unic-langid",
 ]
 
 [[package]]
@@ -5078,6 +5143,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5302,7 +5373,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5813,7 +5884,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5826,7 +5897,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6431,6 +6502,7 @@ dependencies = [
  "env_logger",
  "gpui",
  "gpui_platform",
+ "i18n",
  "input",
  "log",
  "reqwest",
@@ -6556,6 +6628,7 @@ dependencies = [
  "dirs",
  "fastrand",
  "gpui",
+ "i18n",
  "librespot-core",
  "log",
  "serde",
@@ -6973,7 +7046,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7122,6 +7195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -7458,6 +7532,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash 2.1.3",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7485,8 +7568,52 @@ name = "ui"
 version = "0.1.0"
 dependencies = [
  "gpui",
+ "i18n",
  "image",
  "serde",
+]
+
+[[package]]
+name = "unic-langid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
+dependencies = [
+ "unic-langid-impl",
+ "unic-langid-macros",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
+dependencies = [
+ "tinystr",
+]
+
+[[package]]
+name = "unic-langid-macros"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5957eb82e346d7add14182a3315a7e298f04e1ba4baac36f7f0dbfedba5fc25"
+dependencies = [
+ "proc-macro-hack",
+ "tinystr",
+ "unic-langid-impl",
+ "unic-langid-macros-impl",
+]
+
+[[package]]
+name = "unic-langid-macros-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1249a628de3ad34b821ecb1001355bca3940bcb2f88558f1a8bd82e977f75b5"
+dependencies = [
+ "proc-macro-hack",
+ "quote",
+ "syn 2.0.119",
+ "unic-langid-impl",
 ]
 
 [[package]]
@@ -7744,6 +7871,7 @@ name = "views"
 version = "0.1.0"
 dependencies = [
  "gpui",
+ "i18n",
  "input",
  "jiff",
  "router",
@@ -8246,7 +8374,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8727,6 +8855,7 @@ name = "workspace"
 version = "0.1.0"
 dependencies = [
  "gpui",
+ "i18n",
  "input",
  "router",
  "spotify",
@@ -9129,6 +9258,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 
 [workspace.dependencies]
 audio = { path = "crates/audio" }
+i18n = { path = "crates/i18n" }
 spotify = { path = "crates/spotify" }
 state = { path = "crates/state" }
 input = { path = "crates/input" }
@@ -23,6 +24,7 @@ cpal = "0.16"
 dirs = "6.0"
 env_logger = "0.11"
 fastrand = "2.5"
+fluent-bundle = "0.16"
 gpui = { git = "https://github.com/zed-industries/zed", rev = "f25b256f2c10e1b638031a3d8d5a524056ebf268" }
 gpui_platform = { git = "https://github.com/zed-industries/zed", rev = "f25b256f2c10e1b638031a3d8d5a524056ebf268", features = [
   "font-kit",
@@ -39,6 +41,8 @@ reqwest = { version = "0.12", default-features = false, features = [
 rodio = { version = "0.21", default-features = false, features = ["playback"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sys-locale = "0.3"
+unic-langid = { version = "0.9", features = ["macros"] }
 
 librespot-core = { version = "0.8.0", default-features = false, features = [
   "rustls-tls-native-roots",

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -1,0 +1,235 @@
+# common
+common-on = On
+common-off = Off
+common-left = Left
+common-right = Right
+common-search = Search
+common-unknown = Unknown
+common-not-provided = Not provided
+common-not-available = Not available
+number-group = { "," }
+
+# navigation
+nav-home = Home
+nav-search = Search
+nav-library = Your Library
+nav-settings = Settings
+nav-songs = Songs
+nav-albums = Albums
+nav-playlists = Playlists
+
+# app menu
+app-refresh-library = Refresh Library
+app-sign-out = Sign Out
+app-quit = Quit
+
+# table columns
+column-index = #
+column-title = Title
+column-artist = Artist
+column-album = Album
+column-date-added = Date added
+column-length = Length
+column-plays = Plays
+column-name = Name
+column-owner = Owner
+column-year = Year
+column-tracks = Tracks
+
+# track menu
+menu-add-to-playlist = Add to playlist
+menu-new-playlist = New playlist
+menu-no-playlists = No playlists
+menu-toggle-library = Add or remove from Library
+menu-add-to-queue = Add to queue
+menu-song-radio = Go to song radio
+menu-view-details = View details
+menu-copy-link = Copy link
+menu-remove-from-queue = Remove from queue
+
+# queue panel
+queue-title = Queue
+queue-history = History
+queue-now-playing = Now playing
+queue-up-next = Up next
+queue-reset = Reset
+queue-clear = Clear
+queue-empty = Your queue is empty
+
+# player bar
+player-nothing-playing = Nothing playing
+player-percent = { $value }%
+
+# filters
+filter-library = Filter your library
+filter-album = Filter album tracks
+
+# login
+login-signed-out = Sign in to load your Spotify library
+login-restoring = Checking your saved session…
+login-authorizing = Waiting for authorization in your browser…
+login-signed-in = Signed in as { $name }
+login-sign-in = Sign in with Spotify
+
+# album and playlist pages
+detail-album = Album
+detail-playlist = Playlist
+detail-play-album = Play album
+detail-play-playlist = Play playlist
+
+# play button
+play-pause = Pause
+play-resume = Resume
+play-loading = Loading…
+
+# artist page
+artist-eyebrow = Artist
+artist-play = Play now
+artist-popular = Popular
+artist-releases = Releases
+artist-filter-all = All
+artist-filter-albums = Albums
+artist-filter-singles = Singles
+artist-filter-eps = EPs
+
+# release kinds
+release-album = Album
+release-single = Single
+release-compilation = Compilation
+release-ep = EP
+release-audiobook = Audiobook
+release-podcast = Podcast
+release-meta = { $year } • { $kind }
+
+# home page
+home-quick-picks = Quick picks
+home-quick-picks-eyebrow = Start from a song
+
+# search page
+search-placeholder = What do you want to listen to?
+search-best-match = Best match
+search-no-matches = No matches
+search-results = Results
+search-songs = Songs
+search-artists = Artists
+search-albums = Albums
+search-tagged = { $kind } · { $value }
+search-saved =
+    { $count ->
+        [one] { $count } song in Library
+       *[other] { $count } songs in Library
+    }
+kind-song = Song
+kind-artist = Artist
+kind-album = Album
+
+# song page
+song-eyebrow = Song
+song-play = Play song
+song-view-album = View album
+song-loading = Loading song information…
+song-about = About this song
+song-album = Album
+song-released = Released
+song-streams = Streams
+song-position = Position
+song-label = Label
+song-popularity = Popularity
+song-popularity-value = { $value }%
+song-disc-track = Disc { $disc }, track { $track }
+song-track = Track { $track }
+song-credits = Credits
+song-performed-by = Performed by
+song-details = Genres & details
+song-genres = Genres
+song-language = Language
+song-content = Content
+song-explicit = Explicit
+song-clean = Clean
+song-about-artist = About the artist
+song-artist-fallback = Explore the artist's popular songs and releases.
+song-copyright = © { $notice }
+
+# song languages
+language-ar = Arabic
+language-de = German
+language-en = English
+language-es = Spanish
+language-fr = French
+language-hi = Hindi
+language-it = Italian
+language-ja = Japanese
+language-ko = Korean
+language-pt = Portuguese
+language-ru = Russian
+language-tr = Turkish
+language-uk = Ukrainian
+language-zh = Chinese
+language-zxx = No linguistic content
+
+# counts
+count-songs =
+    { $count ->
+        [one] { $count } song
+       *[other] { $count } songs
+    }
+
+# dates
+date-full = { $month } { $day }, { $year }
+month-1 = Jan
+month-2 = Feb
+month-3 = Mar
+month-4 = Apr
+month-5 = May
+month-6 = Jun
+month-7 = Jul
+month-8 = Aug
+month-9 = Sep
+month-10 = Oct
+month-11 = Nov
+month-12 = Dec
+
+# settings
+settings-tab-appearance = Appearance
+settings-tab-playback = Playback
+settings-tab-account = Account
+settings-theme = Theme
+settings-theme-detail = Choose the application colour palette
+settings-theme-config = Open config
+settings-adaptive = Adaptive theme
+settings-adaptive-detail = Tint the palette with the artwork of the playing album
+settings-corners = Corners
+settings-corners-detail = How rounded surfaces and controls are
+settings-font = Font size
+settings-font-detail = Base text size, everything else scales with it
+settings-font-value = { $size } px
+settings-language = Language
+settings-language-detail = The language sonora uses across the interface
+settings-language-system = System
+settings-auto-hide = Auto-hide sidebar
+settings-auto-hide-detail = Collapse the sidebar when the window gets narrow
+settings-window-controls = Window controls
+settings-window-controls-detail = Draw minimise, maximise and close in the title bar
+settings-controls-side = Controls side
+settings-controls-side-detail = Which end of the title bar the controls sit on
+settings-normalisation = Normalise loudness
+settings-normalisation-detail = Keeps tracks at a consistent volume
+settings-account = Account
+settings-account-detail = Sign out of Spotify on this device
+settings-sign-out = Sign out
+
+# themes
+theme-dark = Dark
+theme-light = Light
+theme-midnight = Midnight
+theme-forest = Forest
+theme-ocean = Ocean
+theme-rose = Rose
+theme-lavender = Lavender
+theme-amber = Amber
+
+# corners
+corners-square = Square
+corners-subtle = Subtle
+corners-rounded = Rounded
+corners-round = Round

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -1,0 +1,237 @@
+# common
+common-on = Wł.
+common-off = Wył.
+common-left = Po lewej
+common-right = Po prawej
+common-search = Szukaj
+common-unknown = Nieznane
+common-not-provided = Nie podano
+common-not-available = Brak danych
+number-group = { "\u00A0" }
+
+# navigation
+nav-home = Strona główna
+nav-search = Szukaj
+nav-library = Twoja biblioteka
+nav-settings = Ustawienia
+nav-songs = Utwory
+nav-albums = Albumy
+nav-playlists = Playlisty
+
+# app menu
+app-refresh-library = Odśwież bibliotekę
+app-sign-out = Wyloguj się
+app-quit = Zakończ
+
+# table columns
+column-index = #
+column-title = Tytuł
+column-artist = Wykonawca
+column-album = Album
+column-date-added = Data dodania
+column-length = Czas
+column-plays = Odtworzenia
+column-name = Nazwa
+column-owner = Właściciel
+column-year = Rok
+column-tracks = Utwory
+
+# track menu
+menu-add-to-playlist = Dodaj do playlisty
+menu-new-playlist = Nowa playlista
+menu-no-playlists = Brak playlist
+menu-toggle-library = Dodaj lub usuń z biblioteki
+menu-add-to-queue = Dodaj do kolejki
+menu-song-radio = Radio utworu
+menu-view-details = Szczegóły
+menu-copy-link = Kopiuj link
+menu-remove-from-queue = Usuń z kolejki
+
+# queue panel
+queue-title = Kolejka
+queue-history = Historia
+queue-now-playing = Teraz odtwarzane
+queue-up-next = Następne
+queue-reset = Resetuj
+queue-clear = Wyczyść
+queue-empty = Twoja kolejka jest pusta
+
+# player bar
+player-nothing-playing = Nic nie jest odtwarzane
+player-percent = { $value }%
+
+# filters
+filter-library = Filtruj bibliotekę
+filter-album = Filtruj utwory albumu
+
+# login
+login-signed-out = Zaloguj się, aby wczytać bibliotekę Spotify
+login-restoring = Sprawdzanie zapisanej sesji…
+login-authorizing = Oczekiwanie na autoryzację w przeglądarce…
+login-signed-in = Zalogowano jako { $name }
+login-sign-in = Zaloguj się przez Spotify
+
+# album and playlist pages
+detail-album = Album
+detail-playlist = Playlista
+detail-play-album = Odtwórz album
+detail-play-playlist = Odtwórz playlistę
+
+# play button
+play-pause = Wstrzymaj
+play-resume = Wznów
+play-loading = Ładowanie…
+
+# artist page
+artist-eyebrow = Wykonawca
+artist-play = Odtwórz
+artist-popular = Popularne
+artist-releases = Wydawnictwa
+artist-filter-all = Wszystkie
+artist-filter-albums = Albumy
+artist-filter-singles = Single
+artist-filter-eps = EP
+
+# release kinds
+release-album = Album
+release-single = Singiel
+release-compilation = Kompilacja
+release-ep = EP
+release-audiobook = Audiobook
+release-podcast = Podcast
+release-meta = { $year } • { $kind }
+
+# home page
+home-quick-picks = Szybki wybór
+home-quick-picks-eyebrow = Zacznij od utworu
+
+# search page
+search-placeholder = Czego chcesz posłuchać?
+search-best-match = Najlepszy wynik
+search-no-matches = Brak wyników
+search-results = Wyniki
+search-songs = Utwory
+search-artists = Wykonawcy
+search-albums = Albumy
+search-tagged = { $kind } · { $value }
+search-saved =
+    { $count ->
+        [one] { $count } utwór w bibliotece
+        [few] { $count } utwory w bibliotece
+       *[other] { $count } utworów w bibliotece
+    }
+kind-song = Utwór
+kind-artist = Wykonawca
+kind-album = Album
+
+# song page
+song-eyebrow = Utwór
+song-play = Odtwórz utwór
+song-view-album = Zobacz album
+song-loading = Wczytywanie informacji o utworze…
+song-about = O utworze
+song-album = Album
+song-released = Data wydania
+song-streams = Odtworzenia
+song-position = Pozycja
+song-label = Wytwórnia
+song-popularity = Popularność
+song-popularity-value = { $value }%
+song-disc-track = Płyta { $disc }, utwór { $track }
+song-track = Utwór { $track }
+song-credits = Twórcy
+song-performed-by = Wykonanie
+song-details = Gatunki i szczegóły
+song-genres = Gatunki
+song-language = Język
+song-content = Treść
+song-explicit = Wulgaryzmy
+song-clean = Bez wulgaryzmów
+song-about-artist = O wykonawcy
+song-artist-fallback = Poznaj popularne utwory i wydawnictwa tego wykonawcy.
+song-copyright = © { $notice }
+
+# song languages
+language-ar = Arabski
+language-de = Niemiecki
+language-en = Angielski
+language-es = Hiszpański
+language-fr = Francuski
+language-hi = Hindi
+language-it = Włoski
+language-ja = Japoński
+language-ko = Koreański
+language-pt = Portugalski
+language-ru = Rosyjski
+language-tr = Turecki
+language-uk = Ukraiński
+language-zh = Chiński
+language-zxx = Bez treści językowej
+
+# counts
+count-songs =
+    { $count ->
+        [one] { $count } utwór
+        [few] { $count } utwory
+       *[other] { $count } utworów
+    }
+
+# dates
+date-full = { $day } { $month } { $year }
+month-1 = sty
+month-2 = lut
+month-3 = mar
+month-4 = kwi
+month-5 = maj
+month-6 = cze
+month-7 = lip
+month-8 = sie
+month-9 = wrz
+month-10 = paź
+month-11 = lis
+month-12 = gru
+
+# settings
+settings-tab-appearance = Wygląd
+settings-tab-playback = Odtwarzanie
+settings-tab-account = Konto
+settings-theme = Motyw
+settings-theme-detail = Paleta kolorów aplikacji
+settings-theme-config = Otwórz konfigurację
+settings-adaptive = Motyw adaptacyjny
+settings-adaptive-detail = Zabarw paletę okładką odtwarzanego albumu
+settings-corners = Narożniki
+settings-corners-detail = Jak bardzo zaokrąglone są powierzchnie i kontrolki
+settings-font = Rozmiar czcionki
+settings-font-detail = Bazowy rozmiar tekstu, reszta skaluje się razem z nim
+settings-font-value = { $size } px
+settings-language = Język
+settings-language-detail = Język interfejsu sonora
+settings-language-system = Systemowy
+settings-auto-hide = Automatyczne ukrywanie panelu
+settings-auto-hide-detail = Zwijaj panel boczny, gdy okno staje się wąskie
+settings-window-controls = Przyciski okna
+settings-window-controls-detail = Rysuj minimalizację, maksymalizację i zamknięcie na pasku tytułu
+settings-controls-side = Strona przycisków
+settings-controls-side-detail = Po której stronie paska tytułu znajdują się przyciski
+settings-normalisation = Normalizacja głośności
+settings-normalisation-detail = Utrzymuje stałą głośność utworów
+settings-account = Konto
+settings-account-detail = Wyloguj się ze Spotify na tym urządzeniu
+settings-sign-out = Wyloguj się
+
+# themes
+theme-dark = Ciemny
+theme-light = Jasny
+theme-midnight = Północ
+theme-forest = Las
+theme-ocean = Ocean
+theme-rose = Róża
+theme-lavender = Lawenda
+theme-amber = Bursztyn
+
+# corners
+corners-square = Proste
+corners-subtle = Subtelne
+corners-rounded = Zaokrąglone
+corners-round = Okrągłe

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -1,0 +1,237 @@
+# common
+common-on = Вкл.
+common-off = Выкл.
+common-left = Слева
+common-right = Справа
+common-search = Поиск
+common-unknown = Неизвестно
+common-not-provided = Не указано
+common-not-available = Нет данных
+number-group = { "\u00A0" }
+
+# navigation
+nav-home = Главная
+nav-search = Поиск
+nav-library = Моя медиатека
+nav-settings = Настройки
+nav-songs = Треки
+nav-albums = Альбомы
+nav-playlists = Плейлисты
+
+# app menu
+app-refresh-library = Обновить медиатеку
+app-sign-out = Выйти
+app-quit = Выход
+
+# table columns
+column-index = #
+column-title = Название
+column-artist = Исполнитель
+column-album = Альбом
+column-date-added = Дата добавления
+column-length = Длительность
+column-plays = Прослушивания
+column-name = Название
+column-owner = Владелец
+column-year = Год
+column-tracks = Треки
+
+# track menu
+menu-add-to-playlist = Добавить в плейлист
+menu-new-playlist = Новый плейлист
+menu-no-playlists = Нет плейлистов
+menu-toggle-library = Добавить или удалить из медиатеки
+menu-add-to-queue = Добавить в очередь
+menu-song-radio = Радио по треку
+menu-view-details = Подробнее
+menu-copy-link = Копировать ссылку
+menu-remove-from-queue = Убрать из очереди
+
+# queue panel
+queue-title = Очередь
+queue-history = История
+queue-now-playing = Сейчас играет
+queue-up-next = Далее
+queue-reset = Сбросить
+queue-clear = Очистить
+queue-empty = Очередь пуста
+
+# player bar
+player-nothing-playing = Ничего не играет
+player-percent = { $value }%
+
+# filters
+filter-library = Фильтр медиатеки
+filter-album = Фильтр треков альбома
+
+# login
+login-signed-out = Войдите, чтобы загрузить медиатеку Spotify
+login-restoring = Проверяем сохранённую сессию…
+login-authorizing = Ожидаем авторизацию в браузере…
+login-signed-in = Вы вошли как { $name }
+login-sign-in = Войти через Spotify
+
+# album and playlist pages
+detail-album = Альбом
+detail-playlist = Плейлист
+detail-play-album = Слушать альбом
+detail-play-playlist = Слушать плейлист
+
+# play button
+play-pause = Пауза
+play-resume = Продолжить
+play-loading = Загрузка…
+
+# artist page
+artist-eyebrow = Исполнитель
+artist-play = Слушать
+artist-popular = Популярное
+artist-releases = Релизы
+artist-filter-all = Все
+artist-filter-albums = Альбомы
+artist-filter-singles = Синглы
+artist-filter-eps = EP
+
+# release kinds
+release-album = Альбом
+release-single = Сингл
+release-compilation = Сборник
+release-ep = EP
+release-audiobook = Аудиокнига
+release-podcast = Подкаст
+release-meta = { $year } • { $kind }
+
+# home page
+home-quick-picks = Быстрый выбор
+home-quick-picks-eyebrow = Начните с трека
+
+# search page
+search-placeholder = Что хотите послушать?
+search-best-match = Лучшее совпадение
+search-no-matches = Ничего не найдено
+search-results = Результаты
+search-songs = Треки
+search-artists = Исполнители
+search-albums = Альбомы
+search-tagged = { $kind } · { $value }
+search-saved =
+    { $count ->
+        [one] { $count } трек в медиатеке
+        [few] { $count } трека в медиатеке
+       *[other] { $count } треков в медиатеке
+    }
+kind-song = Трек
+kind-artist = Исполнитель
+kind-album = Альбом
+
+# song page
+song-eyebrow = Трек
+song-play = Слушать трек
+song-view-album = Открыть альбом
+song-loading = Загружаем информацию о треке…
+song-about = О треке
+song-album = Альбом
+song-released = Дата выхода
+song-streams = Прослушивания
+song-position = Позиция
+song-label = Лейбл
+song-popularity = Популярность
+song-popularity-value = { $value }%
+song-disc-track = Диск { $disc }, трек { $track }
+song-track = Трек { $track }
+song-credits = Авторы
+song-performed-by = Исполнение
+song-details = Жанры и детали
+song-genres = Жанры
+song-language = Язык
+song-content = Контент
+song-explicit = Ненормативная лексика
+song-clean = Без ограничений
+song-about-artist = Об исполнителе
+song-artist-fallback = Послушайте популярные треки и релизы исполнителя.
+song-copyright = © { $notice }
+
+# song languages
+language-ar = Арабский
+language-de = Немецкий
+language-en = Английский
+language-es = Испанский
+language-fr = Французский
+language-hi = Хинди
+language-it = Итальянский
+language-ja = Японский
+language-ko = Корейский
+language-pt = Португальский
+language-ru = Русский
+language-tr = Турецкий
+language-uk = Украинский
+language-zh = Китайский
+language-zxx = Без слов
+
+# counts
+count-songs =
+    { $count ->
+        [one] { $count } трек
+        [few] { $count } трека
+       *[other] { $count } треков
+    }
+
+# dates
+date-full = { $day } { $month } { $year }
+month-1 = янв.
+month-2 = фев.
+month-3 = мар.
+month-4 = апр.
+month-5 = мая
+month-6 = июн.
+month-7 = июл.
+month-8 = авг.
+month-9 = сен.
+month-10 = окт.
+month-11 = ноя.
+month-12 = дек.
+
+# settings
+settings-tab-appearance = Внешний вид
+settings-tab-playback = Воспроизведение
+settings-tab-account = Аккаунт
+settings-theme = Тема
+settings-theme-detail = Цветовая палитра приложения
+settings-theme-config = Открыть конфиг
+settings-adaptive = Адаптивная тема
+settings-adaptive-detail = Подкрашивать палитру обложкой играющего альбома
+settings-corners = Углы
+settings-corners-detail = Насколько скруглены поверхности и элементы
+settings-font = Размер шрифта
+settings-font-detail = Базовый размер текста, остальное масштабируется вместе с ним
+settings-font-value = { $size } px
+settings-language = Язык
+settings-language-detail = Язык интерфейса sonora
+settings-language-system = Системный
+settings-auto-hide = Автоскрытие боковой панели
+settings-auto-hide-detail = Сворачивать боковую панель, когда окно становится узким
+settings-window-controls = Кнопки окна
+settings-window-controls-detail = Рисовать свернуть, развернуть и закрыть в заголовке окна
+settings-controls-side = Сторона кнопок
+settings-controls-side-detail = С какой стороны заголовка расположены кнопки
+settings-normalisation = Нормализация громкости
+settings-normalisation-detail = Держит треки на одинаковой громкости
+settings-account = Аккаунт
+settings-account-detail = Выйти из Spotify на этом устройстве
+settings-sign-out = Выйти
+
+# themes
+theme-dark = Тёмная
+theme-light = Светлая
+theme-midnight = Полночь
+theme-forest = Лес
+theme-ocean = Океан
+theme-rose = Роза
+theme-lavender = Лаванда
+theme-amber = Янтарь
+
+# corners
+corners-square = Прямые
+corners-subtle = Лёгкие
+corners-rounded = Скруглённые
+corners-round = Круглые

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -1,0 +1,237 @@
+# common
+common-on = Увімк.
+common-off = Вимк.
+common-left = Ліворуч
+common-right = Праворуч
+common-search = Пошук
+common-unknown = Невідомо
+common-not-provided = Не вказано
+common-not-available = Немає даних
+number-group = { "\u00A0" }
+
+# navigation
+nav-home = Головна
+nav-search = Пошук
+nav-library = Моя медіатека
+nav-settings = Налаштування
+nav-songs = Треки
+nav-albums = Альбоми
+nav-playlists = Плейлисти
+
+# app menu
+app-refresh-library = Оновити медіатеку
+app-sign-out = Вийти
+app-quit = Вихід
+
+# table columns
+column-index = #
+column-title = Назва
+column-artist = Виконавець
+column-album = Альбом
+column-date-added = Дата додавання
+column-length = Тривалість
+column-plays = Прослуховування
+column-name = Назва
+column-owner = Власник
+column-year = Рік
+column-tracks = Треки
+
+# track menu
+menu-add-to-playlist = Додати до плейлиста
+menu-new-playlist = Новий плейлист
+menu-no-playlists = Немає плейлистів
+menu-toggle-library = Додати або вилучити з медіатеки
+menu-add-to-queue = Додати до черги
+menu-song-radio = Радіо за треком
+menu-view-details = Докладніше
+menu-copy-link = Копіювати посилання
+menu-remove-from-queue = Вилучити з черги
+
+# queue panel
+queue-title = Черга
+queue-history = Історія
+queue-now-playing = Зараз грає
+queue-up-next = Далі
+queue-reset = Скинути
+queue-clear = Очистити
+queue-empty = Черга порожня
+
+# player bar
+player-nothing-playing = Нічого не грає
+player-percent = { $value }%
+
+# filters
+filter-library = Фільтр медіатеки
+filter-album = Фільтр треків альбому
+
+# login
+login-signed-out = Увійдіть, щоб завантажити медіатеку Spotify
+login-restoring = Перевіряємо збережений сеанс…
+login-authorizing = Очікуємо авторизацію у браузері…
+login-signed-in = Ви увійшли як { $name }
+login-sign-in = Увійти через Spotify
+
+# album and playlist pages
+detail-album = Альбом
+detail-playlist = Плейлист
+detail-play-album = Слухати альбом
+detail-play-playlist = Слухати плейлист
+
+# play button
+play-pause = Пауза
+play-resume = Продовжити
+play-loading = Завантаження…
+
+# artist page
+artist-eyebrow = Виконавець
+artist-play = Слухати
+artist-popular = Популярне
+artist-releases = Релізи
+artist-filter-all = Усі
+artist-filter-albums = Альбоми
+artist-filter-singles = Сингли
+artist-filter-eps = EP
+
+# release kinds
+release-album = Альбом
+release-single = Сингл
+release-compilation = Збірка
+release-ep = EP
+release-audiobook = Аудіокнига
+release-podcast = Подкаст
+release-meta = { $year } • { $kind }
+
+# home page
+home-quick-picks = Швидкий вибір
+home-quick-picks-eyebrow = Почніть із треку
+
+# search page
+search-placeholder = Що хочете послухати?
+search-best-match = Найкращий збіг
+search-no-matches = Нічого не знайдено
+search-results = Результати
+search-songs = Треки
+search-artists = Виконавці
+search-albums = Альбоми
+search-tagged = { $kind } · { $value }
+search-saved =
+    { $count ->
+        [one] { $count } трек у медіатеці
+        [few] { $count } треки у медіатеці
+       *[other] { $count } треків у медіатеці
+    }
+kind-song = Трек
+kind-artist = Виконавець
+kind-album = Альбом
+
+# song page
+song-eyebrow = Трек
+song-play = Слухати трек
+song-view-album = Відкрити альбом
+song-loading = Завантажуємо інформацію про трек…
+song-about = Про трек
+song-album = Альбом
+song-released = Дата виходу
+song-streams = Прослуховування
+song-position = Позиція
+song-label = Лейбл
+song-popularity = Популярність
+song-popularity-value = { $value }%
+song-disc-track = Диск { $disc }, трек { $track }
+song-track = Трек { $track }
+song-credits = Автори
+song-performed-by = Виконання
+song-details = Жанри та деталі
+song-genres = Жанри
+song-language = Мова
+song-content = Контент
+song-explicit = Ненормативна лексика
+song-clean = Без обмежень
+song-about-artist = Про виконавця
+song-artist-fallback = Послухайте популярні треки та релізи виконавця.
+song-copyright = © { $notice }
+
+# song languages
+language-ar = Арабська
+language-de = Німецька
+language-en = Англійська
+language-es = Іспанська
+language-fr = Французька
+language-hi = Гінді
+language-it = Італійська
+language-ja = Японська
+language-ko = Корейська
+language-pt = Португальська
+language-ru = Російська
+language-tr = Турецька
+language-uk = Українська
+language-zh = Китайська
+language-zxx = Без слів
+
+# counts
+count-songs =
+    { $count ->
+        [one] { $count } трек
+        [few] { $count } треки
+       *[other] { $count } треків
+    }
+
+# dates
+date-full = { $day } { $month } { $year }
+month-1 = січ.
+month-2 = лют.
+month-3 = бер.
+month-4 = квіт.
+month-5 = трав.
+month-6 = черв.
+month-7 = лип.
+month-8 = серп.
+month-9 = вер.
+month-10 = жовт.
+month-11 = лист.
+month-12 = груд.
+
+# settings
+settings-tab-appearance = Вигляд
+settings-tab-playback = Відтворення
+settings-tab-account = Обліковий запис
+settings-theme = Тема
+settings-theme-detail = Кольорова палітра застосунку
+settings-theme-config = Відкрити конфіг
+settings-adaptive = Адаптивна тема
+settings-adaptive-detail = Підфарбовувати палітру обкладинкою альбому, що грає
+settings-corners = Кути
+settings-corners-detail = Наскільки заокруглені поверхні та елементи
+settings-font = Розмір шрифту
+settings-font-detail = Базовий розмір тексту, решта масштабується разом із ним
+settings-font-value = { $size } px
+settings-language = Мова
+settings-language-detail = Мова інтерфейсу sonora
+settings-language-system = Системна
+settings-auto-hide = Автоприховування бічної панелі
+settings-auto-hide-detail = Згортати бічну панель, коли вікно стає вузьким
+settings-window-controls = Кнопки вікна
+settings-window-controls-detail = Малювати згорнути, розгорнути та закрити в заголовку вікна
+settings-controls-side = Сторона кнопок
+settings-controls-side-detail = З якого боку заголовка розташовані кнопки
+settings-normalisation = Нормалізація гучності
+settings-normalisation-detail = Тримає треки на однаковій гучності
+settings-account = Обліковий запис
+settings-account-detail = Вийти зі Spotify на цьому пристрої
+settings-sign-out = Вийти
+
+# themes
+theme-dark = Темна
+theme-light = Світла
+theme-midnight = Північ
+theme-forest = Ліс
+theme-ocean = Океан
+theme-rose = Троянда
+theme-lavender = Лаванда
+theme-amber = Бурштин
+
+# corners
+corners-square = Прямі
+corners-subtle = Легкі
+corners-rounded = Заокруглені
+corners-round = Круглі

--- a/crates/i18n/Cargo.toml
+++ b/crates/i18n/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "i18n"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+fluent-bundle.workspace = true
+gpui.workspace = true
+log.workspace = true
+sys-locale.workspace = true
+unic-langid.workspace = true

--- a/crates/i18n/src/language.rs
+++ b/crates/i18n/src/language.rs
@@ -1,0 +1,79 @@
+use unic_langid::{LanguageIdentifier, langid};
+
+pub const AUTO: &str = "auto";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(usize)]
+pub enum Language {
+    English,
+    Russian,
+    Ukrainian,
+    Polish,
+}
+
+impl Language {
+    pub const ALL: [Self; 4] = [Self::English, Self::Russian, Self::Ukrainian, Self::Polish];
+
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::English => "en-US",
+            Self::Russian => "ru",
+            Self::Ukrainian => "uk",
+            Self::Polish => "pl",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::English => "English",
+            Self::Russian => "Русский",
+            Self::Ukrainian => "Українська",
+            Self::Polish => "Polski",
+        }
+    }
+
+    pub fn from_id(id: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|language| language.id() == id)
+    }
+
+    pub fn detect() -> Self {
+        let Some(locale) = sys_locale::get_locale() else {
+            return Self::English;
+        };
+        let primary = base(&locale);
+
+        Self::ALL
+            .into_iter()
+            .find(|language| base(language.id()) == primary)
+            .unwrap_or(Self::English)
+    }
+
+    pub(crate) fn tag(self) -> LanguageIdentifier {
+        match self {
+            Self::English => langid!("en-US"),
+            Self::Russian => langid!("ru"),
+            Self::Ukrainian => langid!("uk"),
+            Self::Polish => langid!("pl"),
+        }
+    }
+
+    pub(crate) fn source(self) -> &'static str {
+        match self {
+            Self::English => include_str!("../../../assets/i18n/en-US/main.ftl"),
+            Self::Russian => include_str!("../../../assets/i18n/ru/main.ftl"),
+            Self::Ukrainian => include_str!("../../../assets/i18n/uk/main.ftl"),
+            Self::Polish => include_str!("../../../assets/i18n/pl/main.ftl"),
+        }
+    }
+}
+
+pub fn resolve(id: &str) -> Language {
+    Language::from_id(id).unwrap_or_else(Language::detect)
+}
+
+fn base(tag: &str) -> String {
+    tag.split(['-', '_'])
+        .next()
+        .unwrap_or_default()
+        .to_lowercase()
+}

--- a/crates/i18n/src/lib.rs
+++ b/crates/i18n/src/lib.rs
@@ -1,0 +1,197 @@
+mod language;
+
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use fluent_bundle::concurrent::FluentBundle;
+use fluent_bundle::{FluentResource, FluentValue};
+use gpui::SharedString;
+
+pub use fluent_bundle::FluentArgs;
+pub use language::{AUTO, Language, resolve};
+
+static ACTIVE: AtomicUsize = AtomicUsize::new(0);
+static BUNDLES: LazyLock<Vec<FluentBundle<FluentResource>>> = LazyLock::new(build);
+
+pub trait Value<'a> {
+    fn value(self) -> FluentValue<'a>;
+}
+
+macro_rules! values {
+    ($($type:ty),* $(,)?) => {
+        $(
+            impl<'a> Value<'a> for $type {
+                fn value(self) -> FluentValue<'a> {
+                    FluentValue::from(self)
+                }
+            }
+        )*
+    };
+}
+
+values![
+    i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, f32, f64, String
+];
+
+impl<'a> Value<'a> for &'a str {
+    fn value(self) -> FluentValue<'a> {
+        FluentValue::from(self)
+    }
+}
+
+impl<'a> Value<'a> for &'a String {
+    fn value(self) -> FluentValue<'a> {
+        FluentValue::from(self.as_str())
+    }
+}
+
+impl<'a> Value<'a> for &'a SharedString {
+    fn value(self) -> FluentValue<'a> {
+        FluentValue::from(self.as_ref())
+    }
+}
+
+#[macro_export]
+macro_rules! t {
+    ($key:literal) => {
+        $crate::lookup($key, ::std::option::Option::None)
+    };
+    ($key:literal, $($name:ident = $value:expr),+ $(,)?) => {{
+        let mut args = $crate::FluentArgs::new();
+        $(
+            args.set(stringify!($name), $crate::Value::value($value));
+        )+
+        $crate::lookup($key, ::std::option::Option::Some(&args))
+    }};
+}
+
+pub fn language() -> Language {
+    Language::ALL[ACTIVE.load(Ordering::Relaxed)]
+}
+
+pub fn set(language: Language) {
+    ACTIVE.store(language as usize, Ordering::Relaxed);
+}
+
+pub fn lookup(key: &str, args: Option<&FluentArgs>) -> SharedString {
+    let active = language();
+    if let Some(text) = format(active, key, args) {
+        return text;
+    }
+
+    log::warn!("i18n: {key} is missing from {}", active.id());
+    if active != Language::English
+        && let Some(text) = format(Language::English, key, args)
+    {
+        return text;
+    }
+    SharedString::from(key.to_owned())
+}
+
+fn format(language: Language, key: &str, args: Option<&FluentArgs>) -> Option<SharedString> {
+    let bundle = BUNDLES.get(language as usize)?;
+    let pattern = bundle.get_message(key)?.value()?;
+
+    let mut errors = Vec::new();
+    let text = bundle.format_pattern(pattern, args, &mut errors);
+    for error in &errors {
+        log::warn!("i18n: cannot format {key}: {error}");
+    }
+    Some(SharedString::from(text.into_owned()))
+}
+
+fn build() -> Vec<FluentBundle<FluentResource>> {
+    Language::ALL.into_iter().map(bundle).collect()
+}
+
+fn bundle(language: Language) -> FluentBundle<FluentResource> {
+    let mut bundle = FluentBundle::new_concurrent(vec![language.tag()]);
+    bundle.set_use_isolating(false);
+
+    match FluentResource::try_new(language.source().to_owned()) {
+        Ok(resource) => {
+            if let Err(errors) = bundle.add_resource(resource) {
+                for error in errors {
+                    log::error!("i18n: cannot load {}: {error}", language.id());
+                }
+            }
+        }
+        Err((resource, errors)) => {
+            for error in errors {
+                log::error!("i18n: cannot parse {}: {error}", language.id());
+            }
+            bundle.add_resource_overriding(resource);
+        }
+    }
+    bundle
+}
+
+#[cfg(test)]
+fn keys(language: Language) -> Vec<&'static str> {
+    let mut keys: Vec<&str> = language
+        .source()
+        .lines()
+        .filter(|line| !line.starts_with([' ', '#', '.', '*', '[']))
+        .filter_map(|line| line.split_once(" =").map(|(key, _)| key))
+        .filter(|key| !key.is_empty() && !key.starts_with('-'))
+        .collect();
+    keys.sort_unstable();
+    keys
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn locales_share_the_english_key_set() {
+        let english = keys(Language::English);
+        assert!(english.len() > 100);
+
+        for language in Language::ALL {
+            let missing: Vec<&str> = english
+                .iter()
+                .copied()
+                .filter(|key| !keys(language).contains(key))
+                .collect();
+            let extra: Vec<&str> = keys(language)
+                .into_iter()
+                .filter(|key| !english.contains(key))
+                .collect();
+
+            assert!(
+                missing.is_empty(),
+                "{} is missing {missing:?}",
+                language.id()
+            );
+            assert!(extra.is_empty(), "{} has extra {extra:?}", language.id());
+        }
+    }
+
+    #[test]
+    fn every_message_resolves() {
+        for language in Language::ALL {
+            for key in keys(language) {
+                assert!(format(language, key, None).is_some(), "{key} has no value");
+            }
+        }
+    }
+
+    #[test]
+    fn plurals_pick_the_right_category() {
+        let cases = [
+            (Language::English, ["1 song", "2 songs", "5 songs"]),
+            (Language::Russian, ["1 трек", "2 трека", "5 треков"]),
+            (Language::Ukrainian, ["1 трек", "2 треки", "5 треків"]),
+            (Language::Polish, ["1 utwór", "2 utwory", "5 utworów"]),
+        ];
+
+        for (language, expected) in cases {
+            for (count, text) in [1, 2, 5].into_iter().zip(expected) {
+                let mut args = FluentArgs::new();
+                args.set("count", count);
+                assert_eq!(format(language, "count-songs", Some(&args)).unwrap(), text);
+            }
+        }
+    }
+}

--- a/crates/sonora/Cargo.toml
+++ b/crates/sonora/Cargo.toml
@@ -9,6 +9,7 @@ env_logger.workspace = true
 log.workspace = true
 gpui.workspace = true
 gpui_platform.workspace = true
+i18n.workspace = true
 state.workspace = true
 input.workspace = true
 router.workspace = true

--- a/crates/sonora/src/actions.rs
+++ b/crates/sonora/src/actions.rs
@@ -1,4 +1,5 @@
 use gpui::{App, Menu, MenuItem};
+use i18n::t;
 use input::{Quit, RefreshLibrary, SignOut, TogglePlayback};
 use state::Sonora;
 
@@ -33,10 +34,10 @@ pub fn register(cx: &mut App) {
         name: "sonora".into(),
         disabled: false,
         items: vec![
-            MenuItem::action("Refresh Library", RefreshLibrary),
-            MenuItem::action("Sign Out", SignOut),
+            MenuItem::action(t!("app-refresh-library"), RefreshLibrary),
+            MenuItem::action(t!("app-sign-out"), SignOut),
             MenuItem::separator(),
-            MenuItem::action("Quit", Quit),
+            MenuItem::action(t!("app-quit"), Quit),
         ],
     }]);
 }

--- a/crates/sonora/src/main.rs
+++ b/crates/sonora/src/main.rs
@@ -41,10 +41,15 @@ fn main() {
 
             state::init(cx, io);
             router::init(Destination::Home, cx);
-            let (look, overrides) = {
+            let (look, overrides, language) = {
                 let settings = Sonora::global(cx).settings.read(cx);
-                (settings.look(), settings.theme_overrides().clone())
+                (
+                    settings.look(),
+                    settings.theme_overrides().clone(),
+                    settings.language().to_owned(),
+                )
             };
+            i18n::set(i18n::resolve(&language));
             ui::Theme::init(look, &overrides, cx);
 
             actions::register(cx);

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -9,6 +9,7 @@ audio.workspace = true
 dirs.workspace = true
 fastrand.workspace = true
 gpui.workspace = true
+i18n.workspace = true
 librespot-core.workspace = true
 log.workspace = true
 serde.workspace = true

--- a/crates/state/src/detail.rs
+++ b/crates/state/src/detail.rs
@@ -1,10 +1,11 @@
 use gpui::{Context, Entity, Task};
+use i18n::t;
 use spotify::{Album, AlbumDetail, ArtistRef, Playlist, Track};
 
 use crate::{Io, Library, Session, SessionEvent, join};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum Kind {
+pub enum Collection {
     Album,
     Playlist,
 }
@@ -15,7 +16,7 @@ enum Loaded {
 }
 
 pub struct Header {
-    pub kind: &'static str,
+    pub kind: Collection,
     pub title: String,
     pub artist: Option<String>,
     pub artist_refs: Vec<ArtistRef>,
@@ -82,15 +83,15 @@ impl Detail {
 
     pub fn open_album(&mut self, id: &str, cx: &mut Context<Self>) {
         let known = self.library.read(cx).album(id).map(album_header);
-        self.open(Kind::Album, id, known, cx);
+        self.open(Collection::Album, id, known, cx);
     }
 
     pub fn open_playlist(&mut self, id: &str, cx: &mut Context<Self>) {
         let known = self.library.read(cx).playlist(id).map(playlist_header);
-        self.open(Kind::Playlist, id, known, cx);
+        self.open(Collection::Playlist, id, known, cx);
     }
 
-    fn open(&mut self, kind: Kind, id: &str, known: Option<Header>, cx: &mut Context<Self>) {
+    fn open(&mut self, kind: Collection, id: &str, known: Option<Header>, cx: &mut Context<Self>) {
         if self.shows(id) {
             return;
         }
@@ -112,8 +113,8 @@ impl Detail {
         self.task = Some(cx.spawn(async move |this, cx| {
             let loaded = join(io.spawn(async move {
                 match kind {
-                    Kind::Album => client.album(&id).await.map(Loaded::Album),
-                    Kind::Playlist => client.playlist_tracks(&id).await.map(Loaded::Tracks),
+                    Collection::Album => client.album(&id).await.map(Loaded::Album),
+                    Collection::Playlist => client.playlist_tracks(&id).await.map(Loaded::Tracks),
                 }
             }))
             .await;
@@ -152,11 +153,11 @@ impl Detail {
 fn album_header(album: &Album) -> Header {
     let mut parts = Vec::new();
     if album.track_count > 0 {
-        parts.push(format!("{} songs", album.track_count));
+        parts.push(t!("count-songs", count = album.track_count).to_string());
     }
 
     Header {
-        kind: "Album",
+        kind: Collection::Album,
         title: album.name.clone(),
         artist: Some(album.artists.clone()),
         artist_refs: album.artist_refs.clone(),
@@ -172,11 +173,11 @@ fn album_header(album: &Album) -> Header {
 fn playlist_header(playlist: &Playlist) -> Header {
     let mut parts = vec![playlist.owner.clone()];
     if playlist.track_count > 0 {
-        parts.push(format!("{} songs", playlist.track_count));
+        parts.push(t!("count-songs", count = playlist.track_count).to_string());
     }
 
     Header {
-        kind: "Playlist",
+        kind: Collection::Playlist,
         title: playlist.name.clone(),
         artist: None,
         artist_refs: Vec::new(),

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -10,7 +10,7 @@ mod settings;
 mod song;
 
 pub use artist::ArtistDetail;
-pub use detail::{Detail, Header};
+pub use detail::{Collection, Detail, Header};
 pub use home::Home;
 pub use library::{Library, LibraryState};
 pub use playback::{Origin, Playback, PlaybackState, Repeat};

--- a/crates/state/src/settings.rs
+++ b/crates/state/src/settings.rs
@@ -22,6 +22,7 @@ struct Values {
     sidebar_width: f32,
     sidebar_open: bool,
     queue_width: f32,
+    language: String,
     hidden_columns: HashMap<String, Vec<String>>,
     appearance: Appearance,
 }
@@ -48,6 +49,7 @@ impl Default for Values {
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
             sidebar_open: true,
             queue_width: DEFAULT_QUEUE_WIDTH,
+            language: i18n::AUTO.to_owned(),
             hidden_columns: HashMap::new(),
             appearance: Appearance::default(),
         }
@@ -115,6 +117,10 @@ impl AppSettings {
 
     pub fn queue_width(&self) -> f32 {
         self.values.queue_width
+    }
+
+    pub fn language(&self) -> &str {
+        &self.values.language
     }
 
     pub fn auto_hide_sidebar(&self) -> bool {
@@ -206,6 +212,13 @@ impl AppSettings {
 
     pub fn set_queue_width(&mut self, width: f32, cx: &mut Context<Self>) {
         self.values.queue_width = width;
+        self.schedule_save(cx);
+    }
+
+    pub fn set_language(&mut self, language: impl Into<String>, cx: &mut Context<Self>) {
+        self.values.language = language.into();
+        i18n::set(i18n::resolve(&self.values.language));
+        cx.refresh_windows();
         self.schedule_save(cx);
     }
 

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -5,5 +5,6 @@ edition.workspace = true
 
 [dependencies]
 gpui.workspace = true
+i18n.workspace = true
 image.workspace = true
 serde.workspace = true

--- a/crates/ui/src/grid.rs
+++ b/crates/ui/src/grid.rs
@@ -4,7 +4,7 @@ use gpui::prelude::*;
 use gpui::{
     AbsoluteLength, AnyElement, App, Context, Corners, Div, Entity, EventEmitter, FocusHandle,
     Focusable, Interactivity, MouseButton, MouseDownEvent, Pixels, Point, ScrollHandle,
-    StyleRefinement, TextAlign, Window, actions, anchored, div, point, px, svg,
+    SharedString, StyleRefinement, TextAlign, Window, actions, anchored, div, point, px, svg,
 };
 
 use crate::menu::Menu;
@@ -49,6 +49,13 @@ pub struct ColumnSpec<F: 'static> {
 }
 
 impl<F: 'static> ColumnSpec<F> {
+    pub fn label(&self) -> SharedString {
+        match self.header.is_empty() {
+            true => SharedString::default(),
+            false => i18n::lookup(self.header, None),
+        }
+    }
+
     fn share(&self) -> f32 {
         match self.width {
             Width::Fill(share) => share,
@@ -220,7 +227,7 @@ impl<S: GridSource> GridDelegate<S> {
             .iter()
             .map(|spec| Toggle {
                 key: spec.key,
-                label: spec.header,
+                label: spec.label(),
                 visible: !self.hidden.iter().any(|hidden| hidden == spec.key),
             })
             .collect()
@@ -314,7 +321,7 @@ pub enum GridEvent {
 
 pub struct Toggle {
     pub key: &'static str,
-    pub label: &'static str,
+    pub label: SharedString,
     pub visible: bool,
 }
 
@@ -486,7 +493,7 @@ impl<S: GridSource> GridState<S> {
                     column.width,
                     self.delegate.inner_width(ix),
                     column.spec.align,
-                    column.spec.header,
+                    column.spec.label(),
                     column.spec.sortable,
                     self.delegate.direction(column.spec.field),
                 )

--- a/crates/ui/src/metrics.rs
+++ b/crates/ui/src/metrics.rs
@@ -1,4 +1,5 @@
-use gpui::{Pixels, Window, px};
+use gpui::{Pixels, SharedString, Window, px};
+use i18n::t;
 
 const HEADER: f32 = 0.75;
 
@@ -22,12 +23,12 @@ impl Rounding {
         }
     }
 
-    pub fn label(self) -> &'static str {
+    pub fn label(self) -> SharedString {
         match self {
-            Self::Square => "Square",
-            Self::Subtle => "Subtle",
-            Self::Rounded => "Rounded",
-            Self::Round => "Round",
+            Self::Square => t!("corners-square"),
+            Self::Subtle => t!("corners-subtle"),
+            Self::Rounded => t!("corners-rounded"),
+            Self::Round => t!("corners-round"),
         }
     }
 

--- a/crates/ui/src/theme.rs
+++ b/crates/ui/src/theme.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
-use gpui::{App, Global, Hsla, Pixels, Rgba, Task, px, rgb, rgba};
+use gpui::{App, Global, Hsla, Pixels, Rgba, SharedString, Task, px, rgb, rgba};
+use i18n::t;
 use serde::{Deserialize, Serialize};
 
 use crate::metrics::{Metrics, Rounding, Text};
@@ -63,16 +64,16 @@ impl ThemeKind {
         }
     }
 
-    pub fn label(self) -> &'static str {
+    pub fn label(self) -> SharedString {
         match self {
-            Self::Dark => "Dark",
-            Self::Light => "Light",
-            Self::Midnight => "Midnight",
-            Self::Forest => "Forest",
-            Self::Ocean => "Ocean",
-            Self::Rose => "Rose",
-            Self::Lavender => "Lavender",
-            Self::Amber => "Amber",
+            Self::Dark => t!("theme-dark"),
+            Self::Light => t!("theme-light"),
+            Self::Midnight => t!("theme-midnight"),
+            Self::Forest => t!("theme-forest"),
+            Self::Ocean => t!("theme-ocean"),
+            Self::Rose => t!("theme-rose"),
+            Self::Lavender => t!("theme-lavender"),
+            Self::Amber => t!("theme-amber"),
         }
     }
 

--- a/crates/views/Cargo.toml
+++ b/crates/views/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 gpui.workspace = true
+i18n.workspace = true
 jiff.workspace = true
 spotify.workspace = true
 input.workspace = true

--- a/crates/views/src/artist.rs
+++ b/crates/views/src/artist.rs
@@ -4,6 +4,7 @@ use gpui::{
     Window, div, px,
 };
 
+use i18n::t;
 use spotify::{ReleaseType, Track};
 use state::{ArtistDetail, Playback};
 use ui::ActiveTheme as _;
@@ -26,12 +27,21 @@ enum ReleaseFilter {
 impl ReleaseFilter {
     const ALL: [Self; 4] = [Self::All, Self::Singles, Self::Albums, Self::Eps];
 
-    fn label(self) -> &'static str {
+    fn id(self) -> &'static str {
         match self {
-            Self::All => "All",
-            Self::Albums => "Albums",
-            Self::Singles => "Singles",
-            Self::Eps => "EPs",
+            Self::All => "release-filter-all",
+            Self::Albums => "release-filter-albums",
+            Self::Singles => "release-filter-singles",
+            Self::Eps => "release-filter-eps",
+        }
+    }
+
+    fn label(self) -> SharedString {
+        match self {
+            Self::All => t!("artist-filter-all"),
+            Self::Albums => t!("artist-filter-albums"),
+            Self::Singles => t!("artist-filter-singles"),
+            Self::Eps => t!("artist-filter-eps"),
         }
     }
 
@@ -148,10 +158,10 @@ impl ArtistView {
 
         PageHero::new("artist-hero", title)
             .cover(artist.and_then(|artist| artist.cover_large.clone()))
-            .eyebrow("Artist")
+            .eyebrow(t!("artist-eyebrow"))
             .actions(HeroPlayButton::new(
                 "play-artist",
-                "Play now",
+                t!("artist-play"),
                 self.detail.read(cx).tracks().to_vec(),
                 self.playback.clone(),
             ))
@@ -176,27 +186,22 @@ impl ArtistView {
                     div()
                         .text_size(theme.text(Text::Title))
                         .font_weight(FontWeight::BOLD)
-                        .child("Releases"),
+                        .child(t!("artist-releases")),
                 )
                 .child(
                     div()
                         .flex()
                         .gap_1()
                         .children(ReleaseFilter::ALL.map(|filter| {
-                            Button::new(SharedString::from(format!(
-                                "release-filter-{}",
-                                filter.label().to_lowercase()
-                            )))
-                            .label(filter.label())
-                            .small()
-                            .outline()
-                            .selected(self.release_filter == filter)
-                            .on_click(cx.listener(
-                                move |this, _, _, cx| {
+                            Button::new(filter.id())
+                                .label(filter.label())
+                                .small()
+                                .outline()
+                                .selected(self.release_filter == filter)
+                                .on_click(cx.listener(move |this, _, _, cx| {
                                     this.release_filter = filter;
                                     cx.notify();
-                                },
-                            ))
+                                }))
                         })),
                 )
                 .child(
@@ -249,7 +254,7 @@ impl Render for ArtistView {
                             .pb_3()
                             .text_size(theme.text(Text::Title))
                             .font_weight(FontWeight::BOLD)
-                            .child("Popular"),
+                            .child(t!("artist-popular")),
                     ),
             )
             .child(

--- a/crates/views/src/cells.rs
+++ b/crates/views/src/cells.rs
@@ -7,6 +7,7 @@ use gpui::{
     AnyElement, App, Context, Div, Entity, Hsla, MouseButton, Pixels, SharedString, Task, Window,
     div, px, svg,
 };
+use i18n::t;
 use router::{Destination, Link as _, navigate};
 use spotify::ArtistRef;
 use state::{Playback, PlaybackState};
@@ -284,7 +285,8 @@ pub(crate) fn dim<F>(cell: &Cell<F>, value: impl Into<SharedString>, muted: Hsla
         .into_any_element()
 }
 
-pub(crate) fn count(value: u64) -> String {
+pub(crate) fn count(value: u64) -> SharedString {
+    let group = t!("number-group");
     let digits = value.to_string();
     let first = match digits.len() % 3 {
         0 => 3,
@@ -292,10 +294,10 @@ pub(crate) fn count(value: u64) -> String {
     };
     let mut grouped = digits[..first].to_owned();
     for chunk in digits.as_bytes()[first..].chunks(3) {
-        grouped.push(',');
+        grouped.push_str(&group);
         grouped.push_str(std::str::from_utf8(chunk).unwrap_or_default());
     }
-    grouped
+    SharedString::from(grouped)
 }
 
 pub(crate) fn title<F>(

--- a/crates/views/src/detail.rs
+++ b/crates/views/src/detail.rs
@@ -3,8 +3,9 @@ use gpui::{
     AnyElement, App, Context, Entity, Pixels, Render, ScrollHandle, SharedString, Window, px,
 };
 
+use i18n::t;
 use spotify::Track;
-use state::{Detail, Playback};
+use state::{Collection, Detail, Playback};
 use ui::ActiveTheme as _;
 use ui::{ColumnSpec, GridDelegate, GridEvent, GridState, Scrollbar, Scroller, clock, grid};
 
@@ -116,7 +117,9 @@ impl DetailView {
         let theme = cx.theme();
         let muted = theme.muted_foreground;
         let header = self.detail.read(cx).header();
-        let kind = header.map(|header| header.kind).unwrap_or_default();
+        let kind = header
+            .map(|header| header.kind)
+            .unwrap_or(Collection::Album);
         let title = header
             .map(|header| SharedString::from(header.title.clone()))
             .unwrap_or_default();
@@ -128,9 +131,9 @@ impl DetailView {
         let meta = header.map(|header| header.meta.clone()).unwrap_or_default();
         let queued = self.detail.read(cx).tracks().to_vec();
         let duration: std::time::Duration = queued.iter().map(|track| track.duration).sum();
-        let label = match kind {
-            "Playlist" => "Play playlist",
-            _ => "Play album",
+        let (eyebrow, label) = match kind {
+            Collection::Playlist => (t!("detail-playlist"), t!("detail-play-playlist")),
+            Collection::Album => (t!("detail-album"), t!("detail-play-album")),
         };
 
         let mut strip = HeroMetaStrip::new();
@@ -154,7 +157,7 @@ impl DetailView {
 
         PageHero::new("detail-hero", title)
             .cover(header.and_then(|header| header.cover.clone()))
-            .eyebrow(kind)
+            .eyebrow(eyebrow)
             .meta(strip)
             .actions(HeroPlayButton::new(
                 "play-detail",
@@ -200,7 +203,7 @@ impl Searchable for DetailView {
         cx.notify();
     }
 
-    fn hint() -> &'static str {
-        "Filter album tracks"
+    fn hint() -> SharedString {
+        t!("filter-album")
     }
 }

--- a/crates/views/src/hero.rs
+++ b/crates/views/src/hero.rs
@@ -1,31 +1,33 @@
 use gpui::prelude::*;
 use gpui::{AnyElement, App, ElementId, Entity, FontWeight, SharedString, Window, div};
+use i18n::t;
 use spotify::Track;
 use state::{Playback, PlaybackState};
 use ui::{ActiveTheme as _, Button, Card, Text};
 
-pub(crate) fn release_date_label(value: &str) -> String {
+pub(crate) fn release_date_label(value: &str) -> SharedString {
     let parts: Vec<_> = value.split('-').collect();
     if parts.len() != 3 {
-        return value.to_owned();
+        return SharedString::from(value.to_owned());
     }
     let month = match parts[1] {
-        "01" => "Jan",
-        "02" => "Feb",
-        "03" => "Mar",
-        "04" => "Apr",
-        "05" => "May",
-        "06" => "Jun",
-        "07" => "Jul",
-        "08" => "Aug",
-        "09" => "Sep",
-        "10" => "Oct",
-        "11" => "Nov",
-        "12" => "Dec",
-        _ => return value.to_owned(),
+        "01" => t!("month-1"),
+        "02" => t!("month-2"),
+        "03" => t!("month-3"),
+        "04" => t!("month-4"),
+        "05" => t!("month-5"),
+        "06" => t!("month-6"),
+        "07" => t!("month-7"),
+        "08" => t!("month-8"),
+        "09" => t!("month-9"),
+        "10" => t!("month-10"),
+        "11" => t!("month-11"),
+        "12" => t!("month-12"),
+        _ => return SharedString::from(value.to_owned()),
     };
     let day = parts[2].trim_start_matches('0');
-    format!("{month} {day}, {}", parts[0])
+
+    t!("date-full", month = &month, day = day, year = parts[0])
 }
 
 #[derive(IntoElement, Default)]
@@ -117,9 +119,9 @@ impl RenderOnce for HeroPlayButton {
                 .map(|_| playback.state().clone())
         };
         let (label, icon, blocked) = match &state {
-            Some(PlaybackState::Playing) => ("Pause".into(), "icons/pause.svg", false),
-            Some(PlaybackState::Paused) => ("Resume".into(), "icons/play.svg", false),
-            Some(PlaybackState::Loading) => ("Loading…".into(), "icons/play.svg", true),
+            Some(PlaybackState::Playing) => (t!("play-pause"), "icons/pause.svg", false),
+            Some(PlaybackState::Paused) => (t!("play-resume"), "icons/play.svg", false),
+            Some(PlaybackState::Loading) => (t!("play-loading"), "icons/play.svg", true),
             _ => (self.label, "icons/play.svg", false),
         };
         let disabled = first_playable.is_none() || blocked;

--- a/crates/views/src/library/albums.rs
+++ b/crates/views/src/library/albums.rs
@@ -22,7 +22,7 @@ pub(super) const COLUMNS: &[ColumnSpec<AlbumField>] = &[
     ColumnSpec {
         field: AlbumField::Index,
         key: "index",
-        header: "#",
+        header: "column-index",
         align: TextAlign::Center,
         width: Width::Fixed(NUMBER),
         flush: false,
@@ -42,7 +42,7 @@ pub(super) const COLUMNS: &[ColumnSpec<AlbumField>] = &[
     ColumnSpec {
         field: AlbumField::Name,
         key: "name",
-        header: "Album",
+        header: "column-album",
         align: TextAlign::Left,
         width: Width::Fill(0.55),
         flush: false,
@@ -52,7 +52,7 @@ pub(super) const COLUMNS: &[ColumnSpec<AlbumField>] = &[
     ColumnSpec {
         field: AlbumField::Artists,
         key: "artists",
-        header: "Artist",
+        header: "column-artist",
         align: TextAlign::Left,
         width: Width::Fill(0.45),
         flush: false,
@@ -62,7 +62,7 @@ pub(super) const COLUMNS: &[ColumnSpec<AlbumField>] = &[
     ColumnSpec {
         field: AlbumField::Year,
         key: "year",
-        header: "Year",
+        header: "column-year",
         align: TextAlign::Right,
         width: Width::Fixed(YEAR),
         flush: false,
@@ -72,7 +72,7 @@ pub(super) const COLUMNS: &[ColumnSpec<AlbumField>] = &[
     ColumnSpec {
         field: AlbumField::TrackCount,
         key: "tracks",
-        header: "Tracks",
+        header: "column-tracks",
         align: TextAlign::Right,
         width: Width::Fixed(TRAILING),
         flush: false,

--- a/crates/views/src/library/mod.rs
+++ b/crates/views/src/library/mod.rs
@@ -2,7 +2,8 @@ mod albums;
 mod playlists;
 
 use gpui::prelude::*;
-use gpui::{App, Context, Entity, Pixels, Point, Render, ScrollHandle, Window, px};
+use gpui::{App, Context, Entity, Pixels, Point, Render, ScrollHandle, SharedString, Window, px};
+use i18n::t;
 use router::{Destination, LibraryTab, navigate};
 use spotify::Track;
 use state::{AppSettings, Library, LibraryState, Playback, Sonora};
@@ -389,7 +390,7 @@ impl Searchable for LibraryView {
         cx.notify();
     }
 
-    fn hint() -> &'static str {
-        "Filter your library"
+    fn hint() -> SharedString {
+        t!("filter-library")
     }
 }

--- a/crates/views/src/library/playlists.rs
+++ b/crates/views/src/library/playlists.rs
@@ -21,7 +21,7 @@ pub(super) const COLUMNS: &[ColumnSpec<PlaylistField>] = &[
     ColumnSpec {
         field: PlaylistField::Index,
         key: "index",
-        header: "#",
+        header: "column-index",
         align: TextAlign::Center,
         width: Width::Fixed(NUMBER),
         flush: false,
@@ -41,7 +41,7 @@ pub(super) const COLUMNS: &[ColumnSpec<PlaylistField>] = &[
     ColumnSpec {
         field: PlaylistField::Name,
         key: "name",
-        header: "Name",
+        header: "column-name",
         align: TextAlign::Left,
         width: Width::Fill(0.55),
         flush: false,
@@ -51,7 +51,7 @@ pub(super) const COLUMNS: &[ColumnSpec<PlaylistField>] = &[
     ColumnSpec {
         field: PlaylistField::Owner,
         key: "owner",
-        header: "Owner",
+        header: "column-owner",
         align: TextAlign::Left,
         width: Width::Fill(0.45),
         flush: false,
@@ -61,7 +61,7 @@ pub(super) const COLUMNS: &[ColumnSpec<PlaylistField>] = &[
     ColumnSpec {
         field: PlaylistField::TrackCount,
         key: "tracks",
-        header: "Tracks",
+        header: "column-tracks",
         align: TextAlign::Right,
         width: Width::Fixed(TRAILING),
         flush: false,

--- a/crates/views/src/login.rs
+++ b/crates/views/src/login.rs
@@ -1,7 +1,8 @@
 use gpui::{
-    Context, Entity, FontWeight, IntoElement, ParentElement as _, Render, Styled as _, Window, div,
-    px,
+    Context, Entity, FontWeight, IntoElement, ParentElement as _, Render, SharedString,
+    Styled as _, Window, div, px,
 };
+use i18n::t;
 use state::{Session, SessionState};
 use ui::ActiveTheme as _;
 use ui::{Button, Text};
@@ -23,11 +24,11 @@ impl Render for LoginView {
         let pending = self.session.read(cx).is_pending();
 
         let status = match &state {
-            SessionState::SignedOut => "Sign in to load your Spotify library".to_owned(),
-            SessionState::Restoring => "Checking your saved session...".to_owned(),
-            SessionState::Authorizing => "Waiting for authorization in your browser...".to_owned(),
-            SessionState::SignedIn(profile) => format!("Signed in as {}", profile.display_name),
-            SessionState::Failed(error) => error.clone(),
+            SessionState::SignedOut => t!("login-signed-out"),
+            SessionState::Restoring => t!("login-restoring"),
+            SessionState::Authorizing => t!("login-authorizing"),
+            SessionState::SignedIn(profile) => t!("login-signed-in", name = &profile.display_name),
+            SessionState::Failed(error) => SharedString::from(error.clone()),
         };
 
         let theme = *cx.theme();
@@ -62,7 +63,7 @@ impl Render for LoginView {
             )
             .child(
                 Button::new("sign-in")
-                    .label("Sign in with Spotify")
+                    .label(t!("login-sign-in"))
                     .primary()
                     .disabled(pending)
                     .on_click(move |_, _, cx| {

--- a/crates/views/src/quick_picks.rs
+++ b/crates/views/src/quick_picks.rs
@@ -5,6 +5,7 @@ use gpui::{
     App, ClickEvent, Entity, FontWeight, MouseButton, MouseDownEvent, Pixels, SharedString, Window,
     div,
 };
+use i18n::t;
 use spotify::Track;
 use state::Playback;
 use ui::{ActiveTheme as _, Button, Card, Text, eyebrow, heading};
@@ -123,8 +124,8 @@ impl RenderOnce for QuickPicks {
                             .flex()
                             .flex_col()
                             .gap_0p5()
-                            .child(eyebrow("Start from a song", cx))
-                            .child(heading("Quick picks", cx)),
+                            .child(eyebrow(t!("home-quick-picks-eyebrow"), cx))
+                            .child(heading(t!("home-quick-picks"), cx)),
                     )
                     .child(
                         div()

--- a/crates/views/src/release_card.rs
+++ b/crates/views/src/release_card.rs
@@ -1,8 +1,20 @@
 use gpui::prelude::*;
 use gpui::{App, FontWeight, SharedString, Window, div};
+use i18n::t;
 use router::{Destination, Link as _};
-use spotify::Album;
+use spotify::{Album, ReleaseType};
 use ui::{ActiveTheme as _, Artwork, Text};
+
+pub(crate) fn release_label(kind: ReleaseType) -> SharedString {
+    match kind {
+        ReleaseType::Album => t!("release-album"),
+        ReleaseType::Single => t!("release-single"),
+        ReleaseType::Compilation => t!("release-compilation"),
+        ReleaseType::Ep => t!("release-ep"),
+        ReleaseType::Audiobook => t!("release-audiobook"),
+        ReleaseType::Podcast => t!("release-podcast"),
+    }
+}
 
 #[derive(IntoElement)]
 pub(crate) struct ReleaseCard {
@@ -24,10 +36,10 @@ impl RenderOnce for ReleaseCard {
             .cover_large
             .clone()
             .or_else(|| self.album.cover.clone());
-        let release = self.album.release_type.label();
+        let release = release_label(self.album.release_type);
         let metadata = match self.album.year > 0 {
-            true => format!("{} • {release}", self.album.year),
-            false => release.to_owned(),
+            true => t!("release-meta", year = self.album.year, kind = &release),
+            false => release,
         };
 
         div()

--- a/crates/views/src/search.rs
+++ b/crates/views/src/search.rs
@@ -3,6 +3,7 @@ use gpui::{
     AnyElement, App, Context, ElementId, Entity, FontWeight, Hsla, Pixels, Render, ScrollHandle,
     SharedString, Window, div, px,
 };
+use i18n::t;
 use input::Input;
 use router::{Destination, navigate};
 
@@ -37,8 +38,7 @@ impl SearchView {
         playback: Entity<Playback>,
         cx: &mut Context<Self>,
     ) -> Self {
-        let input =
-            cx.new(|cx| Input::new("What do you want to listen to?", cx).icon("icons/search.svg"));
+        let input = cx.new(|cx| Input::new(t!("search-placeholder"), cx).icon("icons/search.svg"));
 
         cx.observe(&input, |this, input, cx| {
             let query = input.read(cx).text().to_owned();
@@ -218,7 +218,7 @@ impl SearchView {
                 .flex_col()
                 .flex_none()
                 .gap_2()
-                .child(eyebrow("Best match", cx).pb_1())
+                .child(eyebrow(t!("search-best-match"), cx).pb_1())
                 .child(card)
                 .into_any_element(),
         )
@@ -247,7 +247,7 @@ impl SearchView {
             return div()
                 .flex_none()
                 .text_color(cx.theme().muted_foreground)
-                .child("No matches")
+                .child(t!("search-no-matches"))
                 .into_any_element();
         }
 
@@ -265,7 +265,7 @@ impl SearchView {
         &self,
         id: &'static str,
         bar: &Entity<Scrollbar>,
-        title: &'static str,
+        title: SharedString,
         rows: Vec<AnyElement>,
         cx: &Context<Self>,
     ) -> AnyElement {
@@ -283,9 +283,9 @@ impl SearchView {
 
     fn column(&self, kind: Kind, cx: &Context<Self>) -> AnyElement {
         let (id, bar, title) = match kind {
-            Kind::Song => ("search-songs", &self.songs, "Songs"),
-            Kind::Artist => ("search-artists", &self.artists, "Artists"),
-            Kind::Album => ("search-albums", &self.albums, "Albums"),
+            Kind::Song => ("search-songs", &self.songs, t!("search-songs")),
+            Kind::Artist => ("search-artists", &self.artists, t!("search-artists")),
+            Kind::Album => ("search-albums", &self.albums, t!("search-albums")),
         };
 
         let rows = self
@@ -318,7 +318,7 @@ impl SearchView {
             })
             .collect();
 
-        self.section("search-all", &self.mixed, "Results", rows, cx)
+        self.section("search-all", &self.mixed, t!("search-results"), rows, cx)
     }
 }
 
@@ -335,32 +335,33 @@ fn meta(hit: &Hit, compact: bool) -> SharedString {
         Hit::Song(track) => tagged(Kind::Song, &track.artists, compact),
         Hit::Album(album) => tagged(Kind::Album, &album.artists, compact),
         Hit::Artist(artist) => match compact {
-            true => SharedString::from(noun(Kind::Artist)),
-            false => SharedString::from(held(artist.saved)),
+            true => noun(Kind::Artist),
+            false => held(artist.saved),
         },
     }
 }
 
 fn tagged(kind: Kind, value: &str, compact: bool) -> SharedString {
-    match compact {
-        true => SharedString::from(format!("{} · {value}", noun(kind))),
-        false => SharedString::from(value.to_owned()),
+    if !compact {
+        return SharedString::from(value.to_owned());
     }
+
+    let noun = noun(kind);
+    t!("search-tagged", kind = &noun, value = value)
 }
 
-fn held(saved: usize) -> String {
+fn held(saved: usize) -> SharedString {
     match saved {
-        0 => noun(Kind::Artist).to_owned(),
-        1 => "1 song in Library".to_owned(),
-        count => format!("{count} songs in Library"),
+        0 => noun(Kind::Artist),
+        count => t!("search-saved", count = count),
     }
 }
 
-fn noun(kind: Kind) -> &'static str {
+fn noun(kind: Kind) -> SharedString {
     match kind {
-        Kind::Song => "Song",
-        Kind::Artist => "Artist",
-        Kind::Album => "Album",
+        Kind::Song => t!("kind-song"),
+        Kind::Artist => t!("kind-artist"),
+        Kind::Album => t!("kind-album"),
     }
 }
 

--- a/crates/views/src/settings.rs
+++ b/crates/views/src/settings.rs
@@ -5,6 +5,7 @@ use gpui::{
     AnyElement, Context, Entity, FontWeight, Pixels, Render, SharedString, Window, div, px,
 };
 use gpui::{ScrollHandle, prelude::*};
+use i18n::{Language, t};
 use state::{AppSettings, Playback, Session, SessionState, Sonora};
 use ui::{ActiveTheme as _, Scrollbar, Scroller};
 use ui::{
@@ -22,11 +23,19 @@ enum Tab {
 impl Tab {
     const ALL: [Self; 3] = [Self::Appearance, Self::Playback, Self::Account];
 
-    fn label(self) -> &'static str {
+    fn id(self) -> &'static str {
         match self {
-            Self::Appearance => "Appearance",
-            Self::Playback => "Playback",
-            Self::Account => "Account",
+            Self::Appearance => "tab-appearance",
+            Self::Playback => "tab-playback",
+            Self::Account => "tab-account",
+        }
+    }
+
+    fn label(self) -> SharedString {
+        match self {
+            Self::Appearance => t!("settings-tab-appearance"),
+            Self::Playback => t!("settings-tab-playback"),
+            Self::Account => t!("settings-tab-account"),
         }
     }
 }
@@ -39,6 +48,7 @@ pub struct SettingsView {
     scrollbar: Entity<Scrollbar>,
     themes_open: bool,
     corners_open: bool,
+    languages_open: bool,
 }
 
 impl SettingsView {
@@ -58,12 +68,13 @@ impl SettingsView {
             scrollbar: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
             themes_open: false,
             corners_open: false,
+            languages_open: false,
         }
     }
 
     fn tabs(&self, cx: &mut Context<Self>) -> impl IntoElement {
         div().flex().gap_1().children(Tab::ALL.map(|tab| {
-            Button::new(SharedString::from(tab.label()))
+            Button::new(tab.id())
                 .label(tab.label())
                 .small()
                 .selected(self.tab == tab)
@@ -71,6 +82,7 @@ impl SettingsView {
                     this.tab = tab;
                     this.themes_open = false;
                     this.corners_open = false;
+                    this.languages_open = false;
                     cx.notify();
                 }))
         }))
@@ -83,6 +95,7 @@ impl SettingsView {
                 self.theme_row(cx).into_any_element(),
                 self.adaptive_row(cx).into_any_element(),
                 self.corners_row(cx).into_any_element(),
+                self.language_row(cx).into_any_element(),
                 self.font_row(cx).into_any_element(),
                 self.auto_hide_row(cx).into_any_element(),
             ]
@@ -109,6 +122,66 @@ impl SettingsView {
             tint: cx.theme().tint,
             ..self.settings.read(cx).look()
         }
+    }
+
+    fn language_row(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = *cx.theme();
+        let muted = theme.muted_foreground;
+        let small = theme.text(Text::Small);
+        let chosen = self.settings.read(cx).language().to_owned();
+        let current = match Language::from_id(&chosen) {
+            Some(language) => SharedString::from(language.label()),
+            None => t!("settings-language-system"),
+        };
+
+        let entries = std::iter::once((i18n::AUTO, t!("settings-language-system"))).chain(
+            Language::ALL
+                .into_iter()
+                .map(|language| (language.id(), SharedString::from(language.label()))),
+        );
+
+        let picker = div()
+            .relative()
+            .child(
+                Button::new("language-picker")
+                    .label(format!("{current}  ▾"))
+                    .small()
+                    .outline()
+                    .on_click(cx.listener(|this, _, _, cx| {
+                        this.languages_open = !this.languages_open;
+                        cx.notify();
+                    })),
+            )
+            .when(self.languages_open, |this| {
+                this.child(
+                    Menu::new("language-dropdown")
+                        .top(px(30.))
+                        .right_0()
+                        .w(px(170.))
+                        .on_dismiss(cx.listener(|this, _, _, cx| {
+                            this.languages_open = false;
+                            cx.notify();
+                        }))
+                        .items(entries.map(|(id, label)| {
+                            MenuItem::new(id, label)
+                                .selected(chosen == id)
+                                .on_click(cx.listener(move |this, _, _, cx| {
+                                    this.settings
+                                        .update(cx, |settings, cx| settings.set_language(id, cx));
+                                    this.languages_open = false;
+                                    cx.notify();
+                                }))
+                        })),
+                )
+            });
+
+        self.row(
+            t!("settings-language"),
+            t!("settings-language-detail"),
+            muted,
+            small,
+            picker.into_any_element(),
+        )
     }
 
     fn corners_row(&self, cx: &mut Context<Self>) -> impl IntoElement {
@@ -157,8 +230,8 @@ impl SettingsView {
             });
 
         self.row(
-            "Corners",
-            "How rounded surfaces and controls are",
+            t!("settings-corners"),
+            t!("settings-corners-detail"),
             muted,
             small,
             picker.into_any_element(),
@@ -201,12 +274,12 @@ impl SettingsView {
             .items_center()
             .gap_2()
             .child(step("font-smaller", "−", -1.))
-            .child(div().child(format!("{:.0} px", look.font)))
+            .child(div().child(t!("settings-font-value", size = look.font.round() as i64)))
             .child(step("font-larger", "+", 1.));
 
         self.row(
-            "Font size",
-            "Base text size, everything else scales with it",
+            t!("settings-font"),
+            t!("settings-font-detail"),
             muted,
             small,
             actions.into_any_element(),
@@ -220,12 +293,15 @@ impl SettingsView {
         let on = self.settings.read(cx).window_controls();
 
         self.row(
-            "Window controls",
-            "Draw minimise, maximise and close in the title bar",
+            t!("settings-window-controls"),
+            t!("settings-window-controls-detail"),
             muted,
             small,
             Button::new("window-controls")
-                .label(if on { "On" } else { "Off" })
+                .label(match on {
+                    true => t!("common-on"),
+                    false => t!("common-off"),
+                })
                 .small()
                 .outline()
                 .on_click(cx.listener(move |this, _, _, cx| {
@@ -245,12 +321,15 @@ impl SettingsView {
         let shown = settings.window_controls();
 
         self.row(
-            "Controls side",
-            "Which end of the title bar the controls sit on",
+            t!("settings-controls-side"),
+            t!("settings-controls-side-detail"),
             muted,
             small,
             Button::new("controls-side")
-                .label(if left { "Left" } else { "Right" })
+                .label(match left {
+                    true => t!("common-left"),
+                    false => t!("common-right"),
+                })
                 .small()
                 .outline()
                 .disabled(!shown)
@@ -269,12 +348,15 @@ impl SettingsView {
         let on = self.settings.read(cx).auto_hide_sidebar();
 
         self.row(
-            "Auto-hide sidebar",
-            "Collapse the sidebar when the window gets narrow",
+            t!("settings-auto-hide"),
+            t!("settings-auto-hide-detail"),
             muted,
             small,
             Button::new("auto-hide-sidebar")
-                .label(if on { "On" } else { "Off" })
+                .label(match on {
+                    true => t!("common-on"),
+                    false => t!("common-off"),
+                })
                 .small()
                 .outline()
                 .on_click(cx.listener(move |this, _, _, cx| {
@@ -376,7 +458,7 @@ impl SettingsView {
             .gap_2()
             .child(
                 Button::new("open-theme-config")
-                    .label("Open config")
+                    .label(t!("settings-theme-config"))
                     .small()
                     .outline()
                     .on_click(move |_, _, cx| {
@@ -389,8 +471,8 @@ impl SettingsView {
             .child(picker);
 
         self.row(
-            "Theme",
-            "Choose the application colour palette",
+            t!("settings-theme"),
+            t!("settings-theme-detail"),
             muted,
             small,
             actions.into_any_element(),
@@ -404,12 +486,15 @@ impl SettingsView {
         let on = self.settings.read(cx).adaptive_theme();
 
         self.row(
-            "Adaptive theme",
-            "Tint the palette with the artwork of the playing album",
+            t!("settings-adaptive"),
+            t!("settings-adaptive-detail"),
             muted,
             small,
             Button::new("adaptive-theme")
-                .label(if on { "On" } else { "Off" })
+                .label(match on {
+                    true => t!("common-on"),
+                    false => t!("common-off"),
+                })
                 .small()
                 .outline()
                 .on_click(cx.listener(move |this, _, _, cx| {
@@ -427,12 +512,15 @@ impl SettingsView {
         let on = self.playback.read(cx).normalisation();
 
         self.row(
-            "Normalise loudness",
-            "Keeps tracks at a consistent volume",
+            t!("settings-normalisation"),
+            t!("settings-normalisation-detail"),
             muted,
             small,
             Button::new("normalisation")
-                .label(if on { "On" } else { "Off" })
+                .label(match on {
+                    true => t!("common-on"),
+                    false => t!("common-off"),
+                })
                 .small()
                 .outline()
                 .on_click(cx.listener(move |this, _, _, cx| {
@@ -450,12 +538,12 @@ impl SettingsView {
         let session = self.session.clone();
 
         self.row(
-            "Account",
-            "Sign out of Spotify on this device",
+            t!("settings-account"),
+            t!("settings-account-detail"),
             muted,
             small,
             Button::new("sign-out")
-                .label("Sign out")
+                .label(t!("settings-sign-out"))
                 .small()
                 .outline()
                 .icon("icons/log-out.svg")
@@ -468,8 +556,8 @@ impl SettingsView {
 
     fn row(
         &self,
-        title: &'static str,
-        detail: &'static str,
+        title: SharedString,
+        detail: SharedString,
         muted: gpui::Hsla,
         small: Pixels,
         action: gpui::AnyElement,

--- a/crates/views/src/song.rs
+++ b/crates/views/src/song.rs
@@ -1,5 +1,6 @@
 use gpui::prelude::*;
-use gpui::{AnyElement, Context, Entity, FontWeight, Render, Window, div, px};
+use gpui::{AnyElement, Context, Entity, FontWeight, Render, SharedString, Window, div, px};
+use i18n::t;
 use router::{Destination, Link as _};
 use spotify::{Credit, Track};
 use state::{Playback, SongDetail};
@@ -18,24 +19,24 @@ pub(crate) struct SongView {
 }
 
 impl SongView {
-    fn language_label(code: &str) -> &str {
+    fn language_label(code: &str) -> SharedString {
         match code {
-            "ar" => "Arabic",
-            "de" => "German",
-            "en" => "English",
-            "es" => "Spanish",
-            "fr" => "French",
-            "hi" => "Hindi",
-            "it" => "Italian",
-            "ja" => "Japanese",
-            "ko" => "Korean",
-            "pt" => "Portuguese",
-            "ru" => "Russian",
-            "tr" => "Turkish",
-            "uk" => "Ukrainian",
-            "zh" => "Chinese",
-            "zxx" => "No linguistic content",
-            _ => code,
+            "ar" => t!("language-ar"),
+            "de" => t!("language-de"),
+            "en" => t!("language-en"),
+            "es" => t!("language-es"),
+            "fr" => t!("language-fr"),
+            "hi" => t!("language-hi"),
+            "it" => t!("language-it"),
+            "ja" => t!("language-ja"),
+            "ko" => t!("language-ko"),
+            "pt" => t!("language-pt"),
+            "ru" => t!("language-ru"),
+            "tr" => t!("language-tr"),
+            "uk" => t!("language-uk"),
+            "zh" => t!("language-zh"),
+            "zxx" => t!("language-zxx"),
+            _ => SharedString::from(code.to_owned()),
         }
     }
 
@@ -90,14 +91,14 @@ impl SongView {
             .gap_3()
             .child(HeroPlayButton::new(
                 "play-song",
-                "Play song",
+                t!("song-play"),
                 vec![track.clone()],
                 self.playback.clone(),
             ))
             .when_some(track.album_id.clone(), |this, album_id| {
                 this.child(
                     Button::new("open-album")
-                        .label("View album")
+                        .label(t!("song-view-album"))
                         .outline()
                         .on_click(move |_, _, cx| {
                             router::navigate(Destination::Album(album_id.clone().into()), cx);
@@ -107,7 +108,7 @@ impl SongView {
 
         PageHero::new("song-hero", track.name.clone())
             .cover(cover)
-            .eyebrow("Song")
+            .eyebrow(t!("song-eyebrow"))
             .meta(meta)
             .actions(actions)
             .explicit(track.explicit)
@@ -122,35 +123,38 @@ impl SongView {
         let release = album
             .map(|detail| detail.album.release_date.clone())
             .unwrap_or_default();
-        let release = if release.is_empty() {
-            "Unknown".to_owned()
-        } else {
-            release_date_label(&release)
+        let release = match release.is_empty() {
+            true => t!("common-unknown"),
+            false => release_date_label(&release),
         };
         let label = album
             .map(|detail| detail.album.label.clone())
             .filter(|value| !value.is_empty())
-            .unwrap_or_else(|| "Not provided".to_owned());
+            .map(SharedString::from)
+            .unwrap_or_else(|| t!("common-not-provided"));
         let number = match (track.disc_number, track.track_number) {
-            (disc, number) if disc > 1 => format!("Disc {disc}, track {number}"),
-            (_, number) if number > 0 => format!("Track {number}"),
-            _ => "Not provided".to_owned(),
+            (disc, number) if disc > 1 => t!("song-disc-track", disc = disc, track = number),
+            (_, number) if number > 0 => t!("song-track", track = number),
+            _ => t!("common-not-provided"),
         };
         let streams = self
             .detail
             .read(cx)
             .playcount()
             .map(cells::count)
-            .unwrap_or_else(|| "Not available".to_owned());
+            .unwrap_or_else(|| t!("common-not-available"));
         let facts = [
-            ("Album", album_name),
-            ("Released", release),
-            ("Streams", streams),
-            ("Position", number),
-            ("Label", label),
-            ("Popularity", format!("{}%", track.popularity)),
+            (t!("song-album"), SharedString::from(album_name)),
+            (t!("song-released"), release),
+            (t!("song-streams"), streams),
+            (t!("song-position"), number),
+            (t!("song-label"), label),
+            (
+                t!("song-popularity"),
+                t!("song-popularity-value", value = track.popularity),
+            ),
         ];
-        InfoCard::new("About this song")
+        InfoCard::new(t!("song-about"))
             .stretch()
             .child(
                 div().flex().flex_col().children(
@@ -170,7 +174,7 @@ impl SongView {
                 .iter()
                 .map(|artist| Credit {
                     name: artist.name.clone(),
-                    role: "Performed by".to_owned(),
+                    role: t!("song-performed-by").to_string(),
                     id: artist.id.clone(),
                 })
                 .collect()
@@ -178,7 +182,7 @@ impl SongView {
             track.credits.clone()
         };
         let portraits = self.detail.read(cx).portraits().clone();
-        InfoCard::new("Credits")
+        InfoCard::new(t!("song-credits"))
             .child(
                 div()
                     .flex()
@@ -233,17 +237,18 @@ impl SongView {
     fn discovery(&self, track: &Track, cx: &Context<Self>) -> AnyElement {
         let theme = *cx.theme();
         let tags = track.tags.clone();
-        let languages = if track.languages.is_empty() {
-            "Not provided".to_owned()
-        } else {
-            track
-                .languages
-                .iter()
-                .map(|language| Self::language_label(language))
-                .collect::<Vec<_>>()
-                .join(", ")
+        let languages = match track.languages.is_empty() {
+            true => t!("common-not-provided"),
+            false => SharedString::from(
+                track
+                    .languages
+                    .iter()
+                    .map(|language| Self::language_label(language))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            ),
         };
-        InfoCard::new("Genres & details")
+        InfoCard::new(t!("song-details"))
             .child(
                 div()
                     .flex()
@@ -251,7 +256,7 @@ impl SongView {
                     .gap_1()
                     .child(div().when_else(
                         tags.is_empty(),
-                        |this| this.child(Fact::new("Genres", "Not available")),
+                        |this| this.child(Fact::new(t!("song-genres"), t!("common-not-available"))),
                         |this| {
                             this.child(
                                 div()
@@ -265,7 +270,7 @@ impl SongView {
                                         div()
                                             .flex_none()
                                             .text_color(theme.muted_foreground)
-                                            .child("Genres"),
+                                            .child(t!("song-genres")),
                                     )
                                     .child(
                                         div()
@@ -290,12 +295,12 @@ impl SongView {
                             )
                         },
                     ))
-                    .child(Fact::new("Language", languages).striped(true))
+                    .child(Fact::new(t!("song-language"), languages).striped(true))
                     .child(Fact::new(
-                        "Content",
+                        t!("song-content"),
                         match track.explicit {
-                            true => "Explicit",
-                            false => "Clean",
+                            true => t!("song-explicit"),
+                            false => t!("song-clean"),
                         },
                     )),
             )
@@ -310,7 +315,7 @@ impl SongView {
         let bio = artist
             .biography
             .clone()
-            .unwrap_or_else(|| "Explore the artist's popular songs and releases.".to_owned());
+            .unwrap_or_else(|| t!("song-artist-fallback").to_string());
         let bio = if bio.chars().count() > 360 {
             format!("{}…", bio.chars().take(360).collect::<String>())
         } else {
@@ -341,7 +346,7 @@ impl SongView {
                         .flex_1()
                         .min_w_0()
                         .gap_2()
-                        .child(eyebrow("About the artist", cx))
+                        .child(eyebrow(t!("song-about-artist"), cx))
                         .child(heading(artist.name.clone(), cx))
                         .child(div().text_color(theme.muted_foreground).child(bio)),
                 )
@@ -384,7 +389,7 @@ impl Render for SongView {
                             div()
                                 .py_8()
                                 .text_color(theme.muted_foreground)
-                                .child("Loading song information…"),
+                                .child(t!("song-loading")),
                         )
                     })
                     .when_some(error, |this, error| {
@@ -426,8 +431,8 @@ impl Render for SongView {
                                     .cloned(),
                                 |this, copyright| {
                                     let copyright = match copyright.starts_with(['©', '℗']) {
-                                        true => copyright,
-                                        false => format!("© {copyright}"),
+                                        true => SharedString::from(copyright),
+                                        false => t!("song-copyright", notice = copyright),
                                     };
                                     this.child(
                                         div()

--- a/crates/views/src/tracks.rs
+++ b/crates/views/src/tracks.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 use ui::ActiveTheme as _;
 
 use gpui::{AnyElement, App, ClipboardItem, Entity, Hsla, Styled as _, TextAlign, WeakEntity};
+use i18n::t;
 use jiff::Timestamp;
 use router::{Destination, navigate};
 use spotify::Track;
@@ -12,6 +13,7 @@ use ui::{
 };
 
 use crate::cells::{self, ALWAYS, DATE, NUMBER, ROOMY, SNUG, TRAILING, WIDE};
+use crate::hero::release_date_label;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TrackField {
@@ -29,7 +31,7 @@ pub(crate) const LIBRARY_COLUMNS: &[ColumnSpec<TrackField>] = &[
     ColumnSpec {
         field: TrackField::Index,
         key: "index",
-        header: "#",
+        header: "column-index",
         align: TextAlign::Center,
         width: Width::Fixed(NUMBER),
         flush: false,
@@ -49,7 +51,7 @@ pub(crate) const LIBRARY_COLUMNS: &[ColumnSpec<TrackField>] = &[
     ColumnSpec {
         field: TrackField::Title,
         key: "title",
-        header: "Title",
+        header: "column-title",
         align: TextAlign::Left,
         width: Width::Fill(0.42),
         flush: false,
@@ -59,7 +61,7 @@ pub(crate) const LIBRARY_COLUMNS: &[ColumnSpec<TrackField>] = &[
     ColumnSpec {
         field: TrackField::Artists,
         key: "artists",
-        header: "Artist",
+        header: "column-artist",
         align: TextAlign::Left,
         width: Width::Fill(0.29),
         flush: false,
@@ -69,7 +71,7 @@ pub(crate) const LIBRARY_COLUMNS: &[ColumnSpec<TrackField>] = &[
     ColumnSpec {
         field: TrackField::Album,
         key: "album",
-        header: "Album",
+        header: "column-album",
         align: TextAlign::Left,
         width: Width::Fill(0.29),
         flush: false,
@@ -79,7 +81,7 @@ pub(crate) const LIBRARY_COLUMNS: &[ColumnSpec<TrackField>] = &[
     ColumnSpec {
         field: TrackField::AddedAt,
         key: "added-at",
-        header: "Date added",
+        header: "column-date-added",
         align: TextAlign::Left,
         width: Width::Fixed(DATE),
         flush: false,
@@ -89,7 +91,7 @@ pub(crate) const LIBRARY_COLUMNS: &[ColumnSpec<TrackField>] = &[
     ColumnSpec {
         field: TrackField::Duration,
         key: "duration",
-        header: "Length",
+        header: "column-length",
         align: TextAlign::Right,
         width: Width::Fixed(TRAILING),
         flush: false,
@@ -102,7 +104,7 @@ pub(crate) const ALBUM_COLUMNS: &[ColumnSpec<TrackField>] = &[
     ColumnSpec {
         field: TrackField::Index,
         key: "index",
-        header: "#",
+        header: "column-index",
         align: TextAlign::Center,
         width: Width::Fixed(NUMBER),
         flush: false,
@@ -112,7 +114,7 @@ pub(crate) const ALBUM_COLUMNS: &[ColumnSpec<TrackField>] = &[
     ColumnSpec {
         field: TrackField::Title,
         key: "title",
-        header: "Title",
+        header: "column-title",
         align: TextAlign::Left,
         width: Width::Fill(0.62),
         flush: false,
@@ -122,7 +124,7 @@ pub(crate) const ALBUM_COLUMNS: &[ColumnSpec<TrackField>] = &[
     ColumnSpec {
         field: TrackField::Artists,
         key: "artists",
-        header: "Artist",
+        header: "column-artist",
         align: TextAlign::Left,
         width: Width::Fill(0.38),
         flush: false,
@@ -132,7 +134,7 @@ pub(crate) const ALBUM_COLUMNS: &[ColumnSpec<TrackField>] = &[
     ColumnSpec {
         field: TrackField::Plays,
         key: "plays",
-        header: "Plays",
+        header: "column-plays",
         align: TextAlign::Left,
         width: Width::Fixed(DATE),
         flush: false,
@@ -142,7 +144,7 @@ pub(crate) const ALBUM_COLUMNS: &[ColumnSpec<TrackField>] = &[
     ColumnSpec {
         field: TrackField::Duration,
         key: "duration",
-        header: "Length",
+        header: "column-length",
         align: TextAlign::Right,
         width: Width::Fixed(TRAILING),
         flush: false,
@@ -190,14 +192,14 @@ impl TrackMenu {
         let playlist_menu = if playlists.is_empty() {
             Menu::new("playlist-submenu")
                 .w(gpui::px(220.))
-                .item(MenuItem::new("no-playlists", "No playlists").disabled())
+                .item(MenuItem::new("no-playlists", t!("menu-no-playlists")).disabled())
         } else {
             Menu::new("playlist-submenu")
                 .w(gpui::px(220.))
                 .max_h(gpui::px(360.))
                 .scrollbar(self.playlist_scrollbar.clone())
                 .item(
-                    MenuItem::new("new-playlist", "New playlist")
+                    MenuItem::new("new-playlist", t!("menu-new-playlist"))
                         .icon("icons/plus.svg")
                         .disabled(),
                 )
@@ -209,36 +211,36 @@ impl TrackMenu {
                 }))
         };
         let copy = match track.id.clone() {
-            Some(id) => MenuItem::new("copy-track-link", "Copy link")
+            Some(id) => MenuItem::new("copy-track-link", t!("menu-copy-link"))
                 .icon("icons/link.svg")
                 .on_click(move |_, _, cx| {
                     cx.write_to_clipboard(ClipboardItem::new_string(format!(
                         "https://open.spotify.com/track/{id}"
                     )));
                 }),
-            None => MenuItem::new("copy-track-link", "Copy link")
+            None => MenuItem::new("copy-track-link", t!("menu-copy-link"))
                 .icon("icons/link.svg")
                 .disabled(),
         };
         let queue = match track.playable {
             true => {
                 let track = track.clone();
-                MenuItem::new("add-to-queue", "Add to queue")
+                MenuItem::new("add-to-queue", t!("menu-add-to-queue"))
                     .icon("icons/list-end.svg")
                     .on_click(move |_, _, cx| {
                         let queue = Sonora::global(cx).queue.clone();
                         queue.update(cx, |queue, cx| queue.append(track.clone(), cx));
                     })
             }
-            false => MenuItem::new("add-to-queue", "Add to queue")
+            false => MenuItem::new("add-to-queue", t!("menu-add-to-queue"))
                 .icon("icons/list-end.svg")
                 .disabled(),
         };
         let details = match track.id.clone() {
-            Some(id) => MenuItem::new("view-details", "View details")
+            Some(id) => MenuItem::new("view-details", t!("menu-view-details"))
                 .icon("icons/info.svg")
                 .on_click(move |_, _, cx| navigate(Destination::Song(id.clone().into()), cx)),
-            None => MenuItem::new("view-details", "View details")
+            None => MenuItem::new("view-details", t!("menu-view-details"))
                 .icon("icons/info.svg")
                 .disabled(),
         };
@@ -247,18 +249,18 @@ impl TrackMenu {
             .relative()
             .w(gpui::px(210.))
             .item(
-                MenuItem::new("add-to-playlist", "Add to playlist")
+                MenuItem::new("add-to-playlist", t!("menu-add-to-playlist"))
                     .icon("icons/list-plus.svg")
                     .submenu(playlist_menu, self.playlist_submenu.clone()),
             )
             .item(
-                MenuItem::new("toggle-library", "Add/Remove to Library")
+                MenuItem::new("toggle-library", t!("menu-toggle-library"))
                     .icon("icons/heart.svg")
                     .disabled(),
             )
             .item(queue)
             .item(
-                MenuItem::new("song-radio", "Go to song radio")
+                MenuItem::new("song-radio", t!("menu-song-radio"))
                     .icon("icons/radio.svg")
                     .disabled(),
             )
@@ -430,7 +432,9 @@ impl GridSource for TrackSource {
                 track
                     .added_at
                     .and_then(|seconds| Timestamp::new(seconds, 0).ok())
-                    .map(|timestamp| timestamp.strftime("%b %-d, %Y").to_string())
+                    .map(|timestamp| {
+                        release_date_label(&timestamp.strftime("%Y-%m-%d").to_string())
+                    })
                     .unwrap_or_default(),
                 detail,
             ),

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 gpui.workspace = true
+i18n.workspace = true
 state.workspace = true
 input.workspace = true
 router.workspace = true

--- a/crates/workspace/src/player_bar.rs
+++ b/crates/workspace/src/player_bar.rs
@@ -5,6 +5,7 @@ use ui::ActiveTheme as _;
 use gpui::prelude::*;
 use gpui::{Context, Entity, MouseMoveEvent, MouseUpEvent, Pixels, Render, SharedString};
 use gpui::{Window, div, px};
+use i18n::t;
 use state::{Playback, PlaybackState, Queue, Repeat};
 
 use ui::{Artwork, Button, InlineLink, InlineLinks, Room, Scrubber, ScrubberState, clock};
@@ -288,7 +289,7 @@ impl PlayerBar {
                                     .truncate(),
                                 None => div()
                                     .id("now-playing-album")
-                                    .child("Nothing playing")
+                                    .child(t!("player-nothing-playing"))
                                     .min_w_0()
                                     .text_color(muted)
                                     .truncate(),
@@ -333,7 +334,7 @@ fn volume_icon(level: f32) -> &'static str {
 }
 
 fn percent(fraction: f32) -> SharedString {
-    SharedString::from(format!("{}%", (fraction * 100.).round()))
+    t!("player-percent", value = (fraction * 100.).round())
 }
 
 impl Render for PlayerBar {

--- a/crates/workspace/src/searchable.rs
+++ b/crates/workspace/src/searchable.rs
@@ -1,5 +1,6 @@
 use gpui::prelude::*;
-use gpui::{AnyView, App, Context, Entity, Pixels, Render, Window, div, px};
+use gpui::{AnyView, App, Context, Entity, Pixels, Render, SharedString, Window, div, px};
+use i18n::t;
 use input::{Dismiss, Input};
 use ui::Button;
 
@@ -12,8 +13,8 @@ pub trait Searchable: 'static {
     where
         Self: Sized;
 
-    fn hint() -> &'static str {
-        "Search"
+    fn hint() -> SharedString {
+        t!("common-search")
     }
 }
 
@@ -68,7 +69,7 @@ impl Filter {
 
     pub fn release(&mut self, cx: &mut Context<Self>) {
         self.clear(cx);
-        self.reset("Search", cx);
+        self.reset(t!("common-search"), cx);
     }
 
     pub fn focus(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -105,7 +106,7 @@ impl Filter {
         self.input.update(cx, |input, cx| input.set_text("", cx));
     }
 
-    fn reset(&mut self, hint: &'static str, cx: &mut Context<Self>) {
+    fn reset(&mut self, hint: SharedString, cx: &mut Context<Self>) {
         self.input.update(cx, |input, cx| {
             input.set_placeholder(hint, cx);
             input.set_text("", cx);

--- a/crates/workspace/src/sidebar_left.rs
+++ b/crates/workspace/src/sidebar_left.rs
@@ -11,24 +11,24 @@ use router::{Destination, LibraryTab, Navigation, NavigationEvent, navigate};
 use state::{AppSettings, Sonora};
 
 const NAV: [(&str, &str, Option<Destination>); 4] = [
-    ("Home", "icons/house.svg", Some(Destination::Home)),
-    ("Search", "icons/search.svg", Some(Destination::Search)),
+    ("nav-home", "icons/house.svg", Some(Destination::Home)),
+    ("nav-search", "icons/search.svg", Some(Destination::Search)),
     (
-        "Your Library",
+        "nav-library",
         "icons/library-big.svg",
         Some(Destination::Library(LibraryTab::Songs)),
     ),
     (
-        "Settings",
+        "nav-settings",
         "icons/settings.svg",
         Some(Destination::Settings),
     ),
 ];
 
 const TABS: [(&str, LibraryTab); 3] = [
-    ("Songs", LibraryTab::Songs),
-    ("Albums", LibraryTab::Albums),
-    ("Playlists", LibraryTab::Playlists),
+    ("nav-songs", LibraryTab::Songs),
+    ("nav-albums", LibraryTab::Albums),
+    ("nav-playlists", LibraryTab::Playlists),
 ];
 
 const MIN_WIDTH: Pixels = px(130.);
@@ -138,7 +138,7 @@ impl Render for Sidebar {
         self.adapt(window, cx);
 
         let mut rows: Vec<AnyElement> = Vec::new();
-        for (index, (label, icon, destination)) in NAV.into_iter().enumerate() {
+        for (index, (key, icon, destination)) in NAV.into_iter().enumerate() {
             if matches!(destination, Some(Destination::Library(_))) {
                 let inside = matches!(current, Destination::Library(_));
                 let text = if inside { foreground } else { muted };
@@ -146,7 +146,7 @@ impl Render for Sidebar {
                 let target = link_destination.unwrap_or(current.clone());
 
                 rows.push(
-                    nav_row(index, label, text, sidebar_accent)
+                    nav_row(index, key, text, sidebar_accent)
                         .icon(icon)
                         .on_click(cx.listener(move |this, _, _, cx| match inside {
                             true => {
@@ -216,7 +216,7 @@ impl Render for Sidebar {
             let text = if active { foreground } else { muted };
 
             rows.push(
-                nav_row(index, label, text, sidebar_accent)
+                nav_row(index, key, text, sidebar_accent)
                     .icon(icon)
                     .when(active, |button| button.bg(sidebar_accent))
                     .when_some(destination, |button, destination| {
@@ -300,10 +300,10 @@ impl Render for Sidebar {
     }
 }
 
-fn nav_row(id: impl Into<ElementId>, label: &'static str, tint: Hsla, accent: Hsla) -> Button {
+fn nav_row(id: impl Into<ElementId>, key: &'static str, tint: Hsla, accent: Hsla) -> Button {
     Button::new(id)
         .ghost()
-        .label(label)
+        .label(i18n::lookup(key, None))
         .tint(tint)
         .gap_2p5()
         .justify_start()

--- a/crates/workspace/src/sidebar_right.rs
+++ b/crates/workspace/src/sidebar_right.rs
@@ -8,6 +8,7 @@ use gpui::{
     Pixels, Point, Render, ScrollStrategy, SharedString, UniformListScrollHandle, Window, anchored,
     div, px, uniform_list,
 };
+use i18n::t;
 use spotify::Track;
 use state::{AppSettings, Playback, Queue, Sonora};
 use ui::{ActiveTheme as _, Button, Card, Menu, MenuItem, Room, Scrollbar, eyebrow, snapped};
@@ -23,7 +24,7 @@ fn fills_content(width: Pixels) -> bool {
     !Room::of(width).fits(Room::Wide)
 }
 
-fn section_label(label: &'static str, window: &Window, cx: &App) -> Div {
+fn section_label(key: &'static str, window: &Window, cx: &App) -> Div {
     div()
         .flex()
         .flex_none()
@@ -31,7 +32,7 @@ fn section_label(label: &'static str, window: &Window, cx: &App) -> Div {
         .h(snapped(cx.theme().metrics.list_row, window))
         .px_2()
         .pb_1()
-        .child(eyebrow(label, cx))
+        .child(eyebrow(i18n::lookup(key, None), cx))
 }
 
 fn track(queue: &Queue, position: QueuePosition) -> Option<Track> {
@@ -104,18 +105,18 @@ impl Sections {
     fn slot(self, index: usize) -> Slot {
         if index < self.past_end() {
             return match index {
-                0 => Slot::Header("History"),
+                0 => Slot::Header("queue-history"),
                 _ => Slot::Track(QueuePosition::Past(index - 1)),
             };
         }
         if index < self.current_end() {
             return match index == self.past_end() {
-                true => Slot::Header("Now playing"),
+                true => Slot::Header("queue-now-playing"),
                 false => Slot::Track(QueuePosition::Current),
             };
         }
         match index == self.current_end() {
-            true => Slot::Header("Up next"),
+            true => Slot::Header("queue-up-next"),
             false => Slot::Track(QueuePosition::Upcoming(index - self.current_end() - 1)),
         }
     }
@@ -437,7 +438,7 @@ impl QueuePanel {
                         .on_action(cx.listener(|this, _, _, cx| this.dismiss_menu(cx)))
                         .on_dismiss(cx.listener(|this, _, _, cx| this.dismiss_menu(cx)))
                         .item(
-                            MenuItem::new("remove-queued-track", "Remove from queue")
+                            MenuItem::new("remove-queued-track", t!("menu-remove-from-queue"))
                                 .icon("icons/x.svg")
                                 .on_click(cx.listener(move |this, _, _, cx| {
                                     this.queue.update(cx, |queue, cx| {
@@ -464,7 +465,7 @@ impl QueuePanel {
             .px_2()
             .border_b_1()
             .border_color(theme.border)
-            .child(eyebrow("Queue", cx))
+            .child(eyebrow(t!("queue-title"), cx))
             .child(
                 div()
                     .flex()
@@ -488,7 +489,7 @@ impl QueuePanel {
                         Button::new("reset-queue")
                             .ghost()
                             .small()
-                            .label("Reset")
+                            .label(t!("queue-reset"))
                             .tint(theme.muted_foreground)
                             .disabled(!self.queue.read(cx).reordered())
                             .on_click(cx.listener(|this, _, _, cx| {
@@ -499,7 +500,7 @@ impl QueuePanel {
                         Button::new("clear-queue")
                             .ghost()
                             .small()
-                            .label("Clear")
+                            .label(t!("queue-clear"))
                             .tint(theme.muted_foreground)
                             .disabled(sections.upcoming == 0)
                             .on_click(cx.listener(|this, _, _, cx| {
@@ -556,9 +557,7 @@ impl QueuePanel {
                 slots
                     .into_iter()
                     .map(|(index, slot, found)| match (slot, found) {
-                        (Slot::Header(label), _) => {
-                            section_label(label, window, cx).into_any_element()
-                        }
+                        (Slot::Header(key), _) => section_label(key, window, cx).into_any_element(),
                         (Slot::Track(position), Some(found)) => {
                             let drop_line = match (position.upcoming(), drop_gap) {
                                 (Some(queued), Some(gap)) if gap == queued => Some(DropLine::Above),
@@ -641,7 +640,7 @@ impl Render for QueuePanel {
                                 .items_center()
                                 .justify_center()
                                 .text_color(theme.muted_foreground)
-                                .child("Your queue is empty"),
+                                .child(t!("queue-empty")),
                         )
                     })
                     .when(!empty, |this| {
@@ -694,12 +693,12 @@ mod tests {
         assert_eq!(
             slots(sections),
             [
-                Slot::Header("History"),
+                Slot::Header("queue-history"),
                 Slot::Track(QueuePosition::Past(0)),
                 Slot::Track(QueuePosition::Past(1)),
-                Slot::Header("Now playing"),
+                Slot::Header("queue-now-playing"),
                 Slot::Track(QueuePosition::Current),
-                Slot::Header("Up next"),
+                Slot::Header("queue-up-next"),
                 Slot::Track(QueuePosition::Upcoming(0)),
                 Slot::Track(QueuePosition::Upcoming(1)),
             ]
@@ -718,9 +717,9 @@ mod tests {
         assert_eq!(
             slots(sections),
             [
-                Slot::Header("Now playing"),
+                Slot::Header("queue-now-playing"),
                 Slot::Track(QueuePosition::Current),
-                Slot::Header("Up next"),
+                Slot::Header("queue-up-next"),
                 Slot::Track(QueuePosition::Upcoming(0)),
             ]
         );
@@ -737,7 +736,10 @@ mod tests {
         assert_eq!(sections.current_index(), None);
         assert_eq!(
             slots(sections),
-            [Slot::Header("History"), Slot::Track(QueuePosition::Past(0))]
+            [
+                Slot::Header("queue-history"),
+                Slot::Track(QueuePosition::Past(0))
+            ]
         );
     }
 


### PR DESCRIPTION
## What changed

- Add a leaf `i18n` crate wrapping Fluent, exposing a `t!("key", arg = value)` macro that needs no `cx`.
- Move all 294 user-facing string sites in `ui`, `views`, `workspace`, `state` and `sonora` behind Fluent keys.
- Ship en-US, ru, uk and pl locales at 184 keys each, with real plural selectors rather than interpolated counts.
- Add a `language` setting that defaults to the system locale, with a picker in the Appearance tab.
- Resolve theme, corner, column and queue-section labels through keys instead of hardcoded literals.

## Why

Every visible string was a Rust literal, so the app could only ever ship in English. Fluent was chosen
over a plain key-value table because Russian, Ukrainian and Polish each have four plural categories
where English has two, and counts like "{n} songs" cannot be expressed correctly by interpolation
alone.

## User impact

The interface can be switched between English, Russian, Ukrainian and Polish from Settings, defaulting
to the system locale on first run. Changing it re-renders open windows immediately, and counts, dates
and thousands separators follow the selected language rather than English conventions.

## Notes

`ColumnSpec.header` and `Slot::Header` now hold a key rather than a label, and `state::detail::Header.kind`
became a `Collection` enum so the view derives both the eyebrow and the play-button label from it.

Developer-facing text is deliberately untouched: `anyhow` contexts, `log::*`, and everything in
`spotify` and `audio`, whose uppercase strings are wire protocol values rather than UI.

The macOS app menu is built once at startup, so it keeps its launch language until restart. It is not
shown on Linux.

## Validation

- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace`

All run after merging `main` into the branch, and all clean. Tests assert that every locale defines
the same key set, that no message is value-less, and that ru/uk/pl plural categories render the
expected forms.

The GUI was not run. No on-screen layout has been checked, so it is not known whether the longer
Russian and Polish strings fit the sidebar, settings rows, column headers or player bar;
`settings-window-controls-detail` and `settings-auto-hide-detail` are the most likely to overflow.
The translations have not been reviewed by a native speaker.
