### PR TITLE
build: ship bare executables, a macos disk image and app icons

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,11 +40,10 @@ jobs:
         shell: bash
         run: |
           case "$GITHUB_REF" in
-            refs/tags/*) version="$GITHUB_REF_NAME"; number="${GITHUB_REF_NAME#v}" ;;
-            *) version="$(git rev-parse --short HEAD)"; number="0.0.0" ;;
+            refs/tags/*) version="$GITHUB_REF_NAME" ;;
+            *) version="$(git rev-parse --short HEAD)" ;;
           esac
-          echo "name=sonora-$version-${{ matrix.target }}" >> "$GITHUB_OUTPUT"
-          echo "number=$number" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: system dependencies
         if: runner.os == 'Linux'
@@ -67,51 +66,96 @@ jobs:
       - name: build
         run: cargo build --release --locked --package sonora --target ${{ matrix.target }}
 
-      - name: package
-        if: runner.os == 'Linux'
+      - name: stage the executable
         shell: bash
         env:
-          NAME: ${{ steps.meta.outputs.name }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          TARGET: ${{ matrix.target }}
         run: |
-          mkdir -p dist stage
-          cp "target/${{ matrix.target }}/release/sonora" stage/
-          cp assets/linux/sonora.desktop stage/
-          tar czf "dist/$NAME.tar.gz" -C stage .
-          cd dist && shasum -a 256 "$NAME.tar.gz" > "$NAME.tar.gz.sha256"
-
-      - name: package
-        if: runner.os == 'macOS'
-        shell: bash
-        env:
-          NAME: ${{ steps.meta.outputs.name }}
-          NUMBER: ${{ steps.meta.outputs.number }}
-        run: |
-          mkdir -p dist stage/sonora.app/Contents/MacOS
-          cp "target/${{ matrix.target }}/release/sonora" stage/sonora.app/Contents/MacOS/
-          sed "s/@VERSION@/$NUMBER/g" assets/macos/Info.plist \
-            > stage/sonora.app/Contents/Info.plist
-          tar czf "dist/$NAME.tar.gz" -C stage sonora.app
-          cd dist && shasum -a 256 "$NAME.tar.gz" > "$NAME.tar.gz.sha256"
-
-      - name: package
-        if: runner.os == 'Windows'
-        shell: pwsh
-        env:
-          NAME: ${{ steps.meta.outputs.name }}
-        run: |
-          New-Item -ItemType Directory -Force dist | Out-Null
-          Compress-Archive -Path "target/${{ matrix.target }}/release/sonora.exe" -DestinationPath "dist/$env:NAME.zip"
-          $hash = (Get-FileHash "dist/$env:NAME.zip" -Algorithm SHA256).Hash.ToLower()
-          "$hash  $env:NAME.zip" | Out-File -Encoding ascii "dist/$env:NAME.zip.sha256"
+          set -euo pipefail
+          mkdir -p dist
+          case "$RUNNER_OS" in
+            macOS)   cp "target/$TARGET/release/sonora" "dist/sonora-$TARGET" ;;
+            Windows) cp "target/$TARGET/release/sonora.exe" "dist/sonora-$VERSION-$TARGET.exe" ;;
+            *)       cp "target/$TARGET/release/sonora" "dist/sonora-$VERSION-$TARGET" ;;
+          esac
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.meta.outputs.name }}
+          name: "${{ runner.os == 'macOS' && format('darwin-{0}', matrix.target) || format('release-{0}', matrix.target) }}"
+          path: dist/*
+          if-no-files-found: error
+
+  bundle:
+    name: macos app bundle
+    needs: build
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: name the artifact
+        id: meta
+        shell: bash
+        run: |
+          case "$GITHUB_REF" in
+            refs/tags/*) version="$GITHUB_REF_NAME"; number="${GITHUB_REF_NAME#v}" ;;
+            *) version="$(git rev-parse --short HEAD)"; number="0.0.0" ;;
+          esac
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: darwin-*
+          path: darwin
+          merge-multiple: true
+
+      - name: assemble the bundle
+        shell: bash
+        env:
+          NUMBER: ${{ steps.meta.outputs.number }}
+        run: |
+          set -euo pipefail
+          mkdir -p Sonora.app/Contents/MacOS Sonora.app/Contents/Resources
+          lipo -create -output Sonora.app/Contents/MacOS/sonora \
+            darwin/sonora-aarch64-apple-darwin \
+            darwin/sonora-x86_64-apple-darwin
+          chmod +x Sonora.app/Contents/MacOS/sonora
+          lipo -info Sonora.app/Contents/MacOS/sonora
+          cp assets/macos/sonora.icns Sonora.app/Contents/Resources/
+          sed "s/@VERSION@/$NUMBER/g" assets/macos/Info.plist > Sonora.app/Contents/Info.plist
+          plutil -lint Sonora.app/Contents/Info.plist
+
+      - name: sign the bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          codesign --force --sign - Sonora.app
+          codesign --verify --strict --verbose=2 Sonora.app
+
+      - name: create the disk image
+        shell: bash
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist staging
+          cp -R Sonora.app staging/
+          ln -s /Applications staging/Applications
+          hdiutil create \
+            -volname Sonora \
+            -srcfolder staging \
+            -ov -format UDZO \
+            "dist/sonora-$VERSION-macos.dmg"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-macos
           path: dist/*
           if-no-files-found: error
 
   release:
-    needs: build
+    needs: [build, bundle]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
@@ -119,13 +163,16 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
+          pattern: release-*
           path: dist
           merge-multiple: true
+
+      - name: checksums
+        run: cd dist && shasum -a 256 * > SHA256SUMS
 
       - uses: softprops/action-gh-release@v2
         with:
           files: dist/*
-          body: Initial release.
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}
           fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,24 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [0.1.0] - 2026-08-07
+## [0.1.1] - 2026-08-07
 
-Initial release.
+### Added
 
-[unreleased]: https://github.com/nolight132/sonora/compare/v0.1.0...HEAD
+- Localized the interface with Fluent, shipping English, Russian, Ukrainian and Polish.
+- Added a language setting that follows the system locale by default.
+- Added an application icon for macOS, Linux and the disk image.
+
+### Changed
+
+- Releases now ship bare executables for Linux and Windows and a universal disk image for macOS.
+- Shuffle moved into the queue, so the queue panel shows the order that will actually play.
+
+### Fixed
+
+- Capped the volume taper at unity gain; the top of the slider no longer clips.
+- Aligned the scrubber thumb with the pointer across the whole track.
+
+[unreleased]: https://github.com/nolight132/sonora/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/nolight132/sonora/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/nolight132/sonora/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "audio"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "cpal",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "i18n"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "fluent-bundle",
  "gpui",
@@ -3303,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "input"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "gpui",
  "i18n",
@@ -5807,7 +5807,7 @@ dependencies = [
 
 [[package]]
 name = "router"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "gpui",
  "ui",
@@ -6497,7 +6497,7 @@ dependencies = [
 
 [[package]]
 name = "sonora"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -6512,6 +6512,7 @@ dependencies = [
  "tokio",
  "ui",
  "views",
+ "winresource",
  "workspace",
 ]
 
@@ -6563,7 +6564,7 @@ dependencies = [
 
 [[package]]
 name = "spotify"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6622,7 +6623,7 @@ dependencies = [
 
 [[package]]
 name = "state"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "audio",
@@ -7566,7 +7567,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "gpui",
  "i18n",
@@ -7869,7 +7870,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "views"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "gpui",
  "i18n",
@@ -8831,6 +8832,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winresource"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0986a8b1d586b7d3e4fe3d9ea39fb451ae22869dcea4aa109d287a374d866087"
+dependencies = [
+ "toml 1.1.4+spec-1.1.0",
+ "version_check",
+]
+
+[[package]]
 name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8853,7 +8864,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "workspace"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "gpui",
  "i18n",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [workspace.dependencies]
@@ -32,6 +32,7 @@ gpui_platform = { git = "https://github.com/zed-industries/zed", rev = "f25b256f
   "x11",
 ] }
 http = "1.3"
+winresource = "0.1"
 image = { version = "0.25", default-features = false }
 jiff = { version = "0.2", default-features = false, features = ["std"] }
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,35 @@
 
 A minimal native Spotify client built with Rust and GPUI.
 
+## Install
+
+### macOS
+
+```sh
+brew install --cask nolight132/tap/sonora
+```
+
+Sonora is signed ad-hoc rather than notarized, so Gatekeeper blocks it on first
+launch. Clear the quarantine attribute once, after installing:
+
+```sh
+xattr -dr com.apple.quarantine /Applications/Sonora.app
+```
+
+### Linux and Windows
+
+Download the executable for your platform from the
+[latest release](https://github.com/nolight132/sonora/releases/latest). On Linux,
+mark it executable first:
+
+```sh
+chmod +x sonora-*-x86_64-unknown-linux-gnu
+```
+
+Linux needs a Vulkan driver at runtime, plus `alsa-lib`, `fontconfig`, `freetype`,
+`libxkbcommon` and the X11/Wayland client libraries. `SHA256SUMS` in the release
+verifies every download.
+
 ## Arch Linux / CachyOS
 
 Install the build and runtime dependencies:

--- a/assets/linux/sonora.desktop
+++ b/assets/linux/sonora.desktop
@@ -3,6 +3,7 @@ Type=Application
 Name=sonora
 GenericName=Music Player
 Comment=A minimal native Spotify client
+Icon=sonora
 Exec=sonora
 Terminal=false
 Categories=AudioVideo;Audio;Player;

--- a/assets/macos/Info.plist
+++ b/assets/macos/Info.plist
@@ -6,14 +6,16 @@
 	<string>en</string>
 	<key>CFBundleExecutable</key>
 	<string>sonora</string>
+	<key>CFBundleIconFile</key>
+	<string>sonora</string>
 	<key>CFBundleIdentifier</key>
 	<string>dev.nolight.sonora</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>sonora</string>
+	<string>Sonora</string>
 	<key>CFBundleDisplayName</key>
-	<string>sonora</string>
+	<string>Sonora</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/crates/sonora/Cargo.toml
+++ b/crates/sonora/Cargo.toml
@@ -18,3 +18,6 @@ views.workspace = true
 workspace.workspace = true
 reqwest.workspace = true
 tokio = { workspace = true, features = ["rt"] }
+
+[target.'cfg(windows)'.build-dependencies]
+winresource.workspace = true

--- a/crates/sonora/build.rs
+++ b/crates/sonora/build.rs
@@ -1,0 +1,15 @@
+fn main() {
+    #[cfg(windows)]
+    {
+        let icon = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../assets/windows/sonora.ico"
+        );
+        println!("cargo:rerun-if-changed={icon}");
+        let mut resource = winresource::WindowsResource::new();
+        resource.set_icon(icon);
+        if let Err(error) = resource.compile() {
+            println!("cargo:warning=cannot embed the windows icon: {error}");
+        }
+    }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -34,11 +34,11 @@
 
           sonora = pkgs.rustPlatform.buildRustPackage {
             pname = "sonora";
-            version = "0.1.0";
+            version = (pkgs.lib.importTOML ./Cargo.toml).workspace.package.version;
 
             src = ./.;
 
-            cargoHash = "sha256-VgzjtVOxlHGwLUvEx2upu+1zI0rRMu6HXuG7Zgw3R6M=";
+            cargoHash = "sha256-pLduNOaYtm36fpu1to7xgvVbnCqneLpY09zGeifQjSo=";
 
             nativeBuildInputs = with pkgs; [
               pkg-config
@@ -51,6 +51,13 @@
             postInstall = ''
               install -Dm444 assets/linux/sonora.desktop \
                 -t "$out/share/applications"
+              install -Dm444 assets/linux/sonora.svg \
+                "$out/share/icons/hicolor/scalable/apps/sonora.svg"
+              for icon in assets/linux/icons/hicolor/*/apps/sonora.png; do
+                size="$(basename "$(dirname "$(dirname "$icon")")")"
+                install -Dm444 "$icon" \
+                  "$out/share/icons/hicolor/$size/apps/sonora.png"
+              done
             '';
 
             postFixup = ''


