### PR TITLE
fix(i18n): resolve input placeholders at render time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,10 @@ i18n::lookup(key, None)                              // when the key is a runtim
 - Dates are assembled from `month-1`..`month-12` plus `date-full`, never `strftime`.
 - A missing key logs `i18n: … is missing` and falls back to English, then to the key itself.
 - `ColumnSpec::header` and `Slot::Header` hold a **key**, not a label; call `ColumnSpec::label()`.
+- **Never call `t!` in a constructor.** Anything stored on a struct and rendered later must hold the
+  key and resolve in `render`, or it freezes in whatever language was active at construction and
+  never follows a language change. `Input::new`/`set_hint` and `Searchable::hint()` take keys for
+  exactly this reason.
 - Developer-facing text — `.context("cannot …")`, `log::warn!`, `PlaybackState::Failed` — stays
   in English. So do wire values in `crates/spotify`.
 - The language lives in `settings.json` (`language`, default `"auto"`). Changing it calls

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3306,6 +3306,7 @@ name = "input"
 version = "0.1.0"
 dependencies = [
  "gpui",
+ "i18n",
  "ui",
 ]
 

--- a/crates/input/Cargo.toml
+++ b/crates/input/Cargo.toml
@@ -5,4 +5,5 @@ edition.workspace = true
 
 [dependencies]
 gpui.workspace = true
+i18n.workspace = true
 ui.workspace = true

--- a/crates/input/src/text.rs
+++ b/crates/input/src/text.rs
@@ -103,7 +103,7 @@ fn offset_to_utf16(text: &str, offset: usize) -> usize {
 
 pub struct Input {
     focus_handle: FocusHandle,
-    placeholder: SharedString,
+    hint: SharedString,
     icon: Option<SharedString>,
     compact: bool,
     content: SharedString,
@@ -116,10 +116,10 @@ pub struct Input {
 }
 
 impl Input {
-    pub fn new(placeholder: impl Into<SharedString>, cx: &mut Context<Self>) -> Self {
+    pub fn new(hint: impl Into<SharedString>, cx: &mut Context<Self>) -> Self {
         Self {
             focus_handle: cx.focus_handle(),
-            placeholder: placeholder.into(),
+            hint: hint.into(),
             icon: None,
             compact: false,
             content: SharedString::default(),
@@ -146,13 +146,16 @@ impl Input {
         &self.content
     }
 
-    pub fn set_placeholder(
-        &mut self,
-        placeholder: impl Into<SharedString>,
-        cx: &mut Context<Self>,
-    ) {
-        self.placeholder = placeholder.into();
+    pub fn set_hint(&mut self, hint: impl Into<SharedString>, cx: &mut Context<Self>) {
+        self.hint = hint.into();
         cx.notify();
+    }
+
+    fn placeholder(&self) -> SharedString {
+        match self.hint.is_empty() {
+            true => SharedString::default(),
+            false => i18n::lookup(&self.hint, None),
+        }
     }
 
     pub fn set_text(&mut self, text: impl Into<SharedString>, cx: &mut Context<Self>) {
@@ -541,7 +544,7 @@ impl Element for Text {
         let style = window.text_style();
 
         let (text, color) = match empty {
-            true => (input.placeholder.clone(), theme.muted_foreground),
+            true => (input.placeholder(), theme.muted_foreground),
             false => (input.content.clone(), style.color),
         };
 

--- a/crates/views/src/detail.rs
+++ b/crates/views/src/detail.rs
@@ -204,6 +204,6 @@ impl Searchable for DetailView {
     }
 
     fn hint() -> SharedString {
-        t!("filter-album")
+        "filter-album".into()
     }
 }

--- a/crates/views/src/library/mod.rs
+++ b/crates/views/src/library/mod.rs
@@ -3,7 +3,6 @@ mod playlists;
 
 use gpui::prelude::*;
 use gpui::{App, Context, Entity, Pixels, Point, Render, ScrollHandle, SharedString, Window, px};
-use i18n::t;
 use router::{Destination, LibraryTab, navigate};
 use spotify::Track;
 use state::{AppSettings, Library, LibraryState, Playback, Sonora};
@@ -391,6 +390,6 @@ impl Searchable for LibraryView {
     }
 
     fn hint() -> SharedString {
-        t!("filter-library")
+        "filter-library".into()
     }
 }

--- a/crates/views/src/search.rs
+++ b/crates/views/src/search.rs
@@ -38,7 +38,7 @@ impl SearchView {
         playback: Entity<Playback>,
         cx: &mut Context<Self>,
     ) -> Self {
-        let input = cx.new(|cx| Input::new(t!("search-placeholder"), cx).icon("icons/search.svg"));
+        let input = cx.new(|cx| Input::new("search-placeholder", cx).icon("icons/search.svg"));
 
         cx.observe(&input, |this, input, cx| {
             let query = input.read(cx).text().to_owned();

--- a/crates/workspace/src/searchable.rs
+++ b/crates/workspace/src/searchable.rs
@@ -1,6 +1,5 @@
 use gpui::prelude::*;
 use gpui::{AnyView, App, Context, Entity, Pixels, Render, SharedString, Window, div, px};
-use i18n::t;
 use input::{Dismiss, Input};
 use ui::Button;
 
@@ -14,7 +13,7 @@ pub trait Searchable: 'static {
         Self: Sized;
 
     fn hint() -> SharedString {
-        t!("common-search")
+        "common-search".into()
     }
 }
 
@@ -69,7 +68,7 @@ impl Filter {
 
     pub fn release(&mut self, cx: &mut Context<Self>) {
         self.clear(cx);
-        self.reset(t!("common-search"), cx);
+        self.reset("common-search".into(), cx);
     }
 
     pub fn focus(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -108,7 +107,7 @@ impl Filter {
 
     fn reset(&mut self, hint: SharedString, cx: &mut Context<Self>) {
         self.input.update(cx, |input, cx| {
-            input.set_placeholder(hint, cx);
+            input.set_hint(hint, cx);
             input.set_text("", cx);
         });
         cx.notify();


### PR DESCRIPTION
## What changed

- Store a Fluent key on `Input` and resolve it in `render` instead of resolving once in the constructor.
- Rename `Input::set_placeholder` to `set_hint` and make `Searchable::hint()` and its three implementations return keys rather than resolved text.
- Fix `Filter::release`, which passed already-translated text where a key is now expected.

## Why

`SearchView::new` built its input with `Input::new(t!("search-placeholder"), cx)`, so the placeholder
was translated once at construction and stored as plain text. Every other string in the app resolves
`t!` inside `render`, which is why the sidebar follows a language change and the search field did not:
`cx.refresh_windows()` repaints, but repainting cannot re-run a constructor. The bug was invisible at
startup because the locale is applied before any view exists, and only appeared after switching
language at runtime.

## User impact

Switching the interface language now updates the search field placeholder and the title-bar filter
hint immediately, along with everything else, instead of leaving them in the language the app was
launched in.

## Notes

`input` gains a dependency on `i18n`, which is legal because `i18n` is a leaf crate.

Every `t!` call in the tree was checked for this same pattern; this was the only one sitting inside a
constructor. CLAUDE.md now forbids calling `t!` in a constructor so the class of bug does not recur.

## Validation

- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace`

All clean. The four hint keys (`search-placeholder`, `common-search`, `filter-album`,
`filter-library`) were confirmed present in the ru bundle.

No automated test covers this: the behaviour is a runtime language switch followed by a repaint, and
the project has no UI test harness. The on-screen before/after was not verified.
