### PR TITLE
refactor(views): give the shell ownership of its side panels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,22 +315,22 @@ Rules:
   that does not fit. Raw viewport width is legitimate in exactly two places: chrome that spans the
   whole window (`PlayerBar`, `TitleBar`, and `Menu`'s submenu flip), and a side panel deciding *its
   own* size — `SidebarLeft` measures the room left over once its own width is taken, `SidebarRight`
-  subtracts the left panel, because asking `Chrome` for a width they are themselves a term in would
-  be circular.
+  subtracts `Chrome::sidebar_left`. `Chrome::content` would be circular for either, because each is
+  a term in it; reading the *other* panel's cut is not.
 - `Workspace::render` publishes the widths every frame via `Chrome::publish`; it notifies only when
   a width actually changed, so it cannot loop.
-- **`Chrome` is only current after that publish.** `Root` and `Workspace` render *before* it, so
-  they read the panel entities directly; everything they render into — content views and both
-  panels — sees this frame's values.
+- **`Chrome` is only current after that publish.** `Workspace` renders *before* it and owns both
+  panels, so it reads them directly; everything it renders into — content views and both panels —
+  sees this frame's values. `SidebarRight` is the one exception: it reads `Chrome::sidebar_left`
+  while `Workspace` is still assembling this frame's publish, so a left-panel change reaches it one
+  frame late, and its `Chrome` observation repaints it on the next.
 - **A view whose layout depends on width must observe the chrome**, or it will not repaint when a
   panel is resized or toggled:
   ```rust
   let chrome = Chrome::entity(cx);
   cx.observe(&chrome, |_, _, cx| cx.notify()).detach();
   ```
-  Content views take no `Entity<SidebarLeft>` for this — that is what `Chrome` replaced. The shell
-  (`Root`, `Workspace`, `SidebarRight`) still holds one, because it needs the width before
-  `Chrome::publish` has run.
+  Nothing outside `Workspace` holds an `Entity<SidebarLeft>` — that is what `Chrome` replaced.
 - `views::cells::content_width(window, inset, cx)` is the shortcut for grid pages: `Chrome::content`
   minus the page's own padding.
 
@@ -442,6 +442,12 @@ caches Spotify data, subscribe to `Session` and clear on `SignedOut`.
 `forward`. `Root` subscribes to `NavigationEvent::Moved` and swaps the workspace content. For a
 clickable region, use the `Link` trait (`div().id(..).link(Destination::Album(id))`) instead of a
 manual click handler.
+
+**Shells.** `crates/views/src/shells/` holds the two top-level layouts, `Workspace` and
+`FullscreenView`; `Root` swaps between them. A shell owns its own chrome — `Workspace` builds both
+sidebars and the player bar — and answers for its title bar through the `shells::Shell` trait
+(`title_bar(content, cx) -> TitleBarOptions`). `Root` supplies only the current screen's toolbar and
+asks the active shell; it never reaches into a panel.
 
 **New screen checklist:** add a `Destination` variant → add a state entity if it loads data → add
 the view under `crates/views/src/` → construct it in `Root::new` and wire it in `Root::show` →

--- a/crates/views/src/chrome/mod.rs
+++ b/crates/views/src/chrome/mod.rs
@@ -56,7 +56,6 @@ impl Chrome {
             .unwrap_or_default()
     }
 
-    #[allow(dead_code)]
     pub fn sidebar_left(cx: &App) -> Pixels {
         Self::get(cx).sidebar_left
     }

--- a/crates/views/src/chrome/sidebar_right.rs
+++ b/crates/views/src/chrome/sidebar_right.rs
@@ -16,7 +16,7 @@ use ui::{
     ActiveTheme as _, Button, Card, Panel, Popup, Room, Scrollbar, Side, Text, eyebrow, snapped,
 };
 
-use crate::chrome::{SidebarLeft, TrackMenu};
+use crate::chrome::{Chrome, TrackMenu};
 
 const MIN_WIDTH: Pixels = px(240.);
 const MAX_WIDTH: Pixels = px(560.);
@@ -178,7 +178,6 @@ impl Render for DraggedTrack {
 pub(crate) struct SidebarRight {
     queue: Entity<Queue>,
     playback: Entity<Playback>,
-    sidebar: Entity<SidebarLeft>,
     context_menu: Option<ContextMenuState>,
     track_menu: TrackMenu,
     drop_gap: Option<usize>,
@@ -195,7 +194,6 @@ impl SidebarRight {
     pub(crate) fn new(
         queue: Entity<Queue>,
         playback: Entity<Playback>,
-        sidebar: Entity<SidebarLeft>,
         cx: &mut Context<Self>,
     ) -> Self {
         cx.observe(&queue, |this, queue, cx| {
@@ -211,7 +209,8 @@ impl SidebarRight {
             cx.notify();
         })
         .detach();
-        cx.observe(&sidebar, |_, _, cx| cx.notify()).detach();
+        let chrome = Chrome::entity(cx);
+        cx.observe(&chrome, |_, _, cx| cx.notify()).detach();
 
         let scroll = UniformListScrollHandle::new();
         let scrollbar = cx.new(|_| Scrollbar::new(scroll.0.borrow().base_handle.clone()));
@@ -226,7 +225,6 @@ impl SidebarRight {
         Self {
             queue,
             playback,
-            sidebar,
             context_menu: None,
             track_menu: TrackMenu::new(playlist_scrollbar),
             drop_gap: None,
@@ -245,7 +243,7 @@ impl SidebarRight {
     }
 
     pub(crate) fn covers_content(&self, window: &Window, cx: &App) -> bool {
-        let content = window.viewport_size().width - self.sidebar.read(cx).occupied_width();
+        let content = window.viewport_size().width - Chrome::sidebar_left(cx);
         self.open && fills_content(content)
     }
 
@@ -253,7 +251,7 @@ impl SidebarRight {
         match self.open {
             false => Pixels::ZERO,
             true if self.covers_content(window, cx) => {
-                window.viewport_size().width - self.sidebar.read(cx).occupied_width()
+                window.viewport_size().width - Chrome::sidebar_left(cx)
             }
             true => self.width,
         }
@@ -571,7 +569,7 @@ impl Render for SidebarRight {
         }
 
         let theme = *cx.theme();
-        let content_width = window.viewport_size().width - self.sidebar.read(cx).occupied_width();
+        let content_width = window.viewport_size().width - Chrome::sidebar_left(cx);
         let fullscreen = fills_content(content_width);
         let queue = self.queue.read(cx);
         let sections = Sections {

--- a/crates/views/src/root.rs
+++ b/crates/views/src/root.rs
@@ -11,9 +11,10 @@ use state::{
 };
 use ui::ActiveTheme as _;
 
-use crate::chrome::{SidebarLeft, TitleBar, TitleBarEvent, TitleBarOptions, Toolbar, Tooled};
+use crate::chrome::{TitleBar, TitleBarEvent, TitleBarOptions, Toolbar, Tooled};
 use crate::screens::search::SearchView;
 use crate::shared::tracks::{ALBUM_COLUMNS, LIBRARY_COLUMNS};
+use crate::shells::Shell;
 use crate::shells::workspace::Workspace;
 use crate::{
     Adaptive, ArtistView, DetailView, FullscreenView, HomeView, LibraryView, LoginView,
@@ -56,7 +57,6 @@ pub struct Root {
     playback: Entity<Playback>,
     io: Io,
     login: Entity<LoginView>,
-    sidebar: Entity<SidebarLeft>,
     title_bar: Entity<TitleBar>,
     shells: Shells,
     view: RootView,
@@ -78,7 +78,6 @@ impl Root {
         cx.observe(&session, |_, _, cx| cx.notify()).detach();
 
         let login = cx.new(|cx| LoginView::new(session.clone(), cx));
-        let sidebar = cx.new(SidebarLeft::new);
 
         let navigation = router::trail(cx);
 
@@ -132,22 +131,16 @@ impl Root {
         let song = cx.new(|cx| SongView::new(song_detail.clone(), playback.clone(), cx));
 
         let start = navigation.read(cx).current();
-        let workspace = cx.new(|cx| {
-            Workspace::new(
-                sidebar.clone(),
-                playback.clone(),
-                queue,
-                library_view.clone().into(),
-                cx,
-            )
-        });
+        let workspace =
+            cx.new(|cx| Workspace::new(playback.clone(), queue, library_view.clone().into(), cx));
         let fullscreen = cx.new(|cx| FullscreenView::new(playback.clone(), cx));
 
         let title_bar = cx.new(TitleBar::new);
         cx.subscribe(&title_bar, |this, _, event, cx| match event {
-            TitleBarEvent::ToggleSidebar => {
-                this.sidebar.update(cx, |sidebar, cx| sidebar.toggle(cx))
-            }
+            TitleBarEvent::ToggleSidebar => this
+                .shells
+                .workspace
+                .update(cx, |workspace, cx| workspace.toggle_sidebar(cx)),
         })
         .detach();
 
@@ -158,7 +151,6 @@ impl Root {
             playback,
             io,
             login,
-            sidebar,
             title_bar,
             shells: Shells {
                 workspace: workspace.clone(),
@@ -227,14 +219,11 @@ impl Root {
     }
 
     fn options(&self, cx: &Context<Self>) -> TitleBarOptions {
+        let content = self.toolbar.clone().map(Into::into);
+
         match self.view {
-            RootView::Workspace => TitleBarOptions {
-                navigation: true,
-                sidebar_open: self.sidebar.read(cx).is_open(),
-                offset: self.sidebar.read(cx).occupied_width(),
-                content: self.toolbar.clone().map(Into::into),
-            },
-            RootView::Fullscreen => TitleBarOptions::default(),
+            RootView::Workspace => self.shells.workspace.read(cx).title_bar(content, cx),
+            RootView::Fullscreen => self.shells.fullscreen.read(cx).title_bar(content, cx),
         }
     }
 

--- a/crates/views/src/shells/fullscreen.rs
+++ b/crates/views/src/shells/fullscreen.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use gpui::prelude::*;
-use gpui::{App, Context, Entity, FocusHandle, Render, SharedString};
+use gpui::{AnyView, App, Context, Entity, FocusHandle, Pixels, Render, SharedString};
 use gpui::{Window, div};
 use i18n::t;
 use input::ToggleFullscreen;
 use state::Playback;
 use ui::{ActiveTheme as _, Artwork, Text};
+
+use crate::chrome::TitleBarOptions;
+use crate::shells::Shell;
 
 const COVER: f32 = 2.4;
 
@@ -27,6 +30,17 @@ impl FullscreenView {
 
     pub fn focus(&self, window: &mut Window, cx: &mut App) {
         window.focus(&self.focus, cx);
+    }
+}
+
+impl Shell for FullscreenView {
+    fn title_bar(&self, _content: Option<AnyView>, _cx: &App) -> TitleBarOptions {
+        TitleBarOptions {
+            navigation: false,
+            sidebar_open: false,
+            offset: Pixels::ZERO,
+            content: None,
+        }
     }
 }
 

--- a/crates/views/src/shells/mod.rs
+++ b/crates/views/src/shells/mod.rs
@@ -2,3 +2,11 @@
 
 pub(crate) mod fullscreen;
 pub(crate) mod workspace;
+
+use gpui::{AnyView, App};
+
+use crate::chrome::TitleBarOptions;
+
+pub(crate) trait Shell {
+    fn title_bar(&self, content: Option<AnyView>, cx: &App) -> TitleBarOptions;
+}

--- a/crates/views/src/shells/workspace.rs
+++ b/crates/views/src/shells/workspace.rs
@@ -6,7 +6,8 @@ use gpui::{Window, div};
 use input::{Dismiss, WORKSPACE_CONTEXT};
 use state::{Playback, Queue};
 
-use crate::chrome::{Chrome, PlayerBar, SidebarLeft, SidebarRight};
+use crate::chrome::{Chrome, PlayerBar, SidebarLeft, SidebarRight, TitleBarOptions};
+use crate::shells::Shell;
 
 pub(crate) struct Workspace {
     sidebar: Entity<SidebarLeft>,
@@ -18,14 +19,13 @@ pub(crate) struct Workspace {
 
 impl Workspace {
     pub fn new(
-        sidebar: Entity<SidebarLeft>,
         playback: Entity<Playback>,
         queue: Entity<Queue>,
         content: AnyView,
         cx: &mut Context<Self>,
     ) -> Self {
-        let sidebar_right =
-            cx.new(|cx| SidebarRight::new(queue.clone(), playback.clone(), sidebar.clone(), cx));
+        let sidebar = cx.new(SidebarLeft::new);
+        let sidebar_right = cx.new(|cx| SidebarRight::new(queue.clone(), playback.clone(), cx));
         let player_bar =
             cx.new(|cx| PlayerBar::with_sidebar_right(playback, queue, sidebar_right.clone(), cx));
 
@@ -40,6 +40,10 @@ impl Workspace {
 
     pub fn focus(&self, window: &mut Window, cx: &mut App) {
         window.focus(&self.focus, cx);
+    }
+
+    pub fn toggle_sidebar(&self, cx: &mut Context<Self>) {
+        self.sidebar.update(cx, |sidebar, cx| sidebar.toggle(cx));
     }
 
     #[allow(dead_code)]
@@ -60,6 +64,19 @@ impl Workspace {
     fn close_queue(&mut self, cx: &mut Context<Self>) {
         if self.sidebar_right.read(cx).is_open() {
             self.sidebar_right.update(cx, |panel, cx| panel.close(cx));
+        }
+    }
+}
+
+impl Shell for Workspace {
+    fn title_bar(&self, content: Option<AnyView>, cx: &App) -> TitleBarOptions {
+        let sidebar = self.sidebar.read(cx);
+
+        TitleBarOptions {
+            navigation: true,
+            sidebar_open: sidebar.is_open(),
+            offset: sidebar.occupied_width(),
+            content,
         }
     }
 }


### PR DESCRIPTION
## What changed

- `SidebarRight` no longer holds an `Entity<SidebarLeft>`; it reads the left panel's contribution through `Chrome::sidebar_left`.
- `Workspace` builds both side panels itself and takes neither as a constructor parameter.
- `Root` no longer owns a side panel. A new crate-private `Shell` trait lets each shell answer which title bar it wants.

## Why

`Workspace::new` received the left panel from outside but built the right one itself. That was a
symptom of two separate leaks rather than an oversight.

The right panel held a reference to the left one purely to compute
`viewport_width - left.occupied_width()` in three places. That is exactly what `Chrome::sidebar_left`
returns, so the panels no longer need to know about each other.

`Root` owned the left panel only because hoisting the title bar left it needing the panel's open
state, its width, and a way to toggle it. So the application root owned a widget that lives inside
one particular shell — and it computed title-bar options for the fullscreen shell too, reaching into
a sidebar that does not exist there. Now each shell answers for itself.

## User impact

None. This is structural.

## Notes

- The `Chrome` read is not the circular case `CLAUDE.md` warns about. That warning covers
  `Chrome::content`, which subtracts both panels, so a panel sizing itself from it would feed its own
  output back in. `Chrome::sidebar_left` is a single-panel read with no term derived from the right
  panel.
- It does trade freshness for the decoupling: `Chrome` is published during `Workspace::render`, so
  the right panel sees the previous frame's left width in the narrow case where the left panel just
  changed and the right one is in its fills-content mode. `SidebarRight` now observes `Chrome`
  instead of the left panel, so it still repaints — one frame later. Accepted deliberately; if it
  ever shows, the fix is to pass the width in rather than to synchronise.
- `FullscreenView` supplies its own title bar options and drops the toolbar, which it has no use for.

## Validation

- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace` — 117 passed
- `cargo clippy --workspace` — warning profile identical to the baseline
- Launched the app: stayed alive, no panics, no unregistered assets, no missing i18n keys

Not exercised: no UI test harness here, so resizing either panel and the fullscreen title bar are
verified by construction and startup only.
