### PR TITLE
refactor(ui): move the text input into the design system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3306,7 +3306,6 @@ name = "input"
 version = "0.3.0"
 dependencies = [
  "gpui",
- "i18n",
  "ui",
 ]
 

--- a/crates/input/Cargo.toml
+++ b/crates/input/Cargo.toml
@@ -6,5 +6,4 @@ license.workspace = true
 
 [dependencies]
 gpui.workspace = true
-i18n.workspace = true
 ui.workspace = true

--- a/crates/input/src/lib.rs
+++ b/crates/input/src/lib.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-mod text;
-
-pub use text::Input;
-
 use gpui::{KeyBinding, actions};
-use ui::{Deselect, GRID_CONTEXT, SelectNext, SelectPrevious};
+use ui::{
+    Backspace, BackspaceWord, Copy, Cut, Delete, DeleteWord, Deselect, Dismiss, End, FORM_CONTEXT,
+    GRID_CONTEXT, Home, INPUT_CONTEXT, Left, Paste, Right, SelectAll, SelectEnd, SelectHome,
+    SelectLeft, SelectNext, SelectPrevious, SelectRight, SelectWordLeft, SelectWordRight, Space,
+    Submit, WordLeft, WordRight,
+};
 
 actions!(
     sonora,
@@ -21,41 +22,13 @@ actions!(
     ]
 );
 
-actions!(
-    input,
-    [
-        Backspace,
-        BackspaceWord,
-        Delete,
-        DeleteWord,
-        Left,
-        Right,
-        WordLeft,
-        WordRight,
-        SelectLeft,
-        SelectRight,
-        SelectWordLeft,
-        SelectWordRight,
-        SelectAll,
-        Home,
-        End,
-        SelectHome,
-        SelectEnd,
-        Paste,
-        Dismiss,
-        Cut,
-        Copy,
-        Space
-    ]
-);
-
 pub const WORKSPACE_CONTEXT: &str = "Workspace";
