### PR TITLE
feat(views): playlist feedback and in-place library updates

### DIFF
--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -276,3 +276,13 @@ corners-square = Square
 corners-subtle = Subtle
 corners-rounded = Rounded
 corners-round = Round
+
+toast-playlist-created = Playlist created
+toast-playlist-renamed = Playlist renamed
+toast-playlist-deleted = Playlist deleted
+toast-playlist-removed = Playlist removed from your library
+toast-playlist-visibility = Playlist visibility changed
+toast-track-added = Song added to the playlist
+toast-playlist-failed = That change could not be saved
+toast-playlist-busy = Another change is still running
+toast-playlist-signed-out = Sign in to change playlists

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -278,3 +278,13 @@ corners-square = Proste
 corners-subtle = Subtelne
 corners-rounded = Zaokrąglone
 corners-round = Okrągłe
+
+toast-playlist-created = Utworzono playlistę
+toast-playlist-renamed = Zmieniono nazwę playlisty
+toast-playlist-deleted = Usunięto playlistę
+toast-playlist-removed = Usunięto playlistę z biblioteki
+toast-playlist-visibility = Zmieniono widoczność playlisty
+toast-track-added = Dodano utwór do playlisty
+toast-playlist-failed = Nie udało się zapisać zmiany
+toast-playlist-busy = Inna zmiana wciąż trwa
+toast-playlist-signed-out = Zaloguj się, aby zmieniać playlisty

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -278,3 +278,13 @@ corners-square = Прямые
 corners-subtle = Лёгкие
 corners-rounded = Скруглённые
 corners-round = Круглые
+
+toast-playlist-created = Плейлист создан
+toast-playlist-renamed = Плейлист переименован
+toast-playlist-deleted = Плейлист удалён
+toast-playlist-removed = Плейлист удалён из медиатеки
+toast-playlist-visibility = Видимость плейлиста изменена
+toast-track-added = Трек добавлен в плейлист
+toast-playlist-failed = Не удалось сохранить изменение
+toast-playlist-busy = Другое изменение ещё выполняется
+toast-playlist-signed-out = Войдите, чтобы менять плейлисты

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -278,3 +278,13 @@ corners-square = Прямі
 corners-subtle = Легкі
 corners-rounded = Заокруглені
 corners-round = Круглі
+
+toast-playlist-created = Плейлист створено
+toast-playlist-renamed = Плейлист перейменовано
+toast-playlist-deleted = Плейлист видалено
+toast-playlist-removed = Плейлист вилучено з медіатеки
+toast-playlist-visibility = Видимість плейлиста змінено
+toast-track-added = Трек додано до плейлиста
+toast-playlist-failed = Не вдалося зберегти зміну
+toast-playlist-busy = Інша зміна ще виконується
+toast-playlist-signed-out = Увійдіть, щоб змінювати плейлисти

--- a/assets/icons/circle-alert.svg
+++ b/assets/icons/circle-alert.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <line x1="12" x2="12" y1="8" y2="12" />
+  <line x1="12" x2="12.01" y1="16" y2="16" />
+</svg>

--- a/assets/icons/circle-check.svg
+++ b/assets/icons/circle-check.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <path d="m9 12 2 2 4-4" />
+</svg>