### PR DESCRIPTION
## What changed

- Release Linux and Windows as bare executables instead of `.tar.gz` and `.zip` archives.
- Build a universal macOS `Sonora.app` with `lipo`, ad-hoc sign it, and ship it as a disk image.
- Reference the generated icons: `CFBundleIconFile` in the bundle, `Icon=` in the desktop entry, the hicolor theme in the Nix package, and the `.ico` embedded into the Windows executable.
- Read the Nix package version from `Cargo.toml` and refresh the vendor hash.
- Replace the ten per-asset `.sha256` files with a single `SHA256SUMS`.
- Bump the workspace to 0.1.1.

## Why

A `.app` is a directory, so macOS has to ship inside a container; a DMG is the format Homebrew Cask
expects. Nothing forced archives on the other two, and a bare `.exe` in particular is strictly better
than a zip. The icons were generated but nothing consumed them, so every platform still showed a
placeholder.

`nix build` on `main` is currently broken: `Cargo.lock` gained the `i18n` crate and the Fluent
dependencies, but `cargoHash` was never updated. Deriving the package version from `Cargo.toml`
stops the two drifting apart again.

## User impact

macOS users can install from a disk image, and every platform shows the real application icon in the
Dock, launcher, taskbar and window decorations. Linux and Windows downloads are a single file rather
than an archive to unpack.

