### PR TITLE
fix(views): seed search radio from track

### DIFF
--- a/crates/state/src/search.rs
+++ b/crates/state/src/search.rs
@@ -159,16 +159,6 @@ impl Search {
         self.hits.first()
     }
 
-    pub fn queue(&self) -> Vec<Track> {
-        self.hits
-            .iter()
-            .filter_map(|hit| match hit {
-                Hit::Song(track) => Some(track.clone()),
-                _ => None,
-            })
-            .collect()
-    }
-
     pub fn is_loading(&self) -> bool {
         self.loading
     }

--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -19,7 +19,7 @@ use crate::shared::cells;
 use crate::shared::tracks::{PlaybackStatus, playback_status};
 
 enum Press {
-    Song(usize),
+    Song(Track),
     Artist(String),
     Album(String),
 }
@@ -96,22 +96,15 @@ impl SearchView {
         self.input.update(cx, |input, cx| input.focus(window, cx));
     }
 
-    fn play(&mut self, index: usize, cx: &mut Context<Self>) {
-        let queued = self.search.read(cx).queue();
-        if index >= queued.len() {
-            return;
-        }
-        self.playback
-            .update(cx, |playback, cx| playback.start(queued, index, cx));
-    }
-
     fn pressed(
         &self,
         target: Press,
         cx: &Context<Self>,
     ) -> impl Fn(&gpui::ClickEvent, &mut Window, &mut App) + 'static {
         cx.listener(move |this, _, _, cx| match &target {
-            Press::Song(index) => this.play(*index, cx),
+            Press::Song(track) => this
+                .playback
+                .update(cx, |playback, cx| playback.play_radio(track, cx)),
             Press::Artist(id) => navigate(Destination::Artist(id.clone().into()), cx),
             Press::Album(id) => navigate(Destination::Album(id.clone().into()), cx),
         })
@@ -163,7 +156,7 @@ impl SearchView {
                             .text_color(theme.muted_foreground)
                             .child(clock(track.duration)),
                     )
-                    .press(self.pressed(Press::Song(place), cx))
+                    .press(self.pressed(Press::Song(track.clone()), cx))
                     .on_mouse_down(MouseButton::Right, move |event, window, cx| {
                         window.prevent_default();
                         let Some(view) = view.upgrade() else {
@@ -206,7 +199,7 @@ impl SearchView {
                 Kind::Song,
                 track.name.clone(),
                 track.artist_refs.clone(),
-                Some(Press::Song(0)),
+                Some(Press::Song(track.clone())),
             ),
             Hit::Artist(artist) => (
                 Kind::Artist,


### PR DESCRIPTION
## Summary
- start search playback as a radio seeded by the selected track
- stop building playback queues from similarly named search results
- apply the same behavior to regular results and the best match

## Validation
- cargo fmt --check
- cargo check --locked --package state --package views
- cargo test --locked --package state --package views
- git diff --check