-pub const INPUT_CONTEXT: &str = "Input";
 
 pub fn bindings() -> Vec<KeyBinding> {
     let editing = Some(INPUT_CONTEXT);
     let away_from_text = format!("{WORKSPACE_CONTEXT} && !{INPUT_CONTEXT}");
     let table = Some(GRID_CONTEXT);
+    let form = Some(FORM_CONTEXT);
 
     vec![
         KeyBinding::new("down", SelectNext, table),
@@ -103,5 +76,7 @@ pub fn bindings() -> Vec<KeyBinding> {
         KeyBinding::new("ctrl-x", Cut, editing),
         KeyBinding::new("space", Space, editing),
         KeyBinding::new("escape", Dismiss, editing),
+        KeyBinding::new("enter", Submit, form),
+        KeyBinding::new("escape", Dismiss, form),
     ]
 }

--- a/crates/ui/src/form.rs
+++ b/crates/ui/src/form.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use gpui::actions;
+
+actions!(form, [Submit]);
+
+pub const FORM_CONTEXT: &str = "Form";

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use gpui::prelude::*;
+use gpui::{
+    App, Bounds, Context, CursorStyle, Element, ElementInputHandler, Entity, GlobalElementId,
+    InspectorElementId, LayoutId, MouseButton, PaintQuad, Pixels, ShapedLine, Style, TextRun,
+    UnderlineStyle, Window, div, fill, point, px, relative, size, svg,
+};
+
+use crate::input::{CARET, CARET_LINES, INPUT_CONTEXT, Input, clamp_offset, clamp_range};
+use crate::theme::ActiveTheme as _;
+
+struct Text {
+    input: Entity<Input>,
+}
+
+struct Painted {
+    line: Option<ShapedLine>,
+    caret: Option<PaintQuad>,
+    selection: Option<PaintQuad>,
+}
+
+impl IntoElement for Text {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for Text {
+    type RequestLayoutState = ();
+    type PrepaintState = Painted;
+
+    fn id(&self) -> Option<gpui::ElementId> {
+        None
+    }
+
+    fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _: Option<&GlobalElementId>,
+        _: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        let mut style = Style::default();
+        style.size.width = relative(1.).into();
+        style.size.height = window.line_height().into();
+        (window.request_layout(style, [], cx), ())
+    }
+
+    fn prepaint(
+        &mut self,
+        _: Option<&GlobalElementId>,
+        _: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Self::PrepaintState {
+        let theme = *cx.theme();
+        let input = self.input.read(cx);
+        let empty = input.content.is_empty();
+        let style = window.text_style();
+
+        let (text, color) = match empty {
+            true => (input.placeholder(), theme.muted_foreground),
+            false => (input.content.clone(), style.color),
+        };
+
+        let selected = match empty {
+            true => 0..0,
+            false => clamp_range(&text, &input.selected_range),
+        };
+        let cursor = match empty {
+            true => 0,
+            false => clamp_offset(&text, input.cursor()),
+        };
+        let marked = match empty {
+            true => None,
+            false => input
+                .marked_range
+                .as_ref()
+                .map(|range| clamp_range(&text, range)),
+        };
+
+        let run = TextRun {
+            len: text.len(),
+            font: style.font(),
+            color,
+            background_color: None,
+            underline: None,
+            strikethrough: None,
+        };
+        let runs = match marked {
+            Some(marked) => [
+                TextRun {
+                    len: marked.start,
+                    ..run.clone()
+                },
+                TextRun {
+                    len: marked.end - marked.start,
+                    underline: Some(UnderlineStyle {
+                        color: Some(run.color),
+                        thickness: px(1.),
+                        wavy: false,
+                    }),
+                    ..run.clone()
+                },
+                TextRun {
+                    len: text.len() - marked.end,
+                    ..run
+                },
+            ]
+            .into_iter()
+            .filter(|run| run.len > 0)
+            .collect(),
+            None => vec![run],
+        };
+
+        let font_size = style.font_size.to_pixels(window.rem_size());
+        let line = window
+            .text_system()
+            .shape_line(text, font_size, &runs, None);
+
+        let (selection, caret) = match selected.is_empty() {
+            true => (
+                None,
+                Some(fill(
+                    Bounds::new(
+                        point(
+                            bounds.left() + line.x_for_index(cursor),
+                            bounds.top() + (bounds.size.height - font_size * CARET_LINES) / 2.,
+                        ),
+                        size(CARET, font_size * CARET_LINES),
+                    ),
+                    theme.foreground,
+                )),
+            ),
+            false => (
+                Some(fill(
+                    Bounds::from_corners(
+                        point(
+                            bounds.left() + line.x_for_index(selected.start),
+                            bounds.top(),
+                        ),
+                        point(
+                            bounds.left() + line.x_for_index(selected.end),
+                            bounds.bottom(),
+                        ),
+                    ),
+                    theme.selection.opacity(0.4),
+                )),
+                None,
+            ),
+        };
+
+        Painted {
+            line: Some(line),
+            caret,
+            selection,
+        }
+    }
+
+    fn paint(
+        &mut self,
+        _: Option<&GlobalElementId>,
+        _: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _: &mut Self::RequestLayoutState,
+        painted: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        let focus = self.input.read(cx).focus_handle.clone();
+        window.handle_input(
+            &focus,
+            ElementInputHandler::new(bounds, self.input.clone()),
+            cx,
+        );
+
+        if let Some(selection) = painted.selection.take() {
+            window.paint_quad(selection);
+        }
+
+        let Some(line) = painted.line.take() else {
+            return;
+        };
+        line.paint(
+            bounds.origin,
+            window.line_height(),
+            gpui::TextAlign::Left,
+            None,
+            window,
+            cx,
+        )
+        .ok();
+
+        if focus.is_focused(window)
+            && let Some(caret) = painted.caret.take()
+        {
+            window.paint_quad(caret);
+        }
+
+        self.input.update(cx, |input, _| {
+            input.last_layout = (!input.content.is_empty()).then_some(line);
+            input.last_bounds = Some(bounds);
+        });
+    }
+}
+
+impl Render for Input {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = *cx.theme();
+        let height = match self.compact {
+            true => theme.metrics.control_small,
+            false => theme.metrics.field,
+        };
+
+        div()
+            .flex()
+            .flex_1()
+            .items_center()
+            .gap_2()
+            .min_w_0()
+            .h(height)
+            .px_3()
+            .rounded(theme.radius)
+            .bg(theme.secondary)
+            .border_1()
+            .border_color(theme.border)
+            .overflow_hidden()
+            .key_context(INPUT_CONTEXT)
+            .track_focus(&self.focus_handle)
+            .cursor(CursorStyle::IBeam)
+            .on_action(cx.listener(Self::backspace))
+            .on_action(cx.listener(Self::backspace_word))
+            .on_action(cx.listener(Self::delete))
+            .on_action(cx.listener(Self::delete_word))
+            .on_action(cx.listener(Self::left))
+            .on_action(cx.listener(Self::right))
+            .on_action(cx.listener(Self::word_left))
+            .on_action(cx.listener(Self::word_right))
+            .on_action(cx.listener(Self::select_left))
+            .on_action(cx.listener(Self::select_right))
+            .on_action(cx.listener(Self::select_word_left))
+            .on_action(cx.listener(Self::select_word_right))
+            .on_action(cx.listener(Self::select_all))
+            .on_action(cx.listener(Self::home))
+            .on_action(cx.listener(Self::end))
+            .on_action(cx.listener(Self::select_home))
+            .on_action(cx.listener(Self::select_end))
+            .on_action(cx.listener(Self::space))
+            .on_action(cx.listener(Self::copy))
+            .on_action(cx.listener(Self::cut))
+            .on_action(cx.listener(Self::paste))
+            .on_mouse_down(MouseButton::Left, cx.listener(Self::on_mouse_down))
+            .on_mouse_move(cx.listener(Self::on_mouse_move))
+            .on_mouse_up(MouseButton::Left, cx.listener(Self::on_mouse_up))
+            .when_some(self.icon.clone(), |this, path| {
+                this.child(
+                    svg()
+                        .path(path)
+                        .size_4()
+                        .flex_none()
+                        .text_color(theme.muted_foreground),
+                )
+            })
+            .child(Text {
+                input: cx.entity().clone(),
+            })
+    }
+}

--- a/crates/ui/src/input/mod.rs
+++ b/crates/ui/src/input/mod.rs
@@ -2,22 +2,45 @@
 
 use std::ops::Range;
 
-use gpui::prelude::*;
 use gpui::{
-    App, Bounds, ClipboardItem, Context, CursorStyle, Element, ElementInputHandler, Entity,
-    EntityInputHandler, FocusHandle, Focusable, GlobalElementId, InspectorElementId, LayoutId,
-    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels, Point,
-    ShapedLine, SharedString, Style, TextRun, UTF16Selection, UnderlineStyle, Window, div, fill,
-    point, px, relative, size, svg,
+    App, Bounds, ClipboardItem, Context, EntityInputHandler, FocusHandle, Focusable,
+    MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point, ShapedLine, SharedString,
+    UTF16Selection, Window, point, px,
 };
 
-use ui::ActiveTheme as _;
+use gpui::actions;
 
-use crate::{
-    Backspace, BackspaceWord, Copy, Cut, Delete, DeleteWord, End, Home, INPUT_CONTEXT, Left, Paste,
-    Right, SelectAll, SelectEnd, SelectHome, SelectLeft, SelectRight, SelectWordLeft,
-    SelectWordRight, Space, WordLeft, WordRight,
-};
+mod element;
+
+actions!(
+    input,
+    [
+        Backspace,
+        BackspaceWord,
+        Delete,
+        DeleteWord,
+        Left,
+        Right,
+        WordLeft,
+        WordRight,
+        SelectLeft,
+        SelectRight,
+        SelectWordLeft,
+        SelectWordRight,
+        SelectAll,
+        Home,
+        End,
+        SelectHome,
+        SelectEnd,
+        Paste,
+        Dismiss,
+        Cut,
+        Copy,
+        Space
+    ]
+);
+
+pub const INPUT_CONTEXT: &str = "Input";
 
 const CARET: Pixels = px(2.);
 const CARET_LINES: f32 = 1.25;
@@ -485,272 +508,6 @@ impl EntityInputHandler for Input {
             &self.content,
             clamp_offset(&self.content, index),
         ))
