### PR TITLE
refactor(views): route responsive decisions through Chrome

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,11 @@ Room::of(width).fits(Room::Roomy)   // ">= Roomy", the only comparison you need
 `Room` is `Ord`, so `fits` is just `>=`. The raw `Pixels` consts exist for the places that need a
 number rather than a step: `ColumnSpec::hide_below` and centering maths.
 
+A breakpoint is a branch — "below this width, lay the page out differently". A packing minimum is
+not: `MIN_COLUMN_WIDTH` in `home/quick_picks.rs`, `PANEL` in `screens/song.rs`, the column widths in
+`shared/cells.rs`. Those stay plain `px` consts at module top; forcing them onto a five-step ladder
+would change how content packs.
+
 Two modules own the measurement:
 
 - **`ui::layout`** — the ladder itself. Pure `gpui`; knows nothing about panels.
@@ -297,8 +302,11 @@ Two modules own the measurement:
 use crate::chrome::Chrome;
 Chrome::content(window, cx)   // viewport width − both sidebars, floored at ui::MIN_CONTENT
 Chrome::room(window, cx)      // the same, classified into a Room
-Chrome::sidebar_left(cx) / Chrome::sidebar_right(cx)
+Chrome::sidebar_left(cx) / Chrome::sidebar_right(cx)   // one panel's cut, for the other panel
 ```
+
+`Chrome::room` is how a view classifies its width: never rebuild `Room::of(…)` from a width you
+derived yourself.
 
 Rules:
 
@@ -306,17 +314,23 @@ Rules:
   ignores both side panels, so tables overflow under the right sidebar and grids pick a column count
   that does not fit. Raw viewport width is legitimate in exactly two places: chrome that spans the
   whole window (`PlayerBar`, `TitleBar`, and `Menu`'s submenu flip), and a side panel deciding *its
-  own* size — `SidebarLeft` and `SidebarRight` subtract only the other panel, because asking
-  `Chrome` for a width they are themselves a term in would be circular.
+  own* size — `SidebarLeft` measures the room left over once its own width is taken, `SidebarRight`
+  subtracts the left panel, because asking `Chrome` for a width they are themselves a term in would
+  be circular.
 - `Workspace::render` publishes the widths every frame via `Chrome::publish`; it notifies only when
   a width actually changed, so it cannot loop.
+- **`Chrome` is only current after that publish.** `Root` and `Workspace` render *before* it, so
+  they read the panel entities directly; everything they render into — content views and both
+  panels — sees this frame's values.
 - **A view whose layout depends on width must observe the chrome**, or it will not repaint when a
   panel is resized or toggled:
   ```rust
   let chrome = Chrome::entity(cx);
   cx.observe(&chrome, |_, _, cx| cx.notify()).detach();
   ```
-  Views take no `Entity<SidebarLeft>` for this — that is what `Chrome` replaced.
+  Content views take no `Entity<SidebarLeft>` for this — that is what `Chrome` replaced. The shell
+  (`Root`, `Workspace`, `SidebarRight`) still holds one, because it needs the width before
+  `Chrome::publish` has run.
 - `views::cells::content_width(window, inset, cx)` is the shortcut for grid pages: `Chrome::content`
   minus the page's own padding.
 

--- a/crates/views/src/chrome/mod.rs
+++ b/crates/views/src/chrome/mod.rs
@@ -71,7 +71,6 @@ impl Chrome {
         (window.viewport_size().width - chrome.sidebar_left - chrome.sidebar_right).max(MIN_CONTENT)
     }
 
-    #[allow(dead_code)]
     pub fn room(window: &Window, cx: &App) -> Room {
         Room::of(Self::content(window, cx))
     }

--- a/crates/views/src/screens/artist.rs
+++ b/crates/views/src/screens/artist.rs
@@ -11,7 +11,10 @@ use i18n::t;
 use spotify::{ReleaseType, Track};
 use state::{AppSettings, ArtistDetail, Playback, Sonora};
 use ui::ActiveTheme as _;
-use ui::{Button, ColumnSpec, GridDelegate, GridEvent, GridState, Scrollbar, Scroller, Text, grid};
+use ui::{
+    Button, ColumnSpec, GridDelegate, GridEvent, GridState, MIN_CONTENT, Scrollbar, Scroller, Text,
+    grid,
+};
 
 use crate::shared::hero::{HeroPlayButton, PageHero};
 use crate::shared::page;
@@ -90,7 +93,7 @@ impl ArtistView {
         columns: &'static [ColumnSpec<TrackField>],
         cx: &mut Context<Self>,
     ) -> Self {
-        let width = px(200.);
+        let width = MIN_CONTENT;
         let settings = Sonora::global(cx).settings.clone();
         let saved = settings.read(cx).table(SECTION);
         let sorting = settings.read(cx).sorting(SECTION);

--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -418,10 +418,10 @@ impl Render for SearchView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = *cx.theme();
         let pad = theme.metrics.inset;
-        let room = cells::content_width(window, pad * 2., cx);
-        let stacked = !Room::of(room).fits(Room::Wide);
-        let inset = match room > VAST {
-            true => (room - VAST) / 2.,
+        let width = cells::content_width(window, pad * 2., cx);
+        let stacked = !Chrome::room(window, cx).fits(Room::Wide);
+        let inset = match width > VAST {
+            true => (width - VAST) / 2.,
             false => Pixels::ZERO,
         };
         let asked = !self.search.read(cx).query().trim().is_empty();

--- a/crates/views/src/screens/song.rs
+++ b/crates/views/src/screens/song.rs
@@ -16,6 +16,7 @@ use ui::{
 use crate::shared::cells;
 use crate::shared::hero::{HeroMetaStrip, HeroPlayButton, PageHero, release_date_label};
 
+const PANEL: Pixels = px(300.);
 const TITLE_SKELETON: Pixels = px(240.);
 const META_SKELETON: Pixels = px(180.);
 const ACTION_SKELETON: Pixels = px(96.);
@@ -324,7 +325,7 @@ impl SongView {
                 .flex()
                 .flex_col()
                 .gap_3()
-                .min_w(px(300.))
+                .min_w(PANEL)
                 .flex_1()
                 .p(theme.metrics.pad)
                 .rounded(theme.radius)
@@ -462,13 +463,13 @@ impl Render for SongView {
                                     .gap_5()
                                     .child(
                                         div()
-                                            .min_w(px(300.))
+                                            .min_w(PANEL)
                                             .flex_1()
                                             .child(self.overview(&track, cx)),
                                     )
                                     .child(
                                         div()
-                                            .min_w(px(300.))
+                                            .min_w(PANEL)
                                             .flex_1()
                                             .flex()
                                             .flex_col()


### PR DESCRIPTION
## What changed

- Route the search page's stacking decision through `Chrome::room` instead of rebuilding the ladder from a locally derived width.
- Replace a duplicated `px(200.)` seed width in the artist view with `ui::MIN_CONTENT`, which it silently equalled.
- Name a thrice-repeated wrap minimum in the song view as a `PANEL` const.
- Correct the "Breakpoints and content width" section of `CLAUDE.md`, which contradicted the code in two places.

## Why

`Chrome::room` existed but had no callers, so the one view that needed a classification built its own
`Room::of(...)` from a width it had already massaged. Two sources for the same decision is how the
ladder drifts.

## User impact

The search page now stacks at content width against `WIDE`, rather than content minus twice the page
inset. It therefore stays side-by-side very slightly longer — that is the ladder's actual definition,
and the previous behaviour was an artefact of measuring the wrong quantity.

## Notes

- `Chrome::sidebar_left` and `Chrome::sidebar_right` still have no honest caller and keep their
  `#[allow(dead_code)]`. Every candidate reads a panel width *upstream* of `Chrome::publish` and
  would get a one-frame-stale value: `Workspace::render` is itself the publisher, `Root::options`
  renders before its child publishes, and `SidebarRight` needs the left width while `Workspace` is
  still laying out. Giving them a real caller means threading the left width into
  `SidebarRight::covers_content` and dropping its `Entity<SidebarLeft>` field — a design change, not
  a conversion, so it was left out.
- A breakpoint is a branch in layout; a packing or reading-width minimum is not. `MIN_COLUMN_WIDTH`,
  the grid column widths, the panel clamps and the reading-width caps stay off the ladder, and
  `CLAUDE.md` now says so explicitly.
- `ui` learned nothing about `Chrome`. No `ui` component was making a responsive decision from a raw
  threshold — `Grid` already takes `hide_below` from its caller.

## Validation

- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace` — 117 passed
- `cargo clippy --workspace` — same warning set as before
- Launched the app: stayed alive, no panics, no unregistered assets, no missing i18n keys

Not exercised: the search page's stacking at various widths is verified by reading, not by running.
