### PR TITLE
refactor(views): compose track columns from one shared set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -520,3 +520,19 @@ distributing unlicensed code.
 Conventional Commits: `type(scope): description`, imperative, lowercase, no trailing period, no body.
 Scopes in use: `player`, `playback`, `views`, `ui`. Never add a `Co-Authored-By` trailer or any
 assistant attribution.
+
+## Pull requests
+
+One heading, one list. Nothing else:
+
+```markdown
+## Summary
+
+- add playlist create, rename, delete, visibility, and track mutation support
+- add album and playlist queue actions
+- add playlist management menus and localized editor UI
+```
+
+Bullets are lowercase, imperative, one line each, and describe behaviour rather than files. No
+Why/User impact/Validation sections, no checklists, no screenshot boilerplate, no test plan. This
+overrides any wider PR template. Never sign off or attribute the assistant.

--- a/crates/views/src/chrome/player_bar.rs
+++ b/crates/views/src/chrome/player_bar.rs
@@ -266,6 +266,7 @@ impl PlayerBar {
         )
     }
 
+    #[allow(dead_code)]
     fn fullscreen_button(&self) -> Button {
         Button::new("toggle-fullscreen")
             .ghost()
@@ -543,7 +544,6 @@ impl Render for PlayerBar {
                         .w_full()
                         .child(div().flex_1().min_w_0().child(seek))
                         .child(self.sound(px(VOLUME_TIGHT), cx))
-                        .child(self.fullscreen_button())
                         .when_some(self.queue_button(cx), |this, button| this.child(button)),
                 ),
             false => base
@@ -571,7 +571,6 @@ impl Render for PlayerBar {
                         .flex_1()
                         .min_w_0()
                         .child(self.sound(px(VOLUME_WIDTH), cx))
-                        .child(self.fullscreen_button())
                         .when_some(self.queue_button(cx), |this, button| this.child(button)),
                 ),
         };

--- a/crates/views/src/screens/library/albums.rs
+++ b/crates/views/src/screens/library/albums.rs
@@ -23,68 +23,75 @@ pub(super) enum AlbumField {
     TrackCount,
 }
 