## Notes

Linux downloads now need `chmod +x`, because GitHub release assets carry no permission bit. This is
the tradeoff for dropping the tarball, and the README says so.

The bundle is signed ad-hoc, not notarized. Ad-hoc signing only makes the binary executable on Apple
Silicon; it does not satisfy Gatekeeper, so first launch still needs
`xattr -dr com.apple.quarantine`. Homebrew cannot do this automatically any more — `--no-quarantine`
was removed in Homebrew 4.7. Removing the step entirely requires a Developer ID certificate and
notarization.

`codesign` is called without `--deep`, which Apple deprecates for signing. The bundle holds a single
executable and no nested code, so a plain signature is correct.

`sonora.desktop` is no longer part of a release download; the Nix package installs it, as it already
did.

## Validation

- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace`
- `nix build` — now succeeds and produces `sonora-0.1.1`; verified the installed tree contains all
  eight hicolor PNGs plus the scalable SVG, and `desktop-file-validate` passes on the installed entry
- `yq` parses the workflow; `plutil`-equivalent parse of `Info.plist` with the version substituted

Not verified: `lipo`, `codesign` and `hdiutil` only run on a tag push, so the macOS bundle and DMG
have never been produced. The Windows resource compile is likewise untested — `build.rs` is
`cfg(windows)` and cannot run here, though it degrades to a warning rather than failing the build.