--- a/crates/sonora/src/assets.rs
+++ b/crates/sonora/src/assets.rs
@@ -48,6 +48,8 @@ const ICONS: &[(&str, &[u8])] = icons![
     "chevrons-up-down",
     "arrow-up-down",
     "chevron-up",
+    "circle-alert",
+    "circle-check",
     "heart",
     "heart-filled",
     "house",

--- a/crates/spotify/src/playlists.rs
+++ b/crates/spotify/src/playlists.rs
@@ -32,6 +32,8 @@ pub async fn create(session: &Session, name: &str) -> Result<String> {
         .map(str::to_owned)
         .ok_or_else(|| anyhow!("cannot read the created playlist id"))?;
 
+    rename(session, &id, name).await?;
+
     let uri = format!("{PLAYLIST_PREFIX}{id}");
     let rootlist = fetch_rootlist(session).await?;
     let body = changes(rootlist.revision.as_deref(), add_op(&uri));
@@ -361,6 +363,21 @@ mod tests {
         assert_eq!(op.rem.length(), 1);
         assert_eq!(op.rem.items[0].uri(), "spotify:playlist:b");
         assert!(op.update_list_attributes.is_none());
+    }
+
+    #[test]
+    fn a_name_survives_the_wire_in_any_script() {
+        for name in ["Playlist", "Плейлист", "Плейліст", "日本語", "hi 🎧"] {
+            let body = changes(None, rename_op(name));
+            let bytes = body.write_to_bytes().expect("encode");
+            let decoded = ListChanges::parse_from_bytes(&bytes).expect("decode");
+            let values = &decoded.deltas[0].ops[0]
+                .update_list_attributes
+                .new_attributes
+                .values;
+
+            assert_eq!(values.name(), name);
+        }
     }
 
     #[test]

--- a/crates/state/src/detail.rs
+++ b/crates/state/src/detail.rs
@@ -56,6 +56,22 @@ impl Detail {
         })
         .detach();
 
+        cx.observe(&library, |this, library, cx| {
+            let Some(id) = this.id.clone() else {
+                return;
+            };
+            let Some(playlist) = library.read(cx).playlist(&id).cloned() else {
+                return;
+            };
+            if this.playlist.as_ref() == Some(&playlist) {
+                return;
+            }
+            this.header = Some(playlist_header(&playlist));
+            this.playlist = Some(playlist);
+            cx.notify();
+        })
+        .detach();
+
         Self {
             id: None,
             header: None,

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -10,17 +10,19 @@ mod search;
 mod session;
 mod settings;
 mod song;
+mod toast;
 
 pub use artist::ArtistDetail;
 pub use detail::{Collection, Detail, Header};
 pub use home::Home;
-pub use library::{Library, LibraryState};
+pub use library::{Library, LibraryEvent, LibraryState};
 pub use playback::{Origin, Playback, PlaybackState, Repeat};
 pub use queue::Queue;
 pub use search::{AlbumHit, ArtistHit, Hit, Kind, Search};
 pub use session::{Session, SessionEvent, SessionState};
 pub use settings::AppSettings;
 pub use song::SongDetail;
+pub use toast::{Note, Toast, Toasts};
 
 use std::future::Future;
 use std::sync::Arc;

--- a/crates/state/src/library.rs
+++ b/crates/state/src/library.rs
@@ -8,7 +8,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use gpui::{Context, Entity, Task};
 use spotify::{Album, Playlist, SpotifyApi, Track};
 
-use crate::{Io, Session, SessionEvent, join};
+use crate::{Io, Note, Session, SessionEvent, Toasts, join};
 
 const PAGE_LIMIT: u32 = 10000;
 
@@ -40,6 +40,10 @@ fn take<T>(label: &str, result: anyhow::Result<Vec<T>>, problems: &mut Vec<Strin
     })
 }
 
+pub enum LibraryEvent {
+    PlaylistGone(String),
+}
+
 pub enum LibraryState {
     Empty,
     Loading,
@@ -51,6 +55,8 @@ pub enum LibraryState {
     },
     Failed(String),
 }