-    }
-}
-
-struct Text {
-    input: Entity<Input>,
-}
-
-struct Painted {
-    line: Option<ShapedLine>,
-    caret: Option<PaintQuad>,
-    selection: Option<PaintQuad>,
-}
-
-impl IntoElement for Text {
-    type Element = Self;
-
-    fn into_element(self) -> Self::Element {
-        self
-    }
-}
-
-impl Element for Text {
-    type RequestLayoutState = ();
-    type PrepaintState = Painted;
-
-    fn id(&self) -> Option<gpui::ElementId> {
-        None
-    }
-
-    fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
-        None
-    }
-
-    fn request_layout(
-        &mut self,
-        _: Option<&GlobalElementId>,
-        _: Option<&InspectorElementId>,
-        window: &mut Window,
-        cx: &mut App,
-    ) -> (LayoutId, Self::RequestLayoutState) {
-        let mut style = Style::default();
-        style.size.width = relative(1.).into();
-        style.size.height = window.line_height().into();
-        (window.request_layout(style, [], cx), ())
-    }
-
-    fn prepaint(
-        &mut self,
-        _: Option<&GlobalElementId>,
-        _: Option<&InspectorElementId>,
-        bounds: Bounds<Pixels>,
-        _: &mut Self::RequestLayoutState,
-        window: &mut Window,
-        cx: &mut App,
-    ) -> Self::PrepaintState {
-        let theme = *cx.theme();
-        let input = self.input.read(cx);
-        let empty = input.content.is_empty();
-        let style = window.text_style();
-
-        let (text, color) = match empty {
-            true => (input.placeholder(), theme.muted_foreground),
-            false => (input.content.clone(), style.color),
-        };
-
-        let selected = match empty {
-            true => 0..0,
-            false => clamp_range(&text, &input.selected_range),
-        };
-        let cursor = match empty {
-            true => 0,
-            false => clamp_offset(&text, input.cursor()),
-        };
-        let marked = match empty {
-            true => None,
-            false => input
-                .marked_range
-                .as_ref()
-                .map(|range| clamp_range(&text, range)),
-        };
-
-        let run = TextRun {
-            len: text.len(),
-            font: style.font(),
-            color,
-            background_color: None,
-            underline: None,
-            strikethrough: None,
-        };
-        let runs = match marked {
-            Some(marked) => [
-                TextRun {
-                    len: marked.start,
-                    ..run.clone()
-                },
-                TextRun {
-                    len: marked.end - marked.start,
-                    underline: Some(UnderlineStyle {
-                        color: Some(run.color),
-                        thickness: px(1.),
-                        wavy: false,
-                    }),
-                    ..run.clone()
-                },
-                TextRun {
-                    len: text.len() - marked.end,
-                    ..run
-                },
-            ]
-            .into_iter()
-            .filter(|run| run.len > 0)
-            .collect(),
-            None => vec![run],
-        };
-
-        let font_size = style.font_size.to_pixels(window.rem_size());
-        let line = window
-            .text_system()
-            .shape_line(text, font_size, &runs, None);
-
-        let (selection, caret) = match selected.is_empty() {
-            true => (
-                None,
-                Some(fill(
-                    Bounds::new(
-                        point(
-                            bounds.left() + line.x_for_index(cursor),
-                            bounds.top() + (bounds.size.height - font_size * CARET_LINES) / 2.,
-                        ),
-                        size(CARET, font_size * CARET_LINES),
-                    ),
-                    theme.foreground,
-                )),
-            ),
-            false => (
-                Some(fill(
-                    Bounds::from_corners(
-                        point(
-                            bounds.left() + line.x_for_index(selected.start),
-                            bounds.top(),
-                        ),
-                        point(
-                            bounds.left() + line.x_for_index(selected.end),
-                            bounds.bottom(),
-                        ),
-                    ),
-                    theme.selection.opacity(0.4),
-                )),
-                None,
-            ),
-        };
-
-        Painted {
-            line: Some(line),
-            caret,
-            selection,
-        }
-    }
-
-    fn paint(
-        &mut self,
-        _: Option<&GlobalElementId>,
-        _: Option<&InspectorElementId>,
-        bounds: Bounds<Pixels>,
-        _: &mut Self::RequestLayoutState,
-        painted: &mut Self::PrepaintState,
-        window: &mut Window,
-        cx: &mut App,
-    ) {
-        let focus = self.input.read(cx).focus_handle.clone();
-        window.handle_input(
-            &focus,
-            ElementInputHandler::new(bounds, self.input.clone()),
-            cx,
-        );
-
-        if let Some(selection) = painted.selection.take() {
-            window.paint_quad(selection);
-        }
-
-        let Some(line) = painted.line.take() else {
-            return;
-        };
-        line.paint(
-            bounds.origin,
-            window.line_height(),
-            gpui::TextAlign::Left,
-            None,
-            window,
-            cx,
-        )
-        .ok();
-
-        if focus.is_focused(window)
-            && let Some(caret) = painted.caret.take()
-        {
-            window.paint_quad(caret);
-        }
-
-        self.input.update(cx, |input, _| {
-            input.last_layout = (!input.content.is_empty()).then_some(line);
-            input.last_bounds = Some(bounds);
-        });
-    }
-}
-
-impl Render for Input {
-    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let theme = *cx.theme();
-        let height = match self.compact {
-            true => theme.metrics.control_small,
-            false => theme.metrics.field,
-        };
-
-        div()
-            .flex()
-            .flex_1()
-            .items_center()
-            .gap_2()
-            .min_w_0()
-            .h(height)
-            .px_3()
-            .rounded(theme.radius)
-            .bg(theme.secondary)
-            .border_1()
-            .border_color(theme.border)
-            .overflow_hidden()
-            .key_context(INPUT_CONTEXT)
-            .track_focus(&self.focus_handle)
-            .cursor(CursorStyle::IBeam)
-            .on_action(cx.listener(Self::backspace))
-            .on_action(cx.listener(Self::backspace_word))
-            .on_action(cx.listener(Self::delete))
-            .on_action(cx.listener(Self::delete_word))
-            .on_action(cx.listener(Self::left))
-            .on_action(cx.listener(Self::right))
-            .on_action(cx.listener(Self::word_left))
-            .on_action(cx.listener(Self::word_right))
-            .on_action(cx.listener(Self::select_left))
-            .on_action(cx.listener(Self::select_right))
-            .on_action(cx.listener(Self::select_word_left))
-            .on_action(cx.listener(Self::select_word_right))
-            .on_action(cx.listener(Self::select_all))
-            .on_action(cx.listener(Self::home))
-            .on_action(cx.listener(Self::end))
-            .on_action(cx.listener(Self::select_home))
-            .on_action(cx.listener(Self::select_end))
-            .on_action(cx.listener(Self::space))
-            .on_action(cx.listener(Self::copy))
-            .on_action(cx.listener(Self::cut))
-            .on_action(cx.listener(Self::paste))
-            .on_mouse_down(MouseButton::Left, cx.listener(Self::on_mouse_down))
-            .on_mouse_move(cx.listener(Self::on_mouse_move))
-            .on_mouse_up(MouseButton::Left, cx.listener(Self::on_mouse_up))
-            .when_some(self.icon.clone(), |this, path| {
-                this.child(
-                    svg()
-                        .path(path)
-                        .size_4()
-                        .flex_none()
-                        .text_color(theme.muted_foreground),
-                )
-            })
-            .child(Text {
-                input: cx.entity().clone(),
-            })
     }
 }
 

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -6,9 +6,11 @@ mod card;
 mod controls;
 mod explicit;
 mod filters;
