### PR TITLE
feat(views): add team credits to about page

### DIFF
--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -259,6 +259,11 @@ settings-license-view = Read the license
 settings-source = Source code
 settings-source-detail = The corresponding source for this build
 settings-source-view = Open the repository
+settings-team = Team
+settings-team-github = GitHub
+settings-role-maintainer = Maintainer
+settings-role-developer = Developer
+settings-role-contributor = Contributor
 settings-notice = Copyright © 2026 nolight132. Sonora comes with absolutely no warranty. It is free software, and you are welcome to redistribute it under the terms of the GNU General Public License version 3 or later. Sonora is unofficial and is not affiliated with Spotify AB.
 
 # themes

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -261,6 +261,11 @@ settings-license-view = Przeczytaj licencję
 settings-source = Kod źródłowy
 settings-source-detail = Kod źródłowy odpowiadający temu wydaniu
 settings-source-view = Otwórz repozytorium
+settings-team = Zespół
+settings-team-github = GitHub
+settings-role-maintainer = Opiekun
+settings-role-developer = Programista
+settings-role-contributor = Współtwórca
 settings-notice = Copyright © 2026 nolight132. Sonora jest dostarczana bez żadnej gwarancji. To wolne oprogramowanie, które możesz rozpowszechniać na warunkach GNU General Public License w wersji 3 lub nowszej. Sonora jest nieoficjalnym klientem i nie jest powiązana ze Spotify AB.
 
 # themes

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -261,6 +261,11 @@ settings-license-view = Прочитать лицензию
 settings-source = Исходный код
 settings-source-detail = Исходный код, соответствующий этой сборке
 settings-source-view = Открыть репозиторий
+settings-team = Команда
+settings-team-github = GitHub
+settings-role-maintainer = Сопровождающий
+settings-role-developer = Разработчик
+settings-role-contributor = Участник
 settings-notice = Copyright © 2026 nolight132. Sonora поставляется без каких-либо гарантий. Это свободное программное обеспечение, и вы можете распространять его на условиях GNU General Public License версии 3 или новее. Sonora — неофициальный клиент и не связан со Spotify AB.
 
 # themes

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -261,6 +261,11 @@ settings-license-view = Прочитати ліцензію
 settings-source = Початковий код
 settings-source-detail = Початковий код, що відповідає цьому складанню
 settings-source-view = Відкрити репозиторій
+settings-team = Команда
+settings-team-github = GitHub
+settings-role-maintainer = Супровідник
+settings-role-developer = Розробник
+settings-role-contributor = Учасник
 settings-notice = Copyright © 2026 nolight132. Sonora постачається без жодних гарантій. Це вільне програмне забезпечення, і ви можете поширювати його на умовах GNU General Public License версії 3 або новішої. Sonora — неофіційний клієнт і не пов'язаний зі Spotify AB.
 
 # themes

--- a/crates/views/src/screens/settings.rs
+++ b/crates/views/src/screens/settings.rs
@@ -11,8 +11,8 @@ use i18n::{Language, t};
 use state::{AppSettings, Playback, Session, SessionState, Sonora};
 use ui::{ActiveTheme as _, Scrollbar, Scroller};
 use ui::{
-    Button, Initials, Look, MAX_FONT, MIN_FONT, Menu, MenuItem, Popover, Popovers, Rounding,
-    Skeleton, Text, Theme, ThemeKind,
+    Avatar, Button, InfoCard, Initials, Look, MAX_FONT, MIN_FONT, Menu, MenuItem, Popover,
+    Popovers, Rounding, Skeleton, Text, Theme, ThemeKind,
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -22,6 +22,50 @@ const SOURCE_URL: &str = "https://github.com/nolight132/sonora";
 const THEMES: &str = "themes";
 const CORNERS: &str = "corners";
 const LANGUAGES: &str = "languages";
+
+#[derive(Clone, Copy)]
+struct Member {
+    login: &'static str,
+    avatar: &'static str,
+    profile: &'static str,
+    role: Role,
+}
+
+#[derive(Clone, Copy)]
+enum Role {
+    Maintainer,
+    Developer,
+    Contributor,
+}
+
+impl Role {
+    fn label(self) -> SharedString {
+        match self {
+            Self::Maintainer => t!("settings-role-maintainer"),
+            Self::Developer => t!("settings-role-developer"),
+            Self::Contributor => t!("settings-role-contributor"),
+        }
+    }
+}
+
+macro_rules! member {
+    ($login:literal, $role:expr) => {
+        Member {
+            login: concat!("@", $login),
+            avatar: concat!("https://github.com/", $login, ".png"),
+            profile: concat!("https://github.com/", $login),
+            role: $role,
+        }
+    };
+}
+
+const MEMBERS: [Member; 5] = [
+    member!("nolight132", Role::Maintainer),
+    member!("zxsleebu", Role::Developer),
+    member!("fx-got", Role::Developer),
+    member!("Makakashan", Role::Contributor),
+    member!("imizgun", Role::Contributor),
+];
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Tab {
@@ -611,6 +655,50 @@ impl SettingsView {
             .child(t!("settings-notice"))
     }
 
+    fn team(&self, cx: &Context<Self>) -> impl IntoElement {
+        let theme = *cx.theme();
+
+        InfoCard::new(t!("settings-team")).child(div().flex().flex_col().gap_3().children(
+            MEMBERS.into_iter().enumerate().map(|(index, member)| {
+                div()
+                    .id(("team-member", index))
+                    .flex()
+                    .items_center()
+                    .gap_3()
+                    .px(theme.metrics.pad)
+                    .py(theme.metrics.pad / 2.)
+                    .rounded(theme.radius)
+                    .cursor_pointer()
+                    .hover(|style| style.bg(theme.secondary_hover))
+                    .on_click(move |_, _, cx| cx.open_url(member.profile))
+                    .child(Avatar::new(Some(member.avatar)).size(theme.metrics.thumb))
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .flex_1()
+                            .min_w_0()
+                            .gap_0p5()
+                            .child(div().font_weight(FontWeight::MEDIUM).child(member.login))
+                            .child(
+                                div()
+                                    .text_size(theme.text(Text::Small))
+                                    .text_color(theme.muted_foreground)
+                                    .child(t!("settings-team-github")),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .flex_none()
+                            .text_size(theme.text(Text::Small))
+                            .font_weight(FontWeight::MEDIUM)
+                            .text_color(theme.muted_foreground)
+                            .child(member.role.label()),
+                    )
+            }),
+        ))
+    }
+
     fn row(
         &self,
         title: SharedString,
@@ -677,7 +765,9 @@ impl Render for SettingsView {
                     .child(div().h(px(1.)).w_full().bg(border))
                     .child(self.tabs(cx))
                     .child(self.panel(cx))
-                    .when(self.tab == Tab::About, |this| this.child(self.notice(cx))),
+                    .when(self.tab == Tab::About, |this| {
+                        this.child(self.team(cx)).child(self.notice(cx))
+                    }),
             )
     }
 }


### PR DESCRIPTION
## Summary

- add the five Sonora team members to the About page
- match the song-details credits card layout with circular GitHub avatars and hover states
- show localized, right-aligned team roles
- open each member's GitHub profile when their row is clicked
- derive profile and avatar URLs from each login with a compile-time macro

## Impact

The About page now credits the project team in a consistent, localized presentation without introducing a new UI component.

Closes #60.

## Validation

- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `git diff HEAD^ --check`
