### PR TITLE
refactor(views): make the shell a sum type and hoist the title bar

### DIFF
--- a/assets/icons/maximize.svg
+++ b/assets/icons/maximize.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M8 3H5a2 2 0 0 0-2 2v3" />
+  <path d="M21 8V5a2 2 0 0 0-2-2h-3" />
+  <path d="M3 16v3a2 2 0 0 0 2 2h3" />
+  <path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+</svg>

--- a/crates/input/src/lib.rs
+++ b/crates/input/src/lib.rs
@@ -16,7 +16,8 @@ actions!(
         TogglePlayback,
         OpenFilter,
         OpenSearch,
-        OpenSettings
+        OpenSettings,
+        ToggleFullscreen
     ]
 );
 

--- a/crates/sonora/src/assets.rs
+++ b/crates/sonora/src/assets.rs
@@ -58,6 +58,7 @@ const ICONS: &[(&str, &[u8])] = icons![
     "list-end",
     "list-plus",
     "log-out",
+    "maximize",
     "music",
     "music-2",
     "pause",

--- a/crates/views/src/lib.rs
+++ b/crates/views/src/lib.rs
@@ -3,6 +3,7 @@
 mod root;
 mod screens;
 mod shared;
+mod shells;
 
 pub use root::Root;
 use screens::artist::ArtistView;
@@ -13,3 +14,4 @@ pub use screens::login::LoginView;
 pub use screens::settings::SettingsView;
 use screens::song::SongView;
 use shared::adaptive::Adaptive;
+use shells::fullscreen::FullscreenView;

--- a/crates/views/src/root.rs
+++ b/crates/views/src/root.rs
@@ -3,19 +3,20 @@
 use gpui::{AnyView, Context, Entity, MouseButton, NavigationDirection, Render};
 use gpui::{Window, div};
 use gpui::{font, prelude::*};
-use input::{OpenFilter, OpenSearch, OpenSettings};
+use input::{OpenFilter, OpenSearch, OpenSettings, ToggleFullscreen};
 use router::{Destination, NavigationEvent, back, forward, navigate};
 use state::{
     ArtistDetail, Detail, Home, Io, Library, Playback, Queue, Search, Session, SessionState,
     SongDetail,
 };
 use ui::ActiveTheme as _;
-use workspace::{Sidebar, Toolbar, Tooled, Workspace};
+use workspace::{Sidebar, TitleBar, TitleBarEvent, TitleBarOptions, Toolbar, Tooled, Workspace};
 
 use crate::screens::search::SearchView;
 use crate::shared::tracks::{ALBUM_COLUMNS, LIBRARY_COLUMNS};
 use crate::{
-    Adaptive, ArtistView, DetailView, HomeView, LibraryView, LoginView, SettingsView, SongView,
+    Adaptive, ArtistView, DetailView, FullscreenView, HomeView, LibraryView, LoginView,
+    SettingsView, SongView,
 };
 
 struct Screens {
@@ -33,9 +34,20 @@ struct Screens {
     settings: Entity<SettingsView>,
 }
 
+struct Shells {
+    workspace: Entity<Workspace>,
+    fullscreen: Entity<FullscreenView>,
+}
+
+enum RootView {
+    Workspace,
+    Fullscreen,
+}
+
 enum Focus {
     Search,
     Workspace,
+    Fullscreen,
 }
 
 pub struct Root {
@@ -43,7 +55,10 @@ pub struct Root {
     playback: Entity<Playback>,
     io: Io,
     login: Entity<LoginView>,
-    workspace: Entity<Workspace>,
+    sidebar: Entity<Sidebar>,
+    title_bar: Entity<TitleBar>,
+    shells: Shells,
+    view: RootView,
     toolbar: Option<Entity<Toolbar>>,
     pending: Option<Focus>,
     screens: Screens,
@@ -125,6 +140,15 @@ impl Root {
                 cx,
             )
         });
+        let fullscreen = cx.new(|cx| FullscreenView::new(playback.clone(), cx));
+
+        let title_bar = cx.new(TitleBar::new);
+        cx.subscribe(&title_bar, |this, _, event, cx| match event {
+            TitleBarEvent::ToggleSidebar => {
+                this.sidebar.update(cx, |sidebar, cx| sidebar.toggle(cx))
+            }
+        })
+        .detach();
 
         let adaptive = cx.new(|cx| Adaptive::new(playback.clone(), cx));
 
@@ -133,7 +157,13 @@ impl Root {
             playback,
             io,
             login,
-            workspace,
+            sidebar,
+            title_bar,
+            shells: Shells {
+                workspace: workspace.clone(),
+                fullscreen,
+            },
+            view: RootView::Workspace,
             toolbar: None,
             pending: None,
             screens: Screens {
@@ -180,6 +210,31 @@ impl Root {
             return;
         };
         toolbar.update(cx, |toolbar, cx| toolbar.focus(window, cx));
+    }
+
+    fn toggle_fullscreen(&mut self, cx: &mut Context<Self>) {
+        let entering = matches!(self.view, RootView::Workspace);
+        self.view = match entering {
+            true => RootView::Fullscreen,
+            false => RootView::Workspace,
+        };
+        self.pending = Some(match entering {
+            true => Focus::Fullscreen,
+            false => Focus::Workspace,
+        });
+        cx.notify();
+    }
+
+    fn options(&self, cx: &Context<Self>) -> TitleBarOptions {
+        match self.view {
+            RootView::Workspace => TitleBarOptions {
+                navigation: true,
+                sidebar_open: self.sidebar.read(cx).is_open(),
+                offset: self.sidebar.read(cx).occupied_width(),
+                content: self.toolbar.clone().map(Into::into),
+            },
+            RootView::Fullscreen => TitleBarOptions::default(),
+        }
     }
 
     fn open_settings(&mut self, cx: &mut Context<Self>) {
@@ -237,12 +292,11 @@ impl Root {
             Destination::Settings => self.screens.settings.clone().into(),
         };
 
-        self.toolbar = toolbar.clone();
+        self.toolbar = toolbar;
 
-        self.workspace.update(cx, |workspace, cx| {
-            workspace.set_content(content, cx);
-            workspace.set_toolbar(toolbar.map(Into::into), cx);
-        });
+        self.shells
+            .workspace
+            .update(cx, |workspace, cx| workspace.set_content(content, cx));
         cx.notify();
     }
 }
@@ -260,10 +314,19 @@ impl Render for Root {
                 .search
                 .update(cx, |search, cx| search.focus(window, cx)),
             Some(Focus::Workspace) => self
+                .shells
                 .workspace
                 .update(cx, |workspace, cx| workspace.focus(window, cx)),
+            Some(Focus::Fullscreen) => self
+                .shells
+                .fullscreen
+                .update(cx, |fullscreen, cx| fullscreen.focus(window, cx)),
             None => {}
         }
+
+        let options = self.options(cx);
+        self.title_bar
+            .update(cx, |bar, cx| bar.set_options(options, cx));
 
         let theme = *cx.theme();
         window.set_rem_size(theme.font_size);
@@ -286,10 +349,16 @@ impl Render for Root {
             .on_action(cx.listener(|this, _: &OpenFilter, window, cx| this.open_filter(window, cx)))
             .on_action(cx.listener(|this, _: &OpenSearch, _, cx| this.open_search(cx)))
             .on_action(cx.listener(|this, _: &OpenSettings, _, cx| this.open_settings(cx)))
+            .on_action(cx.listener(|this, _: &ToggleFullscreen, _, cx| this.toggle_fullscreen(cx)))
             .when_else(
                 show_sign_in,
                 |this| this.child(self.login.clone()),
-                |this| this.child(self.workspace.clone()),
+                |this| {
+                    this.child(self.title_bar.clone()).child(match self.view {
+                        RootView::Workspace => self.shells.workspace.clone().into_any_element(),
+                        RootView::Fullscreen => self.shells.fullscreen.clone().into_any_element(),
+                    })
+                },
             )
     }
 }

--- a/crates/views/src/shells/fullscreen.rs
+++ b/crates/views/src/shells/fullscreen.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use gpui::prelude::*;
+use gpui::{App, Context, Entity, FocusHandle, Render, SharedString};
+use gpui::{Window, div};
+use i18n::t;
+use input::ToggleFullscreen;
+use state::Playback;
+use ui::{ActiveTheme as _, Artwork, Text};
+
+const COVER: f32 = 2.4;
+
+pub struct FullscreenView {
+    playback: Entity<Playback>,
+    focus: FocusHandle,
+}
+
+impl FullscreenView {
+    pub fn new(playback: Entity<Playback>, cx: &mut Context<Self>) -> Self {
+        cx.observe(&playback, |_, _, cx| cx.notify()).detach();
+
+        Self {
+            playback,
+            focus: cx.focus_handle(),
+        }
+    }
+
+    pub fn focus(&self, window: &mut Window, cx: &mut App) {
+        window.focus(&self.focus, cx);
+    }
+}
+
+impl Render for FullscreenView {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = *cx.theme();
+        let cover = ui::snapped(theme.metrics.cover * COVER, window);
+        let track = self.playback.read(cx).track().cloned();
+        let title = match &track {
+            Some(track) => SharedString::from(track.name.clone()),
+            None => t!("player-nothing-playing"),
+        };
+
+        div()
+            .id("fullscreen")
+            .track_focus(&self.focus)
+            .flex()
+            .flex_col()
+            .flex_1()
+            .min_h_0()
+            .w_full()
+            .items_center()
+            .justify_center()
+            .gap_6()
+            .bg(theme.background)
+            .on_click(|_, window, cx| window.dispatch_action(Box::new(ToggleFullscreen), cx))
+            .child(Artwork::new(track.as_ref().and_then(|track| track.cover.clone())).size(cover))
+            .child(
+                div()
+                    .max_w(cover)
+                    .truncate()
+                    .text_size(theme.text(Text::Title))
+                    .child(title),
+            )
+    }
+}