+
+impl gpui::EventEmitter<LibraryEvent> for Library {}
 
 pub struct Library {
     state: LibraryState,
@@ -167,14 +173,15 @@ impl Library {
     pub fn create_playlist(&mut self, name: String, track: Option<String>, cx: &mut Context<Self>) {
         self.mutate_playlist(
             "create playlist",
+            "toast-playlist-created",
             move |client| async move {
                 let id = client.create_playlist(&name).await?;
                 if let Some(track) = track {
                     client.add_track_to_playlist(&id, &track).await?;
                 }
-                Ok(())
+                client.playlist(&id).await.map(|detail| detail.playlist)
             },
-            Self::refresh,
+            Self::insert_playlist,
             cx,
         );
     }
@@ -183,8 +190,9 @@ impl Library {
         let renamed = (id.clone(), name.clone());
         self.mutate_playlist(
             "rename playlist",
+            "toast-playlist-renamed",
             move |client| async move { client.rename_playlist(&id, &name).await },
-            move |this, cx| {
+            move |this, _, cx| {
                 let (id, name) = renamed;
                 this.amend_playlist(&id, |playlist| playlist.name = name, cx);
             },
@@ -196,8 +204,9 @@ impl Library {
         let changed = id.clone();
         self.mutate_playlist(
             "change playlist visibility",
+            "toast-playlist-visibility",
             move |client| async move { client.set_playlist_public(&id, public).await },
-            move |this, cx| {
+            move |this, _, cx| {
                 this.amend_playlist(&changed, |playlist| playlist.public = public, cx);
             },
             cx,
@@ -213,8 +222,9 @@ impl Library {
         let added = playlist_id.clone();
         self.mutate_playlist(
             "add track to playlist",
+            "toast-track-added",
             move |client| async move { client.add_track_to_playlist(&playlist_id, &track_id).await },
-            move |this, cx| {
+            move |this, _, cx| {
                 this.amend_playlist(&added, |playlist| playlist.track_count += 1, cx);
             },
             cx,
@@ -222,10 +232,12 @@ impl Library {
     }
 
     pub fn delete_playlist(&mut self, id: String, cx: &mut Context<Self>) {
+        let deleted = id.clone();
         self.mutate_playlist(
             "delete playlist",
+            "toast-playlist-deleted",
             move |client| async move { client.delete_playlist(&id).await },
-            Self::refresh,
+            move |this, _, cx| this.forget_playlist(&deleted, cx),
             cx,
         );
     }
@@ -234,8 +246,9 @@ impl Library {
         let removed = id.clone();
         self.mutate_playlist(
             "remove playlist from library",
+            "toast-playlist-removed",
             move |client| async move { client.remove_playlist_from_library(&id).await },
-            move |this, cx| this.drop_playlist(&removed, cx),
+            move |this, _, cx| this.forget_playlist(&removed, cx),
             cx,
         );
     }
@@ -254,23 +267,27 @@ impl Library {
         playlists.iter().find(|playlist| playlist.id == id)
     }
 
-    fn mutate_playlist<F, R, A>(
+    fn mutate_playlist<F, R, T, A>(
         &mut self,
         action: &'static str,
+        done: &'static str,
         mutation: F,
         apply: A,
         cx: &mut Context<Self>,
     ) where
         F: FnOnce(Arc<dyn SpotifyApi>) -> R + Send + 'static,
-        R: Future<Output = anyhow::Result<()>> + Send + 'static,
-        A: FnOnce(&mut Self, &mut Context<Self>) + 'static,
+        R: Future<Output = anyhow::Result<T>> + Send + 'static,
+        T: Send + 'static,
+        A: FnOnce(&mut Self, T, &mut Context<Self>) + 'static,
     {
         if self.playlist_task.is_some() {
             log::warn!("library: cannot {action} while another change is running");
+            Toasts::show(Note::Failed, "toast-playlist-busy", cx);
             return;
         }
         let Some(client) = self.session.read(cx).client() else {
             log::warn!("library: cannot {action} while signed out");
+            Toasts::show(Note::Failed, "toast-playlist-signed-out", cx);
             return;
         };
         let io = self.io.clone();
@@ -279,13 +296,33 @@ impl Library {
             this.update(cx, |this, cx| {
                 this.playlist_task = None;
                 match result {
-                    Ok(()) => apply(this, cx),
-                    Err(error) => log::warn!("library: cannot {action}: {error:#}"),
+                    Ok(outcome) => {
+                        apply(this, outcome, cx);
+                        Toasts::show(Note::Done, done, cx);
+                    }
+                    Err(error) => {
+                        log::warn!("library: cannot {action}: {error:#}");
+                        Toasts::show(Note::Failed, "toast-playlist-failed", cx);
+                    }
                 }
                 cx.notify();
             })
             .ok();
         }));
+    }
+
+    fn insert_playlist(&mut self, playlist: Playlist, cx: &mut Context<Self>) {
+        let LibraryState::Ready { playlists, .. } = &mut self.state else {
+            return;
+        };
+        playlists.retain(|known| known.id != playlist.id);
+        playlists.push(playlist);
+        cx.notify();
+    }
+
+    fn forget_playlist(&mut self, id: &str, cx: &mut Context<Self>) {
+        cx.emit(LibraryEvent::PlaylistGone(id.to_owned()));
+        self.drop_playlist(id, cx);
     }
 
     fn drop_playlist(&mut self, id: &str, cx: &mut Context<Self>) {

--- a/crates/state/src/toast.rs
+++ b/crates/state/src/toast.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::time::Duration;
+
+use gpui::{App, AppContext as _, Context, Entity, Global, SharedString};
+
+const LINGER: Duration = Duration::from_secs(4);
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Note {
+    Done,
+    Failed,
+}
+
+#[derive(Clone)]
+pub struct Toast {
+    pub id: usize,
+    pub note: Note,
+    pub key: SharedString,
+}
+
+pub struct Toasts {
+    shown: Vec<Toast>,
+    next: usize,
+}
+
+struct Installed(Entity<Toasts>);
+
+impl Global for Installed {}
+
+impl Toasts {
+    pub fn entity(cx: &mut App) -> Entity<Self> {
+        if cx.try_global::<Installed>().is_none() {
+            let toasts = cx.new(|_| Self {
+                shown: Vec::new(),
+                next: 0,
+            });
+            cx.set_global(Installed(toasts));
+        }
+        cx.global::<Installed>().0.clone()
+    }
+
+    pub fn show(note: Note, key: impl Into<SharedString>, cx: &mut App) {
+        let toasts = Self::entity(cx);
+        toasts.update(cx, |this, cx| this.push(note, key.into(), cx));
+    }
+
+    pub fn shown(&self) -> &[Toast] {
+        &self.shown
+    }
+
+    pub fn dismiss(&mut self, id: usize, cx: &mut Context<Self>) {
+        self.shown.retain(|toast| toast.id != id);
+        cx.notify();
+    }
+
+    fn push(&mut self, note: Note, key: SharedString, cx: &mut Context<Self>) {
+        let id = self.next;
+        self.next += 1;
+        self.shown.push(Toast { id, note, key });
+        cx.notify();
+
+        cx.spawn(async move |this, cx| {
+            cx.background_executor().timer(LINGER).await;
+            this.update(cx, |this, cx| this.dismiss(id, cx)).ok();
+        })
+        .detach();
+    }
+}

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -26,6 +26,7 @@ mod shield;
 mod skeleton;
 mod theme;
 mod time;
+mod toast;
 mod view;
 
 pub use artwork::{Artwork, Avatar};
@@ -63,4 +64,5 @@ pub use shield::Shield;
 pub use skeleton::{Initials, Skeleton};
 pub use theme::{ActiveTheme, Look, MAX_FONT, MIN_FONT, Theme, ThemeKind, ThemeOverrides};
 pub use time::clock;
+pub use toast::Toast;
 pub use view::Mode;

--- a/crates/ui/src/toast.rs
+++ b/crates/ui/src/toast.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use gpui::prelude::*;
+use gpui::{App, ClickEvent, ElementId, Pixels, SharedString, Window, div, px, svg};
+
+use crate::button::Button;
+use crate::metrics::Text;
+use crate::theme::ActiveTheme as _;
+
+const ICON: Pixels = px(16.);
+
+type Press = Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>;
+
+#[derive(IntoElement)]
+pub struct Toast {
+    id: ElementId,
+    message: SharedString,
+    failed: bool,
+    dismiss: Option<Press>,
+}
+
+impl Toast {
+    #[track_caller]
+    pub fn new(id: impl Into<ElementId>, message: impl Into<SharedString>) -> Self {
+        Self {
+            id: id.into(),
+            message: message.into(),
+            failed: false,
+            dismiss: None,
+        }
+    }
+
+    pub fn failed(mut self) -> Self {
+        self.failed = true;
+        self
+    }
+
+    pub fn on_dismiss(
+        mut self,
+        handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.dismiss = Some(Box::new(handler));
+        self
+    }
+}
+
+impl RenderOnce for Toast {
+    fn render(self, _: &mut Window, cx: &mut App) -> impl IntoElement {
+        let Self {
+            id,
+            message,
+            failed,
+            dismiss,
+        } = self;
+
+        let theme = *cx.theme();
+        let (tint, icon) = match failed {
+            true => (theme.danger, "icons/circle-alert.svg"),
+            false => (theme.primary, "icons/circle-check.svg"),
+        };
+
+        div()
+            .id(id)
+            .flex()
+            .items_center()
+            .justify_between()
+            .gap_4()
+            .py(theme.metrics.pad)
+            .pl(theme.metrics.pad * 2)
+            .pr(theme.metrics.pad)
+            .rounded(theme.radius)
+            .border_1()
+            .shadow_md()
+            .border_color(theme.border)
+            .bg(theme.popover)
+            .text_size(theme.text(Text::Small))
+            .text_color(theme.foreground)
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap_2()
+                    .min_w_0()
+                    .child(svg().path(icon).size(ICON).flex_none().text_color(tint))
+                    .child(div().min_w_0().truncate().child(message)),
+            )
+            .children(dismiss.map(|dismiss| {
+                Button::new("dismiss-toast")
+                    .ghost()
+                    .small()
+                    .icon("icons/x.svg")
+                    .on_click(move |event, window, cx| dismiss(event, window, cx))
+            }))
+    }
+}

--- a/crates/views/src/chrome/mod.rs
+++ b/crates/views/src/chrome/mod.rs
@@ -4,6 +4,7 @@ mod player_bar;
 mod sidebar_left;
 mod sidebar_right;
 mod title_bar;
+mod toasts;
 mod toolbar;
 pub(crate) mod tools;
 
@@ -11,6 +12,7 @@ pub(crate) use player_bar::PlayerBar;
 pub(crate) use sidebar_left::SidebarLeft;
 pub(crate) use sidebar_right::SidebarRight;
 pub(crate) use title_bar::{TitleBar, TitleBarEvent, TitleBarOptions};
+pub(crate) use toasts::ToastStack;
 pub(crate) use toolbar::{Searchable, Toolbar, Tooled};
 
 use gpui::{App, AppContext as _, Entity, Global, Pixels, Window};

--- a/crates/views/src/chrome/toasts.rs
+++ b/crates/views/src/chrome/toasts.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use gpui::prelude::*;
+use gpui::{Context, Entity, Render, Window, div};
+use state::{Note, Toasts};
+use ui::{ActiveTheme as _, Toast};
+
+pub(crate) struct ToastStack {
+    toasts: Entity<Toasts>,
+}
+
+impl ToastStack {
+    pub fn new(cx: &mut Context<Self>) -> Self {
+        let toasts = Toasts::entity(cx);
+        cx.observe(&toasts, |_, _, cx| cx.notify()).detach();
+        Self { toasts }
+    }
+}
+
+impl Render for ToastStack {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = *cx.theme();
+        let shown = self.toasts.read(cx).shown().to_vec();
+        if shown.is_empty() {
+            return div();
+        }
+
+        div()
+            .absolute()
+            .bottom(theme.metrics.player_bar)
+            .left_0()
+            .right_0()
+            .flex()
+            .flex_col()
+            .items_center()
+            .gap_2()
+            .pb(theme.metrics.pad)
+            .children(shown.into_iter().map(|toast| {
+                let id = toast.id;
+                let toasts = self.toasts.clone();
+
+                Toast::new(("toast", id), i18n::lookup(&toast.key, None))
+                    .when(toast.note == Note::Failed, Toast::failed)
+                    .on_dismiss(move |_, _, cx| {
+                        toasts.update(cx, |this, cx| this.dismiss(id, cx));
+                    })
+            }))
+    }
+}

--- a/crates/views/src/screens/detail.rs
+++ b/crates/views/src/screens/detail.rs
@@ -8,7 +8,7 @@ use gpui::{
 
 use i18n::t;
 use spotify::Track;
-use state::{AppSettings, Collection, Detail, Playback, Sonora};
+use state::{AppSettings, Collection, Detail, LibraryEvent, Playback, Sonora};
 use ui::{ActiveTheme as _, Button, Menu, Popover, Popovers, Popup, SortAxis};
 use ui::{
     ColumnSpec, FlagAxis, GridDelegate, GridEvent, GridState, RangeAxis, Scrollbar, Scroller,
@@ -115,6 +115,25 @@ impl DetailView {
             let library = Sonora::global(cx).library.clone();
             cx.observe(&library, |this, _, cx| {
                 this.table.update(cx, |table, cx| table.refresh(cx));
+            })
+            .detach();
+        }
+
+        if section == "playlist" {
+            let library = Sonora::global(cx).library.clone();
+            cx.subscribe(&library, |_, _, event, cx| {
+                let LibraryEvent::PlaylistGone(id) = event;
+                let trail = router::trail(cx);
+                if trail.read(cx).current() != router::Destination::Playlist(id.clone().into()) {
+                    return;
+                }
+                match trail.read(cx).can_go_back() {
+                    true => router::back(cx),
+                    false => router::navigate(
+                        router::Destination::Library(router::LibraryTab::Playlists),
+                        cx,
+                    ),
+                }
             })
             .detach();
         }

--- a/crates/views/src/shells/workspace.rs
+++ b/crates/views/src/shells/workspace.rs
@@ -7,7 +7,7 @@ use input::WORKSPACE_CONTEXT;
 use state::{Playback, Queue};
 use ui::Dismiss;
 
-use crate::chrome::{Chrome, PlayerBar, SidebarLeft, SidebarRight, TitleBarOptions};
+use crate::chrome::{Chrome, PlayerBar, SidebarLeft, SidebarRight, TitleBarOptions, ToastStack};
 use crate::shared::playlist_editor::PlaylistEditor;
 use crate::shells::Shell;
 
@@ -16,6 +16,7 @@ pub(crate) struct Workspace {
     player_bar: Entity<PlayerBar>,
     sidebar_right: Entity<SidebarRight>,
     playlist_editor: Entity<PlaylistEditor>,
+    toasts: Entity<ToastStack>,
     content: AnyView,
     focus: FocusHandle,
 }
@@ -37,6 +38,7 @@ impl Workspace {
             player_bar,
             sidebar_right,
             playlist_editor: PlaylistEditor::entity(cx),
+            toasts: cx.new(ToastStack::new),
             content,
             focus: cx.focus_handle(),
         }
@@ -125,7 +127,12 @@ impl Render for Workspace {
                     .child(self.sidebar_right.clone())
                     .when(overlay, |this| this.child(self.sidebar.clone())),
             )
-            .child(self.player_bar.clone())
+            .child(
+                div()
+                    .relative()
+                    .child(self.player_bar.clone())
+                    .child(self.toasts.clone()),
+            )
             .child(self.playlist_editor.clone())
     }
 }


### PR DESCRIPTION
## Summary

- name a playlist on creation, which the create endpoint was dropping
- show a toast above the player for every playlist change, including the ones that previously only reached the log
- reflect a rename on the playlist page instead of leaving the old title
- leave a playlist page when that playlist is deleted while you are on it
- add and drop playlists in place instead of reloading the whole library