### PR TITLE
fix(ui): space the sidebar tabs and draw menus on the popover surface

### DIFF
--- a/crates/ui/src/menu.rs
+++ b/crates/ui/src/menu.rs
@@ -512,7 +512,7 @@ impl RenderOnce for Menu {
             .border_1()
             .gap_1()
             .border_color(theme.border)
-            .bg(theme.secondary)
+            .bg(theme.popover)
             .text_color(theme.popover_foreground)
             .occlude()
             .when_some(dismiss, |this, dismiss| {

--- a/crates/ui/src/theme.rs
+++ b/crates/ui/src/theme.rs
@@ -187,7 +187,7 @@ impl Theme {
             danger: rgb(0x7f1d1d).into(),
             danger_foreground: rgb(0xfef2f2).into(),
             danger_hover: rgb(0x8b2020).into(),
-            popover: rgb(0x0a0a0a).into(),
+            popover: rgb(0x141414).into(),
             popover_foreground: rgb(0xfafafa).into(),
             progress_bar: rgb(0xf5f5f5).into(),
             selection: rgb(0x1d4ed8).into(),

--- a/crates/workspace/src/sidebar_left.rs
+++ b/crates/workspace/src/sidebar_left.rs
@@ -163,13 +163,23 @@ impl Render for Sidebar {
 
                     rows.push(
                         div()
+                            .relative()
                             .flex()
                             .flex_col()
+                            .gap_1()
                             .ml_4()
-                            .children(TABS.into_iter().enumerate().map(|(step, (name, tab))| {
+                            .child(
+                                div()
+                                    .absolute()
+                                    .left_0()
+                                    .top_0()
+                                    .bottom(middle)
+                                    .w(px(1.))
+                                    .bg(sidebar_border),
+                            )
+                            .children(TABS.into_iter().map(|(name, tab)| {
                                 let chosen = current == Destination::Library(tab);
                                 let tint = if chosen { foreground } else { muted };
-                                let tail = step + 1 == TABS.len();
 
                                 div()
                                     .relative()
@@ -177,15 +187,6 @@ impl Render for Sidebar {
                                     .items_center()
                                     .h(nav)
                                     .pl_3()
-                                    .child(
-                                        div()
-                                            .absolute()
-                                            .left_0()
-                                            .top_0()
-                                            .w(px(1.))
-                                            .h(if tail { middle } else { nav })
-                                            .bg(sidebar_border),
-                                    )
                                     .child(
                                         div()
                                             .absolute()


### PR DESCRIPTION
## What changed

- Space the library sub-tabs in the sidebar so their hover backgrounds no longer touch.
- Draw the tree connector as one continuous line on the container rather than per-row segments.
- Give menus the `popover` surface colour instead of `secondary`, matching the text colour they already used.
- Raise `dark`'s `popover` above its `background`, which every other theme already did.

## Why

The sidebar's top-level rows sat in a `gap_1` column but the nested library tabs did not, so Songs,
Albums and Playlists rendered flush and their hover fills merged into one block. Adding a gap alone
would have broken the tree connector, which was drawn as a per-row segment relying on rows touching;
anchoring a single line from the container top to the last row's centre is gap-agnostic and needs no
magic spacing constant.

`Menu` painted itself with `secondary` — the button surface — while colouring its text with
`popover_foreground`. There is no `secondary_foreground` token, so the pair was mismatched and a menu
read as a large button rather than a floating surface. `Scrubber`'s bubble already uses the
`popover` pair correctly.

Switching `Menu` to `popover` exposed a second problem: `dark` is the only theme whose `popover`
equals its `background` (both `0x0a0a0a`), so menus would have gone flat against the page on exactly
the theme in use. Light, midnight and forest all raise it, and every derived theme sets its own, so
`dark` was the outlier.

## User impact

Hovering a library tab highlights that tab alone instead of a merged block, and dropdown, context and
submenu panels read as surfaces floating above the page on every theme.

## Notes

`dark`'s `popover` moves from `0x0a0a0a` to `0x141414` — above `background` and below `secondary`, so
menus look raised without looking like buttons. This also affects the scrubber's hover bubble, which
was equally flat on that theme.

## Validation

- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace`

All clean. Confirmed every theme now has `popover` distinct from `background`, and that the four
derived themes override `popover` themselves so the `dark` change does not leak into them.

The GUI was not run: neither the sidebar spacing nor the new menu colour has been seen on screen.