--- a/crates/views/src/shells/mod.rs
+++ b/crates/views/src/shells/mod.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pub(crate) mod fullscreen;

--- a/crates/workspace/src/lib.rs
+++ b/crates/workspace/src/lib.rs
@@ -13,7 +13,7 @@ pub use chrome::Chrome;
 pub use links::artist_links;
 pub use player_bar::PlayerBar;
 pub use sidebar_left::Sidebar;
-pub use title_bar::TitleBar;
+pub use title_bar::{TitleBar, TitleBarEvent, TitleBarOptions};
 pub use toolbar::{Columned, Filterable, Searchable, Sortable, Toolbar, Tooled, Viewed};
 pub use track_menu::TrackMenu;
 
@@ -25,7 +25,6 @@ use sidebar_right::QueuePanel;
 use state::{Playback, Queue};
 
 pub struct Workspace {
-    title_bar: Entity<TitleBar>,
     sidebar: Entity<Sidebar>,
     player_bar: Entity<PlayerBar>,
     queue_panel: Entity<QueuePanel>,
@@ -41,14 +40,12 @@ impl Workspace {
         content: AnyView,
         cx: &mut Context<Self>,
     ) -> Self {
-        let title_bar = cx.new(|cx| TitleBar::new(sidebar.clone(), cx));
         let queue_panel =
             cx.new(|cx| QueuePanel::new(queue.clone(), playback.clone(), sidebar.clone(), cx));
         let player_bar =
             cx.new(|cx| PlayerBar::with_queue_panel(playback, queue, queue_panel.clone(), cx));
 
         Self {
-            title_bar,
             sidebar,
             player_bar,
             queue_panel,
@@ -68,11 +65,6 @@ impl Workspace {
     pub fn set_content(&mut self, content: AnyView, cx: &mut Context<Self>) {
         self.content = content;
         cx.notify();
-    }
-
-    pub fn set_toolbar(&mut self, toolbar: Option<AnyView>, cx: &mut Context<Self>) {
-        self.title_bar
-            .update(cx, |bar, cx| bar.set_content(toolbar, cx));
     }
 
     pub fn player_bar(&self) -> &Entity<PlayerBar> {
@@ -99,11 +91,12 @@ impl Render for Workspace {
         div()
             .flex()
             .flex_col()
-            .size_full()
+            .w_full()
+            .flex_1()
+            .min_h_0()
             .key_context(WORKSPACE_CONTEXT)
             .track_focus(&self.focus)
             .on_action(cx.listener(|this, _: &Dismiss, _, cx| this.close_queue(cx)))
-            .child(self.title_bar.clone())
             .child(
                 div()
                     .relative()

--- a/crates/workspace/src/player_bar.rs
+++ b/crates/workspace/src/player_bar.rs
@@ -11,6 +11,7 @@ use gpui::{
 };
 use gpui::{Window, div, px};
 use i18n::t;
+use input::ToggleFullscreen;
 use state::{Library, Playback, PlaybackState, Queue, Repeat, Sonora};
 use ui::{
     Artwork, Button, InlineLink, InlineLinks, Popup, Room, Scrollbar, Scrubber, ScrubberState,
@@ -262,6 +263,14 @@ impl PlayerBar {
                     }
                 })),
         )
+    }
+
+    fn fullscreen_button(&self) -> Button {
+        Button::new("toggle-fullscreen")
+            .ghost()
+            .small()
+            .icon("icons/maximize.svg")
+            .on_click(|_, window, cx| window.dispatch_action(Box::new(ToggleFullscreen), cx))
     }
 
     fn toggle(&self, cx: &mut Context<Self>) -> Button {
@@ -533,6 +542,7 @@ impl Render for PlayerBar {
                         .w_full()
                         .child(div().flex_1().min_w_0().child(seek))
                         .child(self.sound(px(VOLUME_TIGHT), cx))
+                        .child(self.fullscreen_button())
                         .when_some(self.queue_button(cx), |this, button| this.child(button)),
                 ),
             false => base
@@ -560,6 +570,7 @@ impl Render for PlayerBar {
                         .flex_1()
                         .min_w_0()
                         .child(self.sound(px(VOLUME_WIDTH), cx))
+                        .child(self.fullscreen_button())
                         .when_some(self.queue_button(cx), |this, button| this.child(button)),
                 ),
         };

--- a/crates/workspace/src/title_bar.rs
+++ b/crates/workspace/src/title_bar.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use gpui::prelude::*;
-use gpui::{AnyView, Context, Entity, MouseButton, Pixels, Render};
+use gpui::{AnyView, Context, Entity, EventEmitter, MouseButton, Pixels, Render};
 use gpui::{Window, div, px};
 use ui::WindowControls;
 use ui::{ActiveTheme as _, Button};
@@ -9,38 +9,61 @@ use ui::{ActiveTheme as _, Button};
 use router::Navigation;
 use state::{AppSettings, Sonora};
 
-use crate::Sidebar;
-
 #[cfg(target_os = "macos")]
 const TITLE_BAR_LEFT_INSET: f32 = 74.;
 #[cfg(not(target_os = "macos"))]
 const TITLE_BAR_LEFT_INSET: f32 = 12.;
 
-pub struct TitleBar {
-    sidebar: Entity<Sidebar>,
-    navigation: Entity<Navigation>,
-    settings: Entity<AppSettings>,
-    content: Option<AnyView>,
+#[derive(Clone, PartialEq)]
+pub struct TitleBarOptions {
+    pub navigation: bool,
+    pub sidebar_open: bool,
+    pub offset: Pixels,
+    pub content: Option<AnyView>,
 }
 
-impl TitleBar {
-    pub fn new(sidebar: Entity<Sidebar>, cx: &mut Context<Self>) -> Self {
-        let navigation = router::trail(cx);
-        let settings = Sonora::global(cx).settings.clone();
-
-        cx.observe(&sidebar, |_, _, cx| cx.notify()).detach();
-        cx.observe(&navigation, |_, _, cx| cx.notify()).detach();
-        cx.observe(&settings, |_, _, cx| cx.notify()).detach();
+impl Default for TitleBarOptions {
+    fn default() -> Self {
         Self {
-            sidebar,
-            navigation,
-            settings,
+            navigation: false,
+            sidebar_open: false,
+            offset: Pixels::ZERO,
             content: None,
         }
     }
+}
 
-    pub fn set_content(&mut self, content: Option<AnyView>, cx: &mut Context<Self>) {
-        self.content = content;
+pub enum TitleBarEvent {
+    ToggleSidebar,
+}
+
+pub struct TitleBar {
+    navigation: Entity<Navigation>,
+    settings: Entity<AppSettings>,
+    options: TitleBarOptions,
+}
+
+impl EventEmitter<TitleBarEvent> for TitleBar {}
+
+impl TitleBar {
+    pub fn new(cx: &mut Context<Self>) -> Self {
+        let navigation = router::trail(cx);
+        let settings = Sonora::global(cx).settings.clone();
+
+        cx.observe(&navigation, |_, _, cx| cx.notify()).detach();
+        cx.observe(&settings, |_, _, cx| cx.notify()).detach();
+        Self {
+            navigation,
+            settings,
+            options: TitleBarOptions::default(),
+        }
+    }
+
+    pub fn set_options(&mut self, options: TitleBarOptions, cx: &mut Context<Self>) {
+        if self.options == options {
+            return;
+        }
+        self.options = options;
         cx.notify();
     }
 
@@ -96,11 +119,9 @@ impl TitleBar {
     }
 
     fn toggle(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let sidebar = self.sidebar.clone();
-        let icon = if sidebar.read(cx).is_open() {
-            "icons/panel-left-close.svg"
-        } else {
-            "icons/panel-left-open.svg"
+        let icon = match self.options.sidebar_open {
+            true => "icons/panel-left-close.svg",
+            false => "icons/panel-left-open.svg",
         };
 
         div()
@@ -115,9 +136,7 @@ impl TitleBar {
                     .flex()
                     .small()
                     .icon(icon)
-                    .on_click(move |_, _, cx| {
-                        sidebar.update(cx, |sidebar, cx| sidebar.toggle(cx));
-                    }),
+                    .on_click(cx.listener(|_, _, _, cx| cx.emit(TitleBarEvent::ToggleSidebar))),
             )
     }
 }
@@ -126,7 +145,12 @@ impl Render for TitleBar {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
         let height = ui::snapped(theme.metrics.title_bar, window);
-        let offset = self.sidebar.read(cx).occupied_width();
+        let navigation = self.options.navigation;
+        let offset = match navigation {
+            true => self.options.offset,
+            false => Pixels::ZERO,
+        };
+        let content = self.options.content.clone();
         let settings = self.settings.read(cx);
         let decorated = cfg!(not(target_os = "macos")) && settings.window_controls();
         let leading = decorated && settings.controls_on_left();
@@ -156,7 +180,7 @@ impl Render for TitleBar {
                     .pr_3()
                     .gap_1()
                     .when(offset > Pixels::ZERO, |this| this.w(offset))
-                    .child(self.toggle(cx)),
+                    .when(navigation, |this| this.child(self.toggle(cx))),
             )
             .child(
                 div()
@@ -165,8 +189,8 @@ impl Render for TitleBar {
                     .min_w_0()
                     .gap_1()
                     .items_center()
-                    .child(self.history(cx))
-                    .children(self.content.clone())
+                    .when(navigation, |this| this.child(self.history(cx)))
+                    .children(content)
                     .pr_3(),
             )
             .when(decorated && !leading, |this| {


### PR DESCRIPTION
## What changed

- Model the application shell as `RootView`, a sum type over Workspace and a new Fullscreen shell, instead of `Root` holding a workspace directly.
- Hoist `TitleBar` out of `Workspace` into `Root`, so it renders above whichever shell is active.
- Replace `TitleBar::set_content` with `TitleBar::set_options`, taking a complete `TitleBarOptions` description.
- Cut `TitleBar`'s dependency on `Sidebar`; it now depends only on `Navigation` and `AppSettings`.
- Add a minimal `FullscreenView` and a `ToggleFullscreen` action reachable from the player bar.

## Why

The fullscreen player does not use any of `Workspace`'s fields — no sidebars, no queue, no content
slot. Bolting it on would have meant a struct whose fields are unused in one of its two modes.
Mutually exclusive states are already modelled as enums here (`LibraryState`, `PlaybackState`,
`Destination`), so the shell follows suit.

The shell axis is deliberately kept out of routing. `Destination` drives navigation history, and
going fullscreen should not be a history entry you can go "back" out of — the user expects to return
to the screen they came from, which is what a plain toggle does.

## User impact

None yet beyond a new button in the player bar that switches to a bare now-playing view and back.
This is groundwork.

## Notes

- Both shells are constructed eagerly, so switching is instant and each keeps its state.
- `RootView` carries no payload. The shells live in a `Shells` bag and the enum is the selection —
  holding entities in the variants as well would have meant two owners of the same handle, since
  both shells must stay alive regardless of which is showing.
- `TitleBarOptions` gained a fourth field beyond navigation/offset/content: `sidebar_open`. The
  toggle icon cannot be derived from `offset`, because in auto-hide mode the sidebar overlays the
  content and occupies zero width while still being open.
- The sidebar toggle reports intent through a new `TitleBarEvent::ToggleSidebar` rather than a
  closure in the options. The options are compared each frame to avoid a repaint loop, and a boxed
  closure would need pointer-identity bookkeeping to stay comparable.
- Fullscreen exits by clicking anywhere on it. Without an exit the player-bar button is a one-way
  trip; a visible affordance belongs with the transport controls, which are not part of this change.
- `Workspace::content` is still an `AnyView`. Turning it into a `Screen` enum is the next change.

## Validation

- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace` — 117 passed
- `cargo clippy --workspace` — no new warnings
- Launched the app: stayed alive, no panics, no unregistered assets, no missing i18n keys

Not exercised: no UI test harness here, so the hoisted title bar and the fullscreen round-trip are
verified by construction and startup only.