-pub(super) const COLUMNS: &[ColumnSpec<AlbumField>] = &[
-    ColumnSpec {
-        field: AlbumField::Index,
-        key: "index",
-        header: "column-index",
-        align: TextAlign::Center,
-        width: Width::Fixed(NUMBER),
-        anchored: true,
-        sortable: false,
-        hide_below: ALWAYS,
-    },
-    ColumnSpec {
-        field: AlbumField::Cover,
-        key: "cover",
-        header: "",
-        align: TextAlign::Left,
-        width: Width::Thumb,
-        anchored: true,
-        sortable: false,
-        hide_below: ALWAYS,
-    },
-    ColumnSpec {
-        field: AlbumField::Name,
-        key: "name",
-        header: "column-album",
-        align: TextAlign::Left,
-        width: Width::Fill(0.55),
-        anchored: false,
-        sortable: true,
-        hide_below: ALWAYS,
-    },
-    ColumnSpec {
-        field: AlbumField::Artists,
-        key: "artists",
-        header: "column-artist",
-        align: TextAlign::Left,
-        width: Width::Fill(0.45),
-        anchored: false,
-        sortable: true,
-        hide_below: ALWAYS,
-    },
-    ColumnSpec {
-        field: AlbumField::Year,
-        key: "year",
-        header: "column-year",
-        align: TextAlign::Right,
-        width: Width::Fixed(YEAR),
-        anchored: false,
-        sortable: true,
-        hide_below: ROOMY,
-    },
-    ColumnSpec {
-        field: AlbumField::TrackCount,
-        key: "tracks",
-        header: "column-tracks",
-        align: TextAlign::Right,
-        width: Width::Fixed(TRAILING),
-        anchored: false,
-        sortable: true,
-        hide_below: WIDE,
-    },
-];
+const COLUMN: ColumnSpec<AlbumField> = ColumnSpec {
+    field: AlbumField::Index,
+    key: "",
+    header: "",
+    align: TextAlign::Left,
+    width: Width::Fill(1.),
+    anchored: false,
+    sortable: true,
+    hide_below: ALWAYS,
+};
+
+const INDEX: ColumnSpec<AlbumField> = ColumnSpec {
+    field: AlbumField::Index,
+    key: "index",
+    header: "column-index",
+    align: TextAlign::Center,
+    width: Width::Fixed(NUMBER),
+    anchored: true,
+    sortable: false,
+    ..COLUMN
+};
+
+const COVER: ColumnSpec<AlbumField> = ColumnSpec {
+    field: AlbumField::Cover,
+    key: "cover",
+    width: Width::Thumb,
+    anchored: true,
+    sortable: false,
+    ..COLUMN
+};
+
+const NAME: ColumnSpec<AlbumField> = ColumnSpec {
+    field: AlbumField::Name,
+    key: "name",
+    header: "column-album",
+    width: Width::Fill(0.55),
+    ..COLUMN
+};
+
+const ARTISTS: ColumnSpec<AlbumField> = ColumnSpec {
+    field: AlbumField::Artists,
+    key: "artists",
+    header: "column-artist",
+    width: Width::Fill(0.45),
+    ..COLUMN
+};
+
+const RELEASE_YEAR: ColumnSpec<AlbumField> = ColumnSpec {
+    field: AlbumField::Year,
+    key: "year",
+    header: "column-year",
+    align: TextAlign::Right,
+    width: Width::Fixed(YEAR),
+    hide_below: ROOMY,
+    ..COLUMN
+};
+
+const TRACK_COUNT: ColumnSpec<AlbumField> = ColumnSpec {
+    field: AlbumField::TrackCount,
+    key: "tracks",
+    header: "column-tracks",
+    align: TextAlign::Right,
+    width: Width::Fixed(TRAILING),
+    hide_below: WIDE,
+    ..COLUMN
+};
+
+pub(super) const COLUMNS: &[ColumnSpec<AlbumField>] =
+    &[INDEX, COVER, NAME, ARTISTS, RELEASE_YEAR, TRACK_COUNT];
 
 pub(super) struct AlbumSource {
     library: Entity<Library>,

--- a/crates/views/src/screens/library/playlists.rs
+++ b/crates/views/src/screens/library/playlists.rs
@@ -20,58 +20,65 @@ pub(super) enum PlaylistField {
     TrackCount,
 }
 
-pub(super) const COLUMNS: &[ColumnSpec<PlaylistField>] = &[
-    ColumnSpec {
-        field: PlaylistField::Index,
-        key: "index",
-        header: "column-index",
-        align: TextAlign::Center,
-        width: Width::Fixed(NUMBER),
-        anchored: true,
-        sortable: false,
-        hide_below: ALWAYS,
-    },
-    ColumnSpec {
-        field: PlaylistField::Cover,
-        key: "cover",
-        header: "",
-        align: TextAlign::Left,
-        width: Width::Thumb,
-        anchored: true,
-        sortable: false,
-        hide_below: ALWAYS,
-    },
-    ColumnSpec {
-        field: PlaylistField::Name,
-        key: "name",
-        header: "column-name",
-        align: TextAlign::Left,
-        width: Width::Fill(0.55),
-        anchored: false,
-        sortable: true,
-        hide_below: ALWAYS,
-    },
-    ColumnSpec {
-        field: PlaylistField::Owner,
-        key: "owner",
-        header: "column-owner",
-        align: TextAlign::Left,
-        width: Width::Fill(0.45),
-        anchored: false,
-        sortable: true,
-        hide_below: ROOMY,
-    },
-    ColumnSpec {
-        field: PlaylistField::TrackCount,
-        key: "tracks",
-        header: "column-tracks",
-        align: TextAlign::Right,
-        width: Width::Fixed(TRAILING),
-        anchored: false,
-        sortable: true,
-        hide_below: SNUG,
-    },
-];
+const COLUMN: ColumnSpec<PlaylistField> = ColumnSpec {
+    field: PlaylistField::Index,
+    key: "",
+    header: "",
+    align: TextAlign::Left,
+    width: Width::Fill(1.),
+    anchored: false,
+    sortable: true,
+    hide_below: ALWAYS,
+};
+
+const INDEX: ColumnSpec<PlaylistField> = ColumnSpec {
+    field: PlaylistField::Index,
+    key: "index",
+    header: "column-index",
+    align: TextAlign::Center,
+    width: Width::Fixed(NUMBER),
+    anchored: true,
+    sortable: false,
+    ..COLUMN
+};
+
+const COVER: ColumnSpec<PlaylistField> = ColumnSpec {
+    field: PlaylistField::Cover,
+    key: "cover",
+    width: Width::Thumb,
+    anchored: true,
+    sortable: false,
+    ..COLUMN
+};
+
+const NAME: ColumnSpec<PlaylistField> = ColumnSpec {
+    field: PlaylistField::Name,
+    key: "name",
+    header: "column-name",
+    width: Width::Fill(0.55),
+    ..COLUMN
+};
+
+const OWNER: ColumnSpec<PlaylistField> = ColumnSpec {
+    field: PlaylistField::Owner,
+    key: "owner",
+    header: "column-owner",
+    width: Width::Fill(0.45),
+    hide_below: ROOMY,
+    ..COLUMN
+};
+
+const TRACK_COUNT: ColumnSpec<PlaylistField> = ColumnSpec {
+    field: PlaylistField::TrackCount,
+    key: "tracks",
+    header: "column-tracks",
+    align: TextAlign::Right,
+    width: Width::Fixed(TRAILING),
+    hide_below: SNUG,
+    ..COLUMN
+};
+
+pub(super) const COLUMNS: &[ColumnSpec<PlaylistField>] = &[INDEX, COVER, NAME, OWNER, TRACK_COUNT];
 
 pub(super) struct PlaylistSource {
     library: Entity<Library>,

--- a/crates/views/src/shared/tracks/columns.rs
+++ b/crates/views/src/shared/tracks/columns.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use gpui::TextAlign;
+use ui::{ColumnSpec, Width};
+
+use crate::shared::cells::{ALWAYS, DATE, NUMBER, ROOMY, SNUG, TRAILING, WIDE};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TrackField {
+    Index,
+    Cover,
+    Title,
+    Artists,
+    Album,
+    AddedAt,
+    Plays,
+    Duration,
+}
+
+const COLUMN: ColumnSpec<TrackField> = ColumnSpec {
+    field: TrackField::Index,
+    key: "",
+    header: "",
+    align: TextAlign::Left,
+    width: Width::Fill(1.),
+    anchored: false,
+    sortable: true,
+    hide_below: ALWAYS,
+};
+
+const INDEX: ColumnSpec<TrackField> = ColumnSpec {
+    field: TrackField::Index,
+    key: "index",
+    header: "column-index",
+    align: TextAlign::Center,
+    width: Width::Fixed(NUMBER),
+    anchored: true,
+    sortable: false,
+    ..COLUMN
+};
+
+const COVER: ColumnSpec<TrackField> = ColumnSpec {
+    field: TrackField::Cover,
+    key: "cover",
+    width: Width::Thumb,
+    anchored: true,
+    sortable: false,
+    ..COLUMN
+};
+
+const TITLE: ColumnSpec<TrackField> = ColumnSpec {
+    field: TrackField::Title,
+    key: "title",
+    header: "column-title",
+    width: Width::Fill(0.42),
+    ..COLUMN
+};
+
+const ARTISTS: ColumnSpec<TrackField> = ColumnSpec {
+    field: TrackField::Artists,
+    key: "artists",
+    header: "column-artist",
+    width: Width::Fill(0.29),
+    hide_below: ROOMY,
+    ..COLUMN
+};
+
+const ALBUM: ColumnSpec<TrackField> = ColumnSpec {
+    field: TrackField::Album,
+    key: "album",
+    header: "column-album",
+    width: Width::Fill(0.29),
+    hide_below: WIDE,
+    ..COLUMN
+};
+
+const ADDED_AT: ColumnSpec<TrackField> = ColumnSpec {
+    field: TrackField::AddedAt,
+    key: "added-at",
+    header: "column-date-added",
+    width: Width::Fixed(DATE),
+    hide_below: WIDE,
+    ..COLUMN
+};
+
+const PLAYS: ColumnSpec<TrackField> = ColumnSpec {
+    field: TrackField::Plays,
+    key: "plays",
+    header: "column-plays",
+    width: Width::Fixed(DATE),
+    hide_below: WIDE,
+    ..COLUMN
+};
+
+const DURATION: ColumnSpec<TrackField> = ColumnSpec {
+    field: TrackField::Duration,
+    key: "duration",
+    header: "column-length",
+    align: TextAlign::Right,
+    width: Width::Fixed(TRAILING),
+    hide_below: SNUG,
+    ..COLUMN
+};
+
+pub(crate) const LIBRARY_COLUMNS: &[ColumnSpec<TrackField>] =
+    &[INDEX, COVER, TITLE, ARTISTS, ALBUM, ADDED_AT, DURATION];
+
+pub(crate) const ALBUM_COLUMNS: &[ColumnSpec<TrackField>] =
+    &[INDEX, TITLE, ARTISTS, PLAYS, DURATION];

--- a/crates/views/src/shared/tracks/mod.rs
+++ b/crates/views/src/shared/tracks/mod.rs
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+mod columns;
+mod sieve;
+mod sort;
+
 use std::cmp::Ordering;
 use std::rc::Rc;
 use ui::ActiveTheme as _;
@@ -8,156 +12,22 @@ use crate::chrome::TrackMenu;
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
     AnyElement, App, Entity, Hsla, InteractiveElement as _, IntoElement as _, SharedString,
-    Styled as _, TextAlign, WeakEntity,
+    Styled as _, WeakEntity,
 };
 use jiff::Timestamp;
 use router::Destination;
 use spotify::Track;
 use state::{Library, Playback, PlaybackState};
-use ui::{
-    Button, Cell, ColumnSpec, GridSource, GridState, Menu, ROW_GROUP, Scrollbar, Width, clock,
-};
+use ui::{Button, Cell, ColumnSpec, GridSource, GridState, Menu, ROW_GROUP, Scrollbar, clock};
 
-use crate::shared::cells::{self, ALWAYS, DATE, NUMBER, ROOMY, SNUG, TRAILING, WIDE};
+use crate::shared::cells;
 use crate::shared::hero::release_date_label;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub(crate) enum TrackField {
-    Index,
-    Cover,
-    Title,
-    Artists,
-    Album,
-    AddedAt,
-    Plays,
-    Duration,
-}
+pub(crate) use columns::{ALBUM_COLUMNS, LIBRARY_COLUMNS, TrackField};
+pub(crate) use sieve::TrackSieve;
+pub(crate) use sort::initial;
 
-pub(crate) const LIBRARY_COLUMNS: &[ColumnSpec<TrackField>] = &[
-    ColumnSpec {
-        field: TrackField::Index,
-        key: "index",
-        header: "column-index",
-        align: TextAlign::Center,
-        width: Width::Fixed(NUMBER),
-        anchored: true,
-        sortable: false,
-        hide_below: ALWAYS,
-    },
-    ColumnSpec {
-        field: TrackField::Cover,
-        key: "cover",
-        header: "",
-        align: TextAlign::Left,
-        width: Width::Thumb,
-        anchored: true,
-        sortable: false,
-        hide_below: ALWAYS,
-    },
-    ColumnSpec {
-        field: TrackField::Title,
-        key: "title",
-        header: "column-title",
-        align: TextAlign::Left,
-        width: Width::Fill(0.42),
-        anchored: false,
-        sortable: true,
-        hide_below: ALWAYS,
-    },
-    ColumnSpec {
-        field: TrackField::Artists,
-        key: "artists",
-        header: "column-artist",
-        align: TextAlign::Left,
-        width: Width::Fill(0.29),
-        anchored: false,
-        sortable: true,
-        hide_below: ROOMY,
-    },
-    ColumnSpec {
-        field: TrackField::Album,
-        key: "album",
-        header: "column-album",
-        align: TextAlign::Left,
-        width: Width::Fill(0.29),
-        anchored: false,
-        sortable: true,
-        hide_below: WIDE,
-    },
-    ColumnSpec {
-        field: TrackField::AddedAt,
-        key: "added-at",
-        header: "column-date-added",
-        align: TextAlign::Left,
-        width: Width::Fixed(DATE),
-        anchored: false,
-        sortable: true,
-        hide_below: WIDE,
-    },
-    ColumnSpec {
-        field: TrackField::Duration,
-        key: "duration",
-        header: "column-length",
-        align: TextAlign::Right,
-        width: Width::Fixed(TRAILING),
-        anchored: false,
-        sortable: true,
-        hide_below: SNUG,
-    },
-];
-
-pub(crate) const ALBUM_COLUMNS: &[ColumnSpec<TrackField>] = &[
-    ColumnSpec {
-        field: TrackField::Index,
-        key: "index",
-        header: "column-index",
-        align: TextAlign::Center,
-        width: Width::Fixed(NUMBER),
-        anchored: true,
-        sortable: false,
-        hide_below: ALWAYS,
-    },
-    ColumnSpec {
-        field: TrackField::Title,
-        key: "title",
-        header: "column-title",
-        align: TextAlign::Left,
-        width: Width::Fill(0.62),
-        anchored: false,
-        sortable: true,
-        hide_below: ALWAYS,
-    },
-    ColumnSpec {
-        field: TrackField::Artists,
-        key: "artists",
-        header: "column-artist",
-        align: TextAlign::Left,
-        width: Width::Fill(0.38),
-        anchored: false,
-        sortable: true,
-        hide_below: ROOMY,
-    },
-    ColumnSpec {
-        field: TrackField::Plays,
-        key: "plays",
-        header: "column-plays",
-        align: TextAlign::Left,
-        width: Width::Fixed(DATE),
-        anchored: false,
-        sortable: true,
-        hide_below: WIDE,
-    },
-    ColumnSpec {
-        field: TrackField::Duration,
-        key: "duration",
-        header: "column-length",
-        align: TextAlign::Right,
-        width: Width::Fixed(TRAILING),
-        anchored: false,
-        sortable: true,
-        hide_below: SNUG,
-    },
-];
+use sort::hits;
 
 pub(crate) type PlaybackStatus = (Option<String>, PlaybackState);
 
@@ -178,35 +48,6 @@ pub(crate) fn ordered(table: &Entity<GridState<TrackSource>>, cx: &App) -> Vec<T
     (0..delegate.row_count())
         .filter_map(|display| delegate.source().at(delegate.row(display), cx))
         .collect()
-}
-
-#[derive(Clone, Copy, Default, PartialEq)]
-pub(crate) struct TrackSieve {
-    pub duration: Option<(f32, f32)>,
-    pub explicit: bool,
-    pub playable: bool,
-}
-
-impl TrackSieve {
-    pub(crate) fn active(&self) -> bool {
-        self.duration.is_some() || self.explicit || self.playable
-    }
-
-    fn keeps(&self, track: &Track) -> bool {
-        if self.explicit && !track.explicit {
-            return false;
-        }
-        if self.playable && !track.playable {
-            return false;
-        }
-        match self.duration {
-            Some((low, high)) => {
-                let seconds = track.duration.as_secs_f32();
-                seconds >= low - 0.5 && seconds <= high + 0.5
-            }
-            None => true,
-        }
-    }
 }
 
 pub(crate) struct TrackSource {
@@ -497,73 +338,21 @@ impl GridSource for TrackSource {
     }
 
     fn compare(&self, field: TrackField, a: usize, b: usize, cx: &App) -> Ordering {
-        let tracks = self.provider.tracks(cx);
-        let text = |index: usize, pick: fn(&Track) -> &String| {
-            tracks
-                .get(index)
-                .map(|track| pick(track).to_lowercase())
-                .unwrap_or_default()
-        };
-
-        match field {
-            TrackField::Title => text(a, |track| &track.name).cmp(&text(b, |track| &track.name)),
-            TrackField::Artists => {
-                text(a, |track| &track.artists).cmp(&text(b, |track| &track.artists))
-            }
-            TrackField::Album => text(a, |track| &track.album).cmp(&text(b, |track| &track.album)),
-            TrackField::AddedAt => tracks
-                .get(a)
-                .and_then(|track| track.added_at)
-                .cmp(&tracks.get(b).and_then(|track| track.added_at)),
-            TrackField::Plays => tracks
-                .get(a)
-                .and_then(|track| track.playcount)
-                .cmp(&tracks.get(b).and_then(|track| track.playcount)),
-            TrackField::Duration => tracks
-                .get(a)
-                .map(|track| track.duration)
-                .cmp(&tracks.get(b).map(|track| track.duration)),
-            TrackField::Index | TrackField::Cover => a.cmp(&b),
-        }
+        sort::compare(self.provider.tracks(cx), field, a, b)
     }
 
     fn group(&self, field: TrackField, row: usize, cx: &App) -> Option<SharedString> {
-        let track = self.provider.tracks(cx).get(row)?;
-
-        match field {
-            TrackField::Title => Some(initial(&track.name)),
-            TrackField::Artists => Some(initial(&track.artists)),
-            TrackField::Album => Some(initial(&track.album)),
-            _ => None,
-        }
+        sort::group(self.provider.tracks(cx), field, row)
     }
-}
-
-pub(crate) fn initial(text: &str) -> SharedString {
-    text.chars()
-        .next()
-        .filter(|first| first.is_alphabetic())
-        .map(|first| SharedString::from(first.to_uppercase().collect::<String>()))
-        .unwrap_or_else(|| SharedString::from("#"))
-}
-
-fn hits(track: &Track, query: &str) -> bool {
-    if query.is_empty() {
-        return true;
-    }
-    let haystack = format!("{} {} {}", track.name, track.artists, track.album);
-    haystack.to_lowercase().contains(query)
 }
 
 #[cfg(test)]
