### PR TITLE
refactor(views): let screens supply their own toolbar controls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -459,8 +459,17 @@ add a sidebar entry in `views/src/chrome/sidebar_left.rs` if it's top-level.
 and `hide_below` for responsive dropping. Hidden columns persist through
 `AppSettings::{hidden_columns, set_hidden_columns}`.
 
-**Filtering.** Implement `chrome::Searchable` on the view; `Root` binds it to the shared `Filter`
-in the title bar. Don't build a second search box.
+**Toolbar.** `chrome::Toolbar` owns only the search field and lays out whatever a screen hands it.
+A screen implements `chrome::Tooled` — `toolbar()` returns its `Entity<Toolbar>`, `tools(&self, cx)`
+returns the finished `Vec<AnyElement>` — and wires itself once with `Toolbar::wire`. Adding a
+control to a screen never touches `toolbar.rs`. Build the standard controls with the shared builders
+in `chrome::tools` (`columns`, `filters`, `sorts`, `views`) rather than writing a menu twice; each
+screen owns one `ui::Popovers` so only one of its popovers is open at a time, and holds its own
+`tools::Sliders` cache so scrubber positions survive across frames (`LibraryView` keeps one per
+section, so tab switches cannot bleed).
+
+**Filtering.** Implement `chrome::Searchable` on the view; `Toolbar::bind` binds it to the search
+field in the title bar. Don't build a second search box.
 
 **Actions and keys.** Declare actions in `crates/input/src/lib.rs` (`actions!` macro), bind them in
 `bindings()`, handle them with `cx.on_action` (global, in `sonora/src/actions.rs`) or

--- a/crates/views/src/chrome/mod.rs
+++ b/crates/views/src/chrome/mod.rs
@@ -5,13 +5,14 @@ mod sidebar_left;
 mod sidebar_right;
 mod title_bar;
 mod toolbar;
+pub(crate) mod tools;
 mod track_menu;
 
 pub(crate) use player_bar::PlayerBar;
 pub(crate) use sidebar_left::SidebarLeft;
 pub(crate) use sidebar_right::SidebarRight;
 pub(crate) use title_bar::{TitleBar, TitleBarEvent, TitleBarOptions};
-pub(crate) use toolbar::{Columned, Filterable, Searchable, Sortable, Toolbar, Tooled, Viewed};
+pub(crate) use toolbar::{Searchable, Toolbar, Tooled};
 pub(crate) use track_menu::TrackMenu;
 
 use gpui::{App, AppContext as _, Entity, Global, Pixels, Window};

--- a/crates/views/src/chrome/toolbar.rs
+++ b/crates/views/src/chrome/toolbar.rs
@@ -1,29 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use gpui::prelude::*;
-use gpui::{App, Context, Entity, Pixels, Render, SharedString, WeakEntity, Window, div, px};
+use gpui::{AnyElement, App, Context, Entity, Pixels, Render, SharedString, Window, div, px};
 use input::{Dismiss, Input};
-use ui::{
-    ActiveTheme as _, Button, FlagAxis, Menu, MenuItem, Mode, Popover, Popovers, RangeAxis,
-    RangeScrubber, RangeState, Sort, SortAxis, Toggle, eyebrow,
-};
+use ui::Button;
 
 const WIDEST: Pixels = px(280.);
-const MENU_WIDTH: Pixels = px(190.);
-const FILTER_WIDTH: Pixels = px(260.);
-const MENU_DROP: Pixels = px(30.);
-
-const COLUMNS: &str = "columns";
-const FILTERS: &str = "filters";
-const SORTS: &str = "sorts";
 
 type Apply = Box<dyn Fn(&str, &mut App)>;
-type Toggles = Box<dyn Fn(&App) -> Vec<Toggle>>;
-type Switch = Box<dyn Fn(&'static str, &mut App)>;
-type Reading = Box<dyn Fn(&App) -> Mode>;
-type Shift = Box<dyn Fn(Mode, &mut App)>;
-type Axes = Box<dyn Fn(&App) -> Vec<SortAxis>>;
-type Rank = Box<dyn Fn(&'static str, &mut App)>;
+type Tools = Box<dyn Fn(&App) -> Vec<AnyElement>>;
 
 pub(crate) trait Searchable: 'static {
     fn search(&mut self, query: &str, cx: &mut Context<Self>)
@@ -38,106 +23,16 @@ pub(crate) trait Searchable: 'static {
     }
 }
 