+mod form;
 mod grid;
 mod info_card;
 mod inline_links;
+mod input;
 mod label;
 mod layout;
 mod menu;
@@ -33,6 +35,7 @@ pub use card::Card;
 pub use controls::WindowControls;
 pub use explicit::ExplicitBadge;
 pub use filters::{FlagAxis, RangeAxis, RangeScrubber, RangeState, SortAxis, Unit};
+pub use form::{FORM_CONTEXT, Submit};
 pub use grid::{
     Cell, ColumnSpec, Deselect, GRID_CONTEXT, Grid, GridDelegate, GridEvent, GridSource, GridState,
     Layout, ROW_GROUP, SelectNext, SelectPrevious, Sort, Sorting, Table, Toggle, Viewport, Width,
@@ -40,6 +43,11 @@ pub use grid::{
 };
 pub use info_card::{Fact, InfoCard};
 pub use inline_links::{InlineLink, InlineLinks};
+pub use input::{
+    Backspace, BackspaceWord, Copy, Cut, Delete, DeleteWord, Dismiss, End, Home, INPUT_CONTEXT,
+    Input, Left, Paste, Right, SelectAll, SelectEnd, SelectHome, SelectLeft, SelectRight,
+    SelectWordLeft, SelectWordRight, Space, WordLeft, WordRight,
+};
 pub use label::{eyebrow, heading, upper};
 pub use layout::{ALWAYS, MIN_CONTENT, ROOMY, Room, SNUG, VAST, WIDE};
 pub use menu::{Menu, MenuItem, SubmenuState};

--- a/crates/views/src/chrome/toolbar.rs
+++ b/crates/views/src/chrome/toolbar.rs
@@ -2,8 +2,8 @@
 
 use gpui::prelude::*;
 use gpui::{AnyElement, App, Context, Entity, Pixels, Render, SharedString, Window, div, px};
-use input::{Dismiss, Input};
 use ui::Button;
+use ui::{Dismiss, Input};
 
 const WIDEST: Pixels = px(280.);
 

--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -6,9 +6,9 @@ use gpui::{
     Render, ScrollHandle, SharedString, Window, div, px,
 };
 use i18n::t;
-use input::Input;
 use router::{Destination, navigate};
 use spotify::Track;
+use ui::Input;
 
 use crate::chrome::{Chrome, TrackMenu};
 use state::{Hit, Kind, Playback, Search};

--- a/crates/views/src/shells/workspace.rs
+++ b/crates/views/src/shells/workspace.rs
@@ -3,8 +3,9 @@
 use gpui::prelude::*;
 use gpui::{AnyView, App, Context, Entity, FocusHandle, Render};
 use gpui::{Window, div};
-use input::{Dismiss, WORKSPACE_CONTEXT};
+use input::WORKSPACE_CONTEXT;
 use state::{Playback, Queue};
+use ui::Dismiss;
 
 use crate::chrome::{Chrome, PlayerBar, SidebarLeft, SidebarRight, TitleBarOptions};
 use crate::shells::Shell;


### PR DESCRIPTION
## Summary

- move the text input element and its state into `ui`, split across state and rendering
- keep actions and key bindings in `input`, which no longer carries an element
- add a form key context and submit action for dialogs