-mod tests {
+mod fixture {
     use std::time::Duration;
 
     use spotify::Track;
 
-    use super::{TrackSieve, hits, initial};
-
-    fn track(seconds: u64, explicit: bool, playable: bool) -> Track {
+    pub(super) fn track(seconds: u64, explicit: bool, playable: bool) -> Track {
         Track {
             id: Some("id".to_owned()),
             name: String::new(),
@@ -584,94 +373,5 @@ mod tests {
             languages: Vec::new(),
             credits: Vec::new(),
         }
-    }
-
-    #[test]
-    fn an_empty_query_hits_everything() {
-        let mut track = track(60, false, true);
-        track.name = "Bark at the Moon".to_owned();
-
-        assert!(hits(&track, ""));
-        assert!(hits(&track, "moon"));
-        assert!(!hits(&track, "sunshine"));
-    }
-
-    #[test]
-    fn an_untouched_sieve_keeps_everything() {
-        let sieve = TrackSieve::default();
-
-        assert!(!sieve.active());
-        assert!(sieve.keeps(&track(30, false, false)));
-        assert!(sieve.keeps(&track(6000, true, true)));
-    }
-
-    #[test]
-    fn duration_bounds_are_inclusive() {
-        let sieve = TrackSieve {
-            duration: Some((60., 180.)),
-            ..TrackSieve::default()
-        };
-
-        assert!(sieve.active());
-        assert!(sieve.keeps(&track(60, false, true)));
-        assert!(sieve.keeps(&track(180, false, true)));
-        assert!(sieve.keeps(&track(120, false, true)));
-        assert!(!sieve.keeps(&track(59, false, true)));
-        assert!(!sieve.keeps(&track(181, false, true)));
-    }
-
-    #[test]
-    fn flags_narrow_independently() {
-        let explicit = TrackSieve {
-            explicit: true,
-            ..TrackSieve::default()
-        };
-        assert!(explicit.keeps(&track(60, true, false)));
-        assert!(!explicit.keeps(&track(60, false, true)));
-
-        let playable = TrackSieve {
-            playable: true,
-            ..TrackSieve::default()
-        };
-        assert!(playable.keeps(&track(60, false, true)));
-        assert!(!playable.keeps(&track(60, true, false)));
-    }
-
-    #[test]
-    fn every_axis_must_pass() {
-        let sieve = TrackSieve {
-            duration: Some((60., 180.)),
-            explicit: true,
-            playable: true,
-        };
-
-        assert!(sieve.keeps(&track(120, true, true)));
-        assert!(!sieve.keeps(&track(120, true, false)));
-        assert!(!sieve.keeps(&track(400, true, true)));
-    }
-
-    #[test]
-    fn letters_bucket_under_their_uppercase_form() {
-        assert_eq!(initial("bark at the moon"), "B");
-        assert_eq!(initial("Bark at the Moon"), "B");
-    }
-
-    #[test]
-    fn cyrillic_keeps_its_own_letter() {
-        assert_eq!(initial("прощай"), "П");
-        assert_eq!(initial("Ялта"), "Я");
-    }
-
-    #[test]
-    fn digits_punctuation_and_emptiness_share_one_bucket() {
-        assert_eq!(initial("99 Luftballons"), "#");
-        assert_eq!(initial("!!!"), "#");
-        assert_eq!(initial(" leading space"), "#");
-        assert_eq!(initial(""), "#");
-    }
-
-    #[test]
-    fn multi_char_uppercase_is_kept_whole() {
-        assert_eq!(initial("ßeta"), "SS");
     }
 }

--- a/crates/views/src/shared/tracks/sieve.rs
+++ b/crates/views/src/shared/tracks/sieve.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use spotify::Track;
+
+#[derive(Clone, Copy, Default, PartialEq)]
+pub(crate) struct TrackSieve {
+    pub duration: Option<(f32, f32)>,
+    pub explicit: bool,
+    pub playable: bool,
+}
+
+impl TrackSieve {
+    pub(crate) fn active(&self) -> bool {
+        self.duration.is_some() || self.explicit || self.playable
+    }
+
+    pub(super) fn keeps(&self, track: &Track) -> bool {
+        if self.explicit && !track.explicit {
+            return false;
+        }
+        if self.playable && !track.playable {
+            return false;
+        }
+        match self.duration {
+            Some((low, high)) => {
+                let seconds = track.duration.as_secs_f32();
+                seconds >= low - 0.5 && seconds <= high + 0.5
+            }
+            None => true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TrackSieve;
+    use crate::shared::tracks::fixture::track;
+
+    #[test]
+    fn an_untouched_sieve_keeps_everything() {
+        let sieve = TrackSieve::default();
+
+        assert!(!sieve.active());
+        assert!(sieve.keeps(&track(30, false, false)));
+        assert!(sieve.keeps(&track(6000, true, true)));
+    }
+
+    #[test]
+    fn duration_bounds_are_inclusive() {
+        let sieve = TrackSieve {
+            duration: Some((60., 180.)),
+            ..TrackSieve::default()
+        };
+
+        assert!(sieve.active());
+        assert!(sieve.keeps(&track(60, false, true)));
+        assert!(sieve.keeps(&track(180, false, true)));
+        assert!(sieve.keeps(&track(120, false, true)));
+        assert!(!sieve.keeps(&track(59, false, true)));
+        assert!(!sieve.keeps(&track(181, false, true)));
+    }
+
+    #[test]
+    fn flags_narrow_independently() {
+        let explicit = TrackSieve {
+            explicit: true,
+            ..TrackSieve::default()
+        };
+        assert!(explicit.keeps(&track(60, true, false)));
+        assert!(!explicit.keeps(&track(60, false, true)));
+
+        let playable = TrackSieve {
+            playable: true,
+            ..TrackSieve::default()
+        };
+        assert!(playable.keeps(&track(60, false, true)));
+        assert!(!playable.keeps(&track(60, true, false)));
+    }
+
+    #[test]
+    fn every_axis_must_pass() {
+        let sieve = TrackSieve {
+            duration: Some((60., 180.)),
+            explicit: true,
+            playable: true,
+        };
+
+        assert!(sieve.keeps(&track(120, true, true)));
+        assert!(!sieve.keeps(&track(120, true, false)));
+        assert!(!sieve.keeps(&track(400, true, true)));
+    }
+}

--- a/crates/views/src/shared/tracks/sort.rs
+++ b/crates/views/src/shared/tracks/sort.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::cmp::Ordering;
+
+use gpui::SharedString;
+use spotify::Track;
+
+use super::TrackField;
+
+pub(super) fn compare(tracks: &[Track], field: TrackField, a: usize, b: usize) -> Ordering {
+    let text = |index: usize, pick: fn(&Track) -> &String| {
+        tracks
+            .get(index)
+            .map(|track| pick(track).to_lowercase())
+            .unwrap_or_default()
+    };
+
+    match field {
+        TrackField::Title => text(a, |track| &track.name).cmp(&text(b, |track| &track.name)),
+        TrackField::Artists => {
+            text(a, |track| &track.artists).cmp(&text(b, |track| &track.artists))
+        }
+        TrackField::Album => text(a, |track| &track.album).cmp(&text(b, |track| &track.album)),
+        TrackField::AddedAt => tracks
+            .get(a)
+            .and_then(|track| track.added_at)
+            .cmp(&tracks.get(b).and_then(|track| track.added_at)),
+        TrackField::Plays => tracks
+            .get(a)
+            .and_then(|track| track.playcount)
+            .cmp(&tracks.get(b).and_then(|track| track.playcount)),
+        TrackField::Duration => tracks
+            .get(a)
+            .map(|track| track.duration)
+            .cmp(&tracks.get(b).map(|track| track.duration)),
+        TrackField::Index | TrackField::Cover => a.cmp(&b),
+    }
+}
+
+pub(super) fn group(tracks: &[Track], field: TrackField, row: usize) -> Option<SharedString> {
+    let track = tracks.get(row)?;
+
+    match field {
+        TrackField::Title => Some(initial(&track.name)),
+        TrackField::Artists => Some(initial(&track.artists)),
+        TrackField::Album => Some(initial(&track.album)),
+        _ => None,
+    }
+}
+
+pub(crate) fn initial(text: &str) -> SharedString {
+    text.chars()
+        .next()
+        .filter(|first| first.is_alphabetic())
+        .map(|first| SharedString::from(first.to_uppercase().collect::<String>()))
+        .unwrap_or_else(|| SharedString::from("#"))
+}
+
+pub(super) fn hits(track: &Track, query: &str) -> bool {
+    if query.is_empty() {
+        return true;
+    }
+    let haystack = format!("{} {} {}", track.name, track.artists, track.album);
+    haystack.to_lowercase().contains(query)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{hits, initial};
+    use crate::shared::tracks::fixture::track;
+
+    #[test]
+    fn an_empty_query_hits_everything() {
+        let mut track = track(60, false, true);
+        track.name = "Bark at the Moon".to_owned();
+
+        assert!(hits(&track, ""));
+        assert!(hits(&track, "moon"));
+        assert!(!hits(&track, "sunshine"));
+    }
+
+    #[test]
+    fn letters_bucket_under_their_uppercase_form() {
+        assert_eq!(initial("bark at the moon"), "B");
+        assert_eq!(initial("Bark at the Moon"), "B");
+    }
+
+    #[test]
+    fn cyrillic_keeps_its_own_letter() {
+        assert_eq!(initial("прощай"), "П");
+        assert_eq!(initial("Ялта"), "Я");
+    }
+
+    #[test]
+    fn digits_punctuation_and_emptiness_share_one_bucket() {
+        assert_eq!(initial("99 Luftballons"), "#");
+        assert_eq!(initial("!!!"), "#");
+        assert_eq!(initial(" leading space"), "#");
+        assert_eq!(initial(""), "#");
+    }
+
+    #[test]
+    fn multi_char_uppercase_is_kept_whole() {
+        assert_eq!(initial("ßeta"), "SS");
+    }
+}


### PR DESCRIPTION
## Summary

- compose both track tables from one shared set of column consts instead of two flat literal arrays
- declare each column with only the fields that differ from a base `COLUMN` const
- give album and playlist columns the same declaration shape
- split `shared/tracks.rs` into `columns`, `sieve`, `sort` and `mod`
- align the album table's title/artists ratio with the library's, moving their boundary by ~2.85% of spare width