-pub(crate) trait Columned: 'static {
-    fn toggles(&self, cx: &App) -> Vec<Toggle>;
-
-    fn toggle_column(&mut self, key: &'static str, cx: &mut Context<Self>)
-    where
-        Self: Sized;
-}
-
-pub(crate) trait Viewed: 'static {
-    fn mode(&self, cx: &App) -> Mode;
-
-    fn set_mode(&mut self, mode: Mode, cx: &mut Context<Self>)
-    where
-        Self: Sized;
-}
-
-pub(crate) trait Filterable: 'static {
-    fn ranges(&self, cx: &App) -> Vec<RangeAxis>;
-
-    fn flags(&self, cx: &App) -> Vec<FlagAxis>;
-
-    fn set_range(&mut self, key: &'static str, value: (f32, f32), cx: &mut Context<Self>)
-    where
-        Self: Sized;
-
-    fn set_flag(&mut self, key: &'static str, on: bool, cx: &mut Context<Self>)
-    where
-        Self: Sized;
-
-    fn reset_filters(&mut self, cx: &mut Context<Self>)
-    where
-        Self: Sized;
-}
-
-pub(crate) trait Sortable: 'static {
-    fn sorts(&self, cx: &App) -> Vec<SortAxis>;
-
-    fn set_sort(&mut self, key: &'static str, cx: &mut Context<Self>)
-    where
-        Self: Sized;
-}
-
-trait Port {
-    fn ranges(&self, cx: &App) -> Vec<RangeAxis>;
-    fn flags(&self, cx: &App) -> Vec<FlagAxis>;
-    fn set_range(&self, key: &'static str, value: (f32, f32), cx: &mut App);
-    fn set_flag(&self, key: &'static str, on: bool, cx: &mut App);
-    fn reset(&self, cx: &mut App);
-}
-
-struct Wire<V>(WeakEntity<V>);
-
-impl<V: Filterable> Port for Wire<V> {
-    fn ranges(&self, cx: &App) -> Vec<RangeAxis> {
-        self.0
-            .upgrade()
-            .map(|view| view.read(cx).ranges(cx))
-            .unwrap_or_default()
-    }
-
-    fn flags(&self, cx: &App) -> Vec<FlagAxis> {
-        self.0
-            .upgrade()
-            .map(|view| view.read(cx).flags(cx))
-            .unwrap_or_default()
-    }
-
-    fn set_range(&self, key: &'static str, value: (f32, f32), cx: &mut App) {
-        self.0
-            .update(cx, |view, cx| view.set_range(key, value, cx))
-            .ok();
-    }
-
-    fn set_flag(&self, key: &'static str, on: bool, cx: &mut App) {
-        self.0
-            .update(cx, |view, cx| view.set_flag(key, on, cx))
-            .ok();
-    }
-
-    fn reset(&self, cx: &mut App) {
-        self.0.update(cx, |view, cx| view.reset_filters(cx)).ok();
-    }
-}
-
 pub(crate) trait Tooled: 'static {
     fn toolbar(&self) -> Entity<Toolbar>;
+
+    fn tools(&self, cx: &App) -> Vec<AnyElement>;
 }
 
 pub(crate) struct Toolbar {
     input: Entity<Input>,
     apply: Option<Apply>,
-    toggles: Option<Toggles>,
-    switch: Option<Switch>,
-    reading: Option<Reading>,
-    shift: Option<Shift>,
-    axes: Option<Axes>,
-    rank: Option<Rank>,
-    port: Option<Box<dyn Port>>,
-    sliders: Vec<(&'static str, RangeState)>,
-    popovers: Popovers,
+    tools: Option<Tools>,
     open: bool,
 }
 
@@ -161,15 +56,7 @@ impl Toolbar {
         Self {
             input,
             apply: None,
-            toggles: None,
-            switch: None,
-            reading: None,
-            shift: None,
-            axes: None,
-            rank: None,
-            port: None,
-            sliders: Vec::new(),
-            popovers: Popovers::default(),
+            tools: None,
             open: false,
         }
     }
@@ -185,59 +72,13 @@ impl Toolbar {
         cx.notify();
     }
 
-    pub fn columns<V: Columned>(&mut self, view: &Entity<V>, cx: &mut Context<Self>) {
-        let read = view.downgrade();
-        let write = view.downgrade();
-
-        self.toggles = Some(Box::new(move |cx| {
-            read.upgrade()
-                .map(|view| view.read(cx).toggles(cx))
+    pub fn wire<V: Tooled>(&mut self, view: &Entity<V>, cx: &mut Context<Self>) {
+        let source = view.downgrade();
+        self.tools = Some(Box::new(move |cx| {
+            source
+                .upgrade()
+                .map(|view| view.read(cx).tools(cx))
                 .unwrap_or_default()
-        }));
-        self.switch = Some(Box::new(move |key, cx| {
-            write
-                .update(cx, |view, cx| view.toggle_column(key, cx))
-                .ok();
-        }));
-
-        cx.observe(view, |_, _, cx| cx.notify()).detach();
-        cx.notify();
-    }
-
-    pub fn views<V: Viewed>(&mut self, view: &Entity<V>, cx: &mut Context<Self>) {
-        let read = view.downgrade();
-        let write = view.downgrade();
-
-        self.reading = Some(Box::new(move |cx| {
-            read.upgrade()
-                .map(|view| view.read(cx).mode(cx))
-                .unwrap_or_default()
-        }));
-        self.shift = Some(Box::new(move |mode, cx| {
-            write.update(cx, |view, cx| view.set_mode(mode, cx)).ok();
-        }));
-
-        cx.observe(view, |_, _, cx| cx.notify()).detach();
-        cx.notify();
-    }
-
-    pub fn filters<V: Filterable>(&mut self, view: &Entity<V>, cx: &mut Context<Self>) {
-        self.port = Some(Box::new(Wire(view.downgrade())));
-        cx.observe(view, |_, _, cx| cx.notify()).detach();
-        cx.notify();
-    }
-
-    pub fn sorts<V: Sortable>(&mut self, view: &Entity<V>, cx: &mut Context<Self>) {
-        let read = view.downgrade();
-        let write = view.downgrade();
-
-        self.axes = Some(Box::new(move |cx| {
-            read.upgrade()
-                .map(|view| view.read(cx).sorts(cx))
-                .unwrap_or_default()
-        }));
-        self.rank = Some(Box::new(move |key, cx| {
-            write.update(cx, |view, cx| view.set_sort(key, cx)).ok();
         }));
 
         cx.observe(view, |_, _, cx| cx.notify()).detach();
@@ -266,237 +107,14 @@ impl Toolbar {
         self.input.update(cx, |input, cx| input.set_text("", cx));
         cx.notify();
     }
-
-    fn mode(&self, cx: &App) -> Mode {
-        match self.reading.as_ref() {
-            Some(reading) => reading(cx),
-            None => Mode::default(),
-        }
-    }
-
-    fn switcher(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let next = match self.mode(cx) {
-            Mode::List => Mode::Cards,
-            Mode::Cards => Mode::List,
-        };
-
-        Button::new("view-toggle")
-            .icon(next.icon())
-            .small()
-            .ghost()
-            .on_click(cx.listener(move |this, _, _, cx| {
-                this.popovers.close();
-                if let Some(shift) = this.shift.as_ref() {
-                    shift(next, cx);
-                }
-                cx.notify();
-            }))
-    }
-
-    fn ranks(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let axes = match self.axes.as_ref() {
-            Some(axes) => axes(cx),
-            None => Vec::new(),
-        };
-        let sorted = axes.iter().any(|axis| axis.order.is_some());
-        let theme = *cx.theme();
-
-        Popover::new(SORTS, self.popovers.clone())
-            .button(
-                Button::new("sort-toggle")
-                    .icon("icons/arrow-up-down.svg")
-                    .small()
-                    .ghost()
-                    .tint(match sorted {
-                        true => theme.primary,
-                        false => theme.muted_foreground,
-                    }),
-            )
-            .menu(
-                Menu::new("sort-menu")
-                    .top(MENU_DROP)
-                    .right_0()
-                    .w(MENU_WIDTH)
-                    .items(axes.into_iter().map(|axis| {
-                        let key = axis.key;
-                        let arrow = axis.order.map(|order| match order {
-                            Sort::Ascending => "icons/chevron-up.svg",
-                            Sort::Descending => "icons/chevron-down.svg",
-                        });
-
-                        MenuItem::new(key, axis.label)
-                            .selected(axis.order.is_some())
-                            .when_some(arrow, MenuItem::icon)
-                            .on_click(cx.listener(move |this, _, _, cx| {
-                                if let Some(rank) = this.rank.as_ref() {
-                                    rank(key, cx);
-                                }
-                                cx.notify();
-                            }))
-                    })),
-            )
-    }
-
-    fn menu(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let toggles = match self.toggles.as_ref() {
-            Some(toggles) => toggles(cx),
-            None => Vec::new(),
-        };
-
-        Popover::new(COLUMNS, self.popovers.clone())
-            .button(
-                Button::new("columns-toggle")
-                    .icon("icons/columns-3.svg")
-                    .small()
-                    .ghost(),
-            )
-            .menu(
-                Menu::new("columns-menu")
-                    .top(MENU_DROP)
-                    .right_0()
-                    .w(MENU_WIDTH)
-                    .items(toggles.into_iter().map(|toggle| {
-                        let key = toggle.key;
-                        MenuItem::new(key, toggle.label)
-                            .selected(toggle.visible)
-                            .on_click(cx.listener(move |this, _, _, cx| {
-                                if let Some(switch) = this.switch.as_ref() {
-                                    switch(key, cx);
-                                }
-                                cx.notify();
-                            }))
-                    })),
-            )
-    }
-}
-
-impl Toolbar {
-    fn slider(&mut self, key: &'static str) -> RangeState {
-        if let Some((_, state)) = self.sliders.iter().find(|(known, _)| *known == key) {
-            return state.clone();
-        }
-
-        let state = RangeState::new(key);
-        self.sliders.push((key, state.clone()));
-        state
-    }
-
-    fn sift(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
-        let theme = *cx.theme();
-        let ranges = match self.port.as_ref() {
-            Some(port) => port.ranges(cx),
-            None => Vec::new(),
-        };
-        let flags = match self.port.as_ref() {
-            Some(port) => port.flags(cx),
-            None => Vec::new(),
-        };
-        let narrowed = ranges.iter().any(|axis| !axis.whole()) || flags.iter().any(|flag| flag.on);
-
-        let states: Vec<RangeState> = ranges.iter().map(|axis| self.slider(axis.key)).collect();
-
-        let sliders: Vec<MenuItem> = ranges
-            .iter()
-            .zip(states.iter())
-            .map(|(axis, state)| {
-                let key = axis.key;
-                let unit = axis.unit;
-                let copy = axis.clone();
-                MenuItem::new(key, axis.label.clone()).content(
-                    div()
-                        .flex()
-                        .flex_col()
-                        .gap_1()
-                        .py_1()
-                        .child(
-                            div()
-                                .flex()
-                                .items_center()
-                                .justify_between()
-                                .gap_2()
-                                .child(eyebrow(axis.label.clone(), cx))
-                                .child(
-                                    div()
-                                        .text_size(theme.text(ui::Text::Small))
-                                        .text_color(theme.muted_foreground)
-                                        .child(format!(
-                                            "{} - {}",
-                                            unit.say(axis.value.0),
-                                            unit.say(axis.value.1)
-                                        )),
-                                ),
-                        )
-                        .child(
-                            RangeScrubber::new(state, axis.share())
-                                .stops(axis.stops())
-                                .colors(theme.progress_bar, theme.muted, theme.foreground)
-                                .on_change(cx.listener(move |this, share: &(f32, f32), _, cx| {
-                                    if let Some(port) = this.port.as_ref() {
-                                        port.set_range(key, copy.at(*share), cx);
-                                    }
-                                    cx.notify();
-                                })),
-                        ),
-                )
-            })
-            .collect();
-
-        let switches: Vec<MenuItem> = flags
-            .iter()
-            .map(|flag| {
-                let key = flag.key;
-                let on = flag.on;
-                MenuItem::new(key, flag.label.clone())
-                    .selected(on)
-                    .on_click(cx.listener(move |this, _, _, cx| {
-                        if let Some(port) = this.port.as_ref() {
-                            port.set_flag(key, !on, cx);
-                        }
-                        cx.notify();
-                    }))
-            })
-            .collect();
-
-        Popover::new(FILTERS, self.popovers.clone())
-            .button(
-                Button::new("filters-toggle")
-                    .icon("icons/funnel.svg")
-                    .small()
-                    .ghost()
-                    .tint(match narrowed {
-                        true => theme.primary,
-                        false => theme.muted_foreground,
-                    }),
-            )
-            .menu(
-                Menu::new("filters-menu")
-                    .top(MENU_DROP)
-                    .right_0()
-                    .w(FILTER_WIDTH)
-                    .items(sliders)
-                    .items(switches)
-                    .item(MenuItem::separator("filters-end"))
-                    .item(
-                        MenuItem::new("filters-reset", i18n::t!("filter-reset")).on_click(
-                            cx.listener(|this, _, _, cx| {
-                                if let Some(port) = this.port.as_ref() {
-                                    port.reset(cx);
-                                }
-                                cx.notify();
-                            }),
-                        ),
-                    ),
-            )
-    }
 }
 
 impl Render for Toolbar {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let sift = match self.port.is_some() {
-            true => Some(self.sift(cx).into_any_element()),
-            false => None,
+        let tools = match self.tools.as_ref() {
+            Some(tools) => tools(cx),
+            None => Vec::new(),
         };
-        let listed = self.mode(cx) == Mode::List;
 
         div()
             .flex()
@@ -506,12 +124,7 @@ impl Render for Toolbar {
             .justify_end()
             .gap_1()
             .on_action(cx.listener(|this, _: &Dismiss, _, cx| this.close(cx)))
-            .when(self.toggles.is_some() && listed, |this| {
-                this.child(self.menu(cx))
-            })
-            .children(sift)
-            .when(self.axes.is_some(), |this| this.child(self.ranks(cx)))
-            .when(self.reading.is_some(), |this| this.child(self.switcher(cx)))
+            .children(tools)
             .when(self.apply.is_some(), |this| {
                 this.when(self.open, |this| {
                     this.child(

--- a/crates/views/src/chrome/tools.rs
+++ b/crates/views/src/chrome/tools.rs
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use gpui::prelude::*;
+use gpui::{AnyElement, App, Pixels, div, px};
+use ui::{
+    ActiveTheme as _, Button, FlagAxis, Menu, MenuItem, Mode, Popover, Popovers, RangeAxis,
+    RangeScrubber, RangeState, Sort, SortAxis, Text, Toggle, eyebrow,
+};
+
+const MENU_WIDTH: Pixels = px(190.);
+const FILTER_WIDTH: Pixels = px(260.);
+const MENU_DROP: Pixels = px(30.);
+
+const COLUMNS: &str = "columns";
+const FILTERS: &str = "filters";
+const SORTS: &str = "sorts";
+
+#[derive(Default)]
+pub(crate) struct Sliders(RefCell<Vec<(&'static str, RangeState)>>);
+
+impl Sliders {
+    fn state(&self, key: &'static str) -> RangeState {
+        let mut cache = self.0.borrow_mut();
+        if let Some((_, state)) = cache.iter().find(|(known, _)| *known == key) {
+            return state.clone();
+        }
+
+        let state = RangeState::new(key);
+        cache.push((key, state.clone()));
+        state
+    }
+}
+
+pub(crate) enum Sift {
+    Range(&'static str, (f32, f32)),
+    Flag(&'static str, bool),
+    Reset,
+}
+
+pub(crate) fn columns(
+    group: &Popovers,
+    toggles: Vec<Toggle>,
+    switch: impl Fn(&'static str, &mut App) + 'static,
+) -> AnyElement {
+    let switch = Rc::new(switch);
+
+    Popover::new(COLUMNS, group.clone())
+        .button(
+            Button::new("columns-toggle")
+                .icon("icons/columns-3.svg")
+                .small()
+                .ghost(),
+        )
+        .menu(
+            Menu::new("columns-menu")
+                .top(MENU_DROP)
+                .right_0()
+                .w(MENU_WIDTH)
+                .items(toggles.into_iter().map(move |toggle| {
+                    let key = toggle.key;
+                    let switch = switch.clone();
+
+                    MenuItem::new(key, toggle.label)
+                        .selected(toggle.visible)
+                        .on_click(move |_, _, cx| switch(key, cx))
+                })),
+        )
+        .into_any_element()
+}
+
+pub(crate) fn sorts(
+    group: &Popovers,
+    axes: Vec<SortAxis>,
+    rank: impl Fn(&'static str, &mut App) + 'static,
+    cx: &App,
+) -> AnyElement {
+    let theme = *cx.theme();
+    let sorted = axes.iter().any(|axis| axis.order.is_some());
+    let rank = Rc::new(rank);
+
+    Popover::new(SORTS, group.clone())
+        .button(
+            Button::new("sort-toggle")
+                .icon("icons/arrow-up-down.svg")
+                .small()
+                .ghost()
+                .tint(match sorted {
+                    true => theme.primary,
+                    false => theme.muted_foreground,
+                }),
+        )
+        .menu(
+            Menu::new("sort-menu")
+                .top(MENU_DROP)
+                .right_0()
+                .w(MENU_WIDTH)
+                .items(axes.into_iter().map(move |axis| {
+                    let key = axis.key;
+                    let rank = rank.clone();
+                    let arrow = axis.order.map(|order| match order {
+                        Sort::Ascending => "icons/chevron-up.svg",
+                        Sort::Descending => "icons/chevron-down.svg",
+                    });
+
+                    MenuItem::new(key, axis.label)
+                        .selected(axis.order.is_some())
+                        .when_some(arrow, MenuItem::icon)
+                        .on_click(move |_, _, cx| rank(key, cx))
+                })),
+        )
+        .into_any_element()
+}
+
+pub(crate) fn filters(
+    group: &Popovers,
+    sliders: &Sliders,
+    ranges: Vec<RangeAxis>,
+    flags: Vec<FlagAxis>,
+    sift: impl Fn(Sift, &mut App) + 'static,
+    cx: &App,
+) -> AnyElement {
+    let theme = *cx.theme();
+    let narrowed = ranges.iter().any(|axis| !axis.whole()) || flags.iter().any(|flag| flag.on);
+    let sift = Rc::new(sift);
+
+    let scrubbers: Vec<MenuItem> = ranges
+        .iter()
+        .map(|axis| {
+            let key = axis.key;
+            let unit = axis.unit;
+            let copy = axis.clone();
+            let sift = sift.clone();
+            let state = sliders.state(key);
+
+            MenuItem::new(key, axis.label.clone()).content(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap_1()
+                    .py_1()
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .justify_between()
+                            .gap_2()
+                            .child(eyebrow(axis.label.clone(), cx))
+                            .child(
+                                div()
+                                    .text_size(theme.text(Text::Small))
+                                    .text_color(theme.muted_foreground)
+                                    .child(format!(
+                                        "{} - {}",
+                                        unit.say(axis.value.0),
+                                        unit.say(axis.value.1)
+                                    )),
+                            ),
+                    )
+                    .child(
+                        RangeScrubber::new(&state, axis.share())
+                            .stops(axis.stops())
+                            .colors(theme.progress_bar, theme.muted, theme.foreground)
+                            .on_change(move |share: &(f32, f32), _, cx| {
+                                sift(Sift::Range(key, copy.at(*share)), cx);
+                            }),
+                    ),
+            )
+        })
+        .collect();
+
+    let switches: Vec<MenuItem> = flags
+        .iter()
+        .map(|flag| {
+            let key = flag.key;
+            let on = flag.on;
+            let sift = sift.clone();
+
+            MenuItem::new(key, flag.label.clone())
+                .selected(on)
+                .on_click(move |_, _, cx| sift(Sift::Flag(key, !on), cx))
+        })
+        .collect();
+
+    let reset = sift.clone();
+
+    Popover::new(FILTERS, group.clone())
+        .button(
+            Button::new("filters-toggle")
+                .icon("icons/funnel.svg")
+                .small()
+                .ghost()
+                .tint(match narrowed {
+                    true => theme.primary,
+                    false => theme.muted_foreground,
+                }),
+        )
+        .menu(
+            Menu::new("filters-menu")
+                .top(MENU_DROP)
+                .right_0()
+                .w(FILTER_WIDTH)
+                .items(scrubbers)
+                .items(switches)
+                .item(MenuItem::separator("filters-end"))
+                .item(
+                    MenuItem::new("filters-reset", i18n::t!("filter-reset"))
+                        .on_click(move |_, _, cx| reset(Sift::Reset, cx)),
+                ),
+        )
+        .into_any_element()
+}
+
+pub(crate) fn views(
+    group: &Popovers,
+    mode: Mode,
+    shift: impl Fn(Mode, &mut App) + 'static,
+) -> AnyElement {
+    let next = match mode {
+        Mode::List => Mode::Cards,
+        Mode::Cards => Mode::List,
+    };
+    let group = group.clone();
+
+    Button::new("view-toggle")
+        .icon(next.icon())
+        .small()
+        .ghost()
+        .on_click(move |_, _, cx| {
+            group.close();
+            shift(next, cx);
+        })
+        .into_any_element()
+}

--- a/crates/views/src/screens/detail.rs
+++ b/crates/views/src/screens/detail.rs
@@ -2,19 +2,21 @@
 
 use gpui::prelude::*;
 use gpui::{
-    AnyElement, App, Context, Entity, Pixels, Render, ScrollHandle, SharedString, Window, px,
+    AnyElement, App, Context, Entity, Pixels, Render, ScrollHandle, SharedString, WeakEntity,
+    Window, px,
 };
 
 use i18n::t;
 use spotify::Track;
 use state::{AppSettings, Collection, Detail, Playback, Sonora};
-use ui::{ActiveTheme as _, SortAxis};
+use ui::{ActiveTheme as _, Popovers, SortAxis};
 use ui::{
     ColumnSpec, FlagAxis, GridDelegate, GridEvent, GridState, RangeAxis, Scrollbar, Scroller,
     Table as _, Toggle, Unit, clock, grid,
 };
 
-use crate::chrome::{Chrome, Columned, Filterable, Searchable, Sortable, Toolbar, Tooled};
+use crate::chrome::tools::{self, Sift, Sliders};
+use crate::chrome::{Chrome, Searchable, Toolbar, Tooled};
 use crate::shared::hero::{HeroMetaStrip, HeroPlayButton, PageHero, release_date_label};
 use crate::shared::tracks::{
     PlaybackStatus, TrackField, TrackSieve, TrackSource, Tracks, playback_status,
@@ -46,6 +48,9 @@ pub(crate) struct DetailView {
     section: &'static str,
     sorted: Option<String>,
     toolbar: Entity<Toolbar>,
+    popovers: Popovers,
+    sliders: Sliders,
+    me: WeakEntity<Self>,
 }
 
 impl DetailView {
@@ -134,9 +139,7 @@ impl DetailView {
         let toolbar = cx.new(|cx| {
             let mut toolbar = Toolbar::new(cx);
             toolbar.bind(&me, cx);
-            toolbar.columns(&me, cx);
-            toolbar.filters(&me, cx);
-            toolbar.sorts(&me, cx);
+            toolbar.wire(&me, cx);
             toolbar
         });
 
@@ -151,6 +154,9 @@ impl DetailView {
             section,
             sorted: None,
             toolbar,
+            popovers: Popovers::default(),
+            sliders: Sliders::default(),
+            me: me.downgrade(),
         }
     }
 
@@ -285,7 +291,7 @@ impl Searchable for DetailView {
     }
 }
 
-impl Sortable for DetailView {
+impl DetailView {
     fn sorts(&self, cx: &App) -> Vec<SortAxis> {
         self.table.sortables(cx)
     }
@@ -294,9 +300,7 @@ impl Sortable for DetailView {
         self.table.clone().cycle_sort(key, cx);
         cx.notify();
     }
-}
 
-impl Columned for DetailView {
     fn toggles(&self, cx: &App) -> Vec<Toggle> {
         self.table
             .read(cx)
@@ -324,6 +328,38 @@ impl Tooled for DetailView {
     fn toolbar(&self) -> Entity<Toolbar> {
         self.toolbar.clone()
     }
+
+    fn tools(&self, cx: &App) -> Vec<AnyElement> {
+        let columned = self.me.clone();
+        let sifted = self.me.clone();
+        let sorted = self.me.clone();
+
+        vec![
+            tools::columns(&self.popovers, self.toggles(cx), move |key, cx| {
+                columned
+                    .update(cx, |view, cx| view.toggle_column(key, cx))
+                    .ok();
+            }),
+            tools::filters(
+                &self.popovers,
+                &self.sliders,
+                self.ranges(cx),
+                self.flags(cx),
+                move |change, cx| {
+                    sifted.update(cx, |view, cx| view.narrow(change, cx)).ok();
+                },
+                cx,
+            ),
+            tools::sorts(
+                &self.popovers,
+                self.sorts(cx),
+                move |key, cx| {
+                    sorted.update(cx, |view, cx| view.set_sort(key, cx)).ok();
+                },
+                cx,
+            ),
+        ]
+    }
 }
 
 impl DetailView {
@@ -339,9 +375,7 @@ impl DetailView {
         });
         cx.notify();
     }
-}
 
-impl Filterable for DetailView {
     fn ranges(&self, cx: &App) -> Vec<RangeAxis> {
         let table = self.table.read(cx);
         let Some(bounds) = table
@@ -381,23 +415,15 @@ impl Filterable for DetailView {
         ]
     }
 
-    fn set_range(&mut self, _key: &'static str, value: (f32, f32), cx: &mut Context<Self>) {
+    fn narrow(&mut self, change: Sift, cx: &mut Context<Self>) {
         let mut sieve = self.sieve(cx);
-        sieve.duration = Some(value);
-        self.sift(sieve, cx);
-    }
-
-    fn set_flag(&mut self, key: &'static str, on: bool, cx: &mut Context<Self>) {
-        let mut sieve = self.sieve(cx);
-        match key {
-            "filter-explicit" => sieve.explicit = on,
-            "filter-playable" => sieve.playable = on,
-            _ => return,
+        match change {
+            Sift::Range(_, value) => sieve.duration = Some(value),
+            Sift::Flag("filter-explicit", on) => sieve.explicit = on,
+            Sift::Flag("filter-playable", on) => sieve.playable = on,
+            Sift::Flag(..) => return,
+            Sift::Reset => sieve = TrackSieve::default(),
         }
         self.sift(sieve, cx);
-    }
-
-    fn reset_filters(&mut self, cx: &mut Context<Self>) {
-        self.sift(TrackSieve::default(), cx);
     }
 }

--- a/crates/views/src/screens/library/mod.rs
+++ b/crates/views/src/screens/library/mod.rs
@@ -3,11 +3,12 @@
 mod albums;
 mod playlists;
 
-use crate::chrome::{Chrome, Columned, Filterable, Searchable, Sortable, Toolbar, Tooled, Viewed};
+use crate::chrome::tools::{self, Sift, Sliders};
+use crate::chrome::{Chrome, Searchable, Toolbar, Tooled};
 use gpui::prelude::*;
 use gpui::{
     AnyElement, App, Context, Entity, FontWeight, Pixels, Point, Render, ScrollHandle,
-    SharedString, Window, div, px,
+    SharedString, WeakEntity, Window, div, px,
 };
 use i18n::t;
 use router::{Destination, LibraryTab, navigate};
@@ -15,8 +16,8 @@ use spotify::Track;
 use state::{AppSettings, Library, LibraryState, Origin, Playback, PlaybackState, Sonora};
 use ui::{
     ActiveTheme as _, Card, FlagAxis, GridDelegate, GridEvent, GridSource, GridState, Mode,
-    RangeAxis, Scrollbar, Scroller, Sort, SortAxis, Text, Toggle, Unit, Viewport, heading,
-    scrolled,
+    Popovers, RangeAxis, Scrollbar, Scroller, Sort, SortAxis, Text, Toggle, Unit, Viewport,
+    heading, scrolled,
 };
 
 use crate::shared::release_card::ReleaseCard;
@@ -105,6 +106,9 @@ pub struct LibraryView {
     albums: Entity<GridState<AlbumSource>>,
     playlists: Entity<GridState<PlaylistSource>>,
     toolbar: Entity<Toolbar>,
+    popovers: Popovers,
+    sliders: [Sliders; 3],
+    me: WeakEntity<Self>,
 }
 
 impl LibraryView {
@@ -215,10 +219,7 @@ impl LibraryView {
         let toolbar = cx.new(|cx| {
             let mut toolbar = Toolbar::new(cx);
             toolbar.bind(&me, cx);
-            toolbar.columns(&me, cx);
-            toolbar.views(&me, cx);
-            toolbar.filters(&me, cx);
-            toolbar.sorts(&me, cx);
+            toolbar.wire(&me, cx);
             toolbar
         });
 
@@ -235,6 +236,9 @@ impl LibraryView {
             albums,
             playlists,
             toolbar,
+            popovers: Popovers::default(),
+            sliders: Section::ALL.map(|_| Sliders::default()),
+            me: me.downgrade(),
         }
     }
 
@@ -481,12 +485,10 @@ impl Render for LibraryView {
         let table = self.table(self.section);
         table.set_viewport(viewport, cx);
 
-        Scroller::new("library-page", &self.scrollbar).child(
-            match self.views[self.section.slot()] {
-                Mode::List => table.element(),
-                Mode::Cards => self.cards(cx),
-            },
-        )
+        Scroller::new("library-page", &self.scrollbar).child(match self.mode() {
+            Mode::List => table.element(),
+            Mode::Cards => self.cards(cx),
+        })
     }
 }
 
@@ -503,7 +505,7 @@ impl Searchable for LibraryView {
     }
 }
 
-impl Sortable for LibraryView {
+impl LibraryView {
     fn sorts(&self, cx: &App) -> Vec<SortAxis> {
         self.table(self.section).sortables(cx)
     }
@@ -512,20 +514,8 @@ impl Sortable for LibraryView {
         self.table(self.section).cycle_sort(key, cx);
         cx.notify();
     }
-}
 
-impl Columned for LibraryView {
-    fn toggles(&self, cx: &App) -> Vec<Toggle> {
-        self.column_toggles(cx)
-    }
-
-    fn toggle_column(&mut self, key: &'static str, cx: &mut Context<Self>) {
-        self.switch_column(key, cx);
-    }
-}
-
-impl Viewed for LibraryView {
-    fn mode(&self, _cx: &App) -> Mode {
+    fn mode(&self) -> Mode {
         self.views[self.section.slot()]
     }
 
@@ -544,6 +534,50 @@ impl Viewed for LibraryView {
 impl Tooled for LibraryView {
     fn toolbar(&self) -> Entity<Toolbar> {
         self.toolbar.clone()
+    }
+
+    fn tools(&self, cx: &App) -> Vec<AnyElement> {
+        let columned = self.me.clone();
+        let sifted = self.me.clone();
+        let sorted = self.me.clone();
+        let viewed = self.me.clone();
+
+        let columns = matches!(self.mode(), Mode::List).then(|| {
+            tools::columns(&self.popovers, self.column_toggles(cx), move |key, cx| {
+                columned
+                    .update(cx, |view, cx| view.switch_column(key, cx))
+                    .ok();
+            })
+        });
+
+        let mut tools = Vec::new();
+        tools.extend(columns);
+        tools.push(tools::filters(
+            &self.popovers,
+            &self.sliders[self.section.slot()],
+            self.ranges(cx),
+            self.flags(cx),
+            move |change, cx| {
+                sifted.update(cx, |view, cx| view.narrow(change, cx)).ok();
+            },
+            cx,
+        ));
+        tools.push(tools::sorts(
+            &self.popovers,
+            self.sorts(cx),
+            move |key, cx| {
+                sorted.update(cx, |view, cx| view.set_sort(key, cx)).ok();
+            },
+            cx,
+        ));
+        tools.push(tools::views(
+            &self.popovers,
+            self.mode(),
+            move |mode, cx| {
+                viewed.update(cx, |view, cx| view.set_mode(mode, cx)).ok();
+            },
+        ));
+        tools
     }
 }
 
@@ -573,9 +607,7 @@ impl LibraryView {
         });
         cx.notify();
     }
-}
 
-impl Filterable for LibraryView {
     fn ranges(&self, cx: &App) -> Vec<RangeAxis> {
         match self.section {
             Section::Tracks => {
@@ -647,30 +679,28 @@ impl Filterable for LibraryView {
         ]
     }
 
-    fn set_range(&mut self, key: &'static str, value: (f32, f32), cx: &mut Context<Self>) {
-        match key {
-            "filter-year" => self.set_span(Some(value), cx),
-            _ => {
+    fn narrow(&mut self, change: Sift, cx: &mut Context<Self>) {
+        match change {
+            Sift::Range("filter-year", value) => self.set_span(Some(value), cx),
+            Sift::Range(_, value) => {
                 let mut sieve = self.sieve(cx);
                 sieve.duration = Some(value);
                 self.sift(sieve, cx);
             }
+            Sift::Flag(key, on) => {
+                let mut sieve = self.sieve(cx);
+                match key {
+                    "filter-explicit" => sieve.explicit = on,
+                    "filter-playable" => sieve.playable = on,
+                    _ => return,
+                }
+                self.sift(sieve, cx);
+            }
+            Sift::Reset => {
+                self.sift(TrackSieve::default(), cx);
+                self.set_span(None, cx);
+            }
         }
-    }
-
-    fn set_flag(&mut self, key: &'static str, on: bool, cx: &mut Context<Self>) {
-        let mut sieve = self.sieve(cx);
-        match key {
-            "filter-explicit" => sieve.explicit = on,
-            "filter-playable" => sieve.playable = on,
-            _ => return,
-        }
-        self.sift(sieve, cx);
-    }
-
-    fn reset_filters(&mut self, cx: &mut Context<Self>) {
-        self.sift(TrackSieve::default(), cx);
-        self.set_span(None, cx);
     }
 }
 


### PR DESCRIPTION
## What changed

- Invert ownership of toolbar controls: a screen now supplies finished elements through `Tooled::tools`, and `Toolbar` only lays them out.
- Delete the `Columned`, `Viewed`, `Filterable` and `Sortable` traits, the `Port`/`Wire` adapter and eight plumbing fields.
- Extract the menu construction both screens share into `chrome::tools`.
- Move the range-slider state out of `Toolbar` and into the screens, per Library section.

## Why

`Toolbar` knew about every kind of control and stored a closure pair for each. Adding one sort
button to one screen meant a new trait, two type aliases, two fields, an initialiser, a wiring
method, a render method, a render line, an export and two impls — nine edits across four files, for
machinery that serves exactly two screens. Every other screen has no toolbar at all.

Screens can build their own controls now that `Popover` carries its own open state, so the shared
type no longer needs to know what a columns menu or a sort menu is.

## User impact

None. Control order, behaviour and every string are unchanged: columns, filters, sort, view toggle,
then search, with columns still hidden in card mode.

## Notes

- `Toolbar` went from twelve fields to four and from 538 lines to 151. Adding a control to a screen
  now touches no shared file — that was the acceptance criterion.
- Search stays built into `Toolbar`. It is a focusable `Entity<Input>` and the global `OpenFilter`
  action reaches it through the cached toolbar entity; an anonymous element could not be focused.
- `chrome::tools` holds what both screens would otherwise duplicate — the columns, filters, sort and
  view builders, the slider cache and a `Sift` enum that collapses the three filter callbacks into
  one match. Screens pass data plus a closure.
- Slider state moved to the screens because it is real state: the cache lazily creates a
  `RangeState` per axis, which is what makes scrubber positions survive across frames. `LibraryView`
  keeps `[Sliders; 3]` indexed by section, so a Songs duration position can never reach the Albums
  year axis. Isolation is structural, not just key-based.
- Each screen owns one `Popovers` group, so only one of its popovers can be open at a time.
- Screens gained a `WeakEntity<Self>`, since `tools` takes `&self` and `&App` while the control
  handlers need to mutate the screen.

## Validation

- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace` — 117 passed, unchanged from baseline
- `cargo clippy --workspace` — warning set byte-identical to baseline
- Launched the app: stayed alive, no panics, no unregistered assets, no missing i18n keys

Not exercised: no UI test harness here, so opening each popover, dragging the duration slider and
switching sections with a filter applied are verified by construction only. The per-section slider
isolation in particular is worth a manual pass.
