### PR TITLE
fix(playback): separate play next from queueing

### DIFF
--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -46,6 +46,7 @@ menu-no-playlists = No playlists
 menu-add-to-library = Add to Library
 menu-remove-from-library = Remove from Library
 menu-remove-from-playlist = Remove from playlist
+menu-play-next = Play next
 menu-add-to-queue = Add to queue
 menu-song-radio = Go to song radio
 menu-go-to-album = Go to album

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -46,6 +46,7 @@ menu-no-playlists = Brak playlist
 menu-add-to-library = Dodaj do biblioteki
 menu-remove-from-library = Usuń z biblioteki
 menu-remove-from-playlist = Usuń z playlisty
+menu-play-next = Odtwórz jako następny
 menu-add-to-queue = Dodaj do kolejki
 menu-song-radio = Radio utworu
 menu-go-to-album = Przejdź do albumu

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -46,6 +46,7 @@ menu-no-playlists = Нет плейлистов
 menu-add-to-library = Добавить в медиатеку
 menu-remove-from-library = Удалить из медиатеки
 menu-remove-from-playlist = Удалить из плейлиста
+menu-play-next = Воспроизвести следующим
 menu-add-to-queue = Добавить в очередь
 menu-song-radio = Радио по треку
 menu-go-to-album = Перейти к альбому

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -46,6 +46,7 @@ menu-no-playlists = Немає плейлистів
 menu-add-to-library = Додати до медіатеки
 menu-remove-from-library = Вилучити з медіатеки
 menu-remove-from-playlist = Вилучити з плейлиста
+menu-play-next = Відтворити наступним
 menu-add-to-queue = Додати до черги
 menu-song-radio = Радіо за треком
 menu-go-to-album = Перейти до альбому

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -12,6 +12,12 @@ use spotify::{SpotifyApi, Track};
 
 type Fetch = Pin<Box<dyn Future<Output = Result<Vec<Track>>> + Send>>;
 
+#[derive(Clone, Copy)]
+enum QueuePlacement {
+    Next,
+    End,
+}
+
 use crate::queue::Queue;
 use crate::{AppSettings, Io, Session, SessionEvent, join};
 
@@ -207,10 +213,30 @@ impl Playback {
             self.begin(vec![track], 0, None, cx);
             return;
         }
+        self.queue.update(cx, |queue, cx| queue.append(track, cx));
+    }
+
+    pub fn play_next(&mut self, track: Track, cx: &mut Context<Self>) {
+        if self.queue.read(cx).current().is_none() {
+            self.begin(vec![track], 0, None, cx);
+            return;
+        }
         self.queue.update(cx, |queue, cx| queue.prepend(track, cx));
     }
 
     pub fn enqueue_all(&mut self, tracks: Vec<Track>, cx: &mut Context<Self>) {
+        if tracks.is_empty() {
+            return;
+        }
+        if self.queue.read(cx).current().is_none() {
+            self.begin(tracks, 0, None, cx);
+            return;
+        }
+        self.queue
+            .update(cx, |queue, cx| queue.append_all(tracks, cx));
+    }
+
+    pub fn play_next_all(&mut self, tracks: Vec<Track>, cx: &mut Context<Self>) {
         if tracks.is_empty() {
             return;
         }
@@ -224,7 +250,14 @@ impl Playback {
 
     pub fn enqueue_album(&mut self, album: &str, cx: &mut Context<Self>) {
         let album = album.to_owned();
-        self.enqueue_from("album", cx, move |client| {
+        self.enqueue_from("album", QueuePlacement::End, cx, move |client| {
+            Box::pin(async move { client.album_tracks(&album).await })
+        });
+    }
+
+    pub fn play_album_next(&mut self, album: &str, cx: &mut Context<Self>) {
+        let album = album.to_owned();
+        self.enqueue_from("album", QueuePlacement::Next, cx, move |client| {
             Box::pin(async move { client.album_tracks(&album).await })
         });
     }
@@ -239,7 +272,14 @@ impl Playback {
 
     pub fn enqueue_playlist(&mut self, playlist: &str, cx: &mut Context<Self>) {
         let playlist = playlist.to_owned();
-        self.enqueue_from("playlist", cx, move |client| {
+        self.enqueue_from("playlist", QueuePlacement::End, cx, move |client| {
+            Box::pin(async move { client.playlist_tracks(&playlist).await })
+        });
+    }
+
+    pub fn play_playlist_next(&mut self, playlist: &str, cx: &mut Context<Self>) {
+        let playlist = playlist.to_owned();
+        self.enqueue_from("playlist", QueuePlacement::Next, cx, move |client| {
             Box::pin(async move { client.playlist_tracks(&playlist).await })
         });
     }
@@ -252,8 +292,13 @@ impl Playback {
         });
     }
 
-    fn enqueue_from<F>(&mut self, source: &'static str, cx: &mut Context<Self>, tracks: F)
-    where
+    fn enqueue_from<F>(
+        &mut self,
+        source: &'static str,
+        placement: QueuePlacement,
+        cx: &mut Context<Self>,
+        tracks: F,
+    ) where
         F: FnOnce(Arc<dyn SpotifyApi>) -> Fetch + Send + 'static,
     {
         if self.enqueue.is_some() {
@@ -268,7 +313,10 @@ impl Playback {
             this.update(cx, |this, cx| {
                 this.enqueue = None;
                 match loaded {
-                    Ok(tracks) => this.enqueue_all(tracks, cx),
+                    Ok(tracks) => match placement {
+                        QueuePlacement::Next => this.play_next_all(tracks, cx),
+                        QueuePlacement::End => this.enqueue_all(tracks, cx),
+                    },
                     Err(error) => log::error!("playback: cannot enqueue {source}: {error:#}"),
                 }
             })

--- a/crates/views/src/screens/settings.rs
+++ b/crates/views/src/screens/settings.rs
@@ -656,6 +656,8 @@ impl SettingsView {
     }
 
     fn team(&self, cx: &Context<Self>) -> impl IntoElement {
+        let theme = *cx.theme();
+
         InfoCard::new(t!("settings-team")).flex_none().child(
             div()
                 .flex()

--- a/crates/views/src/shared/menu.rs
+++ b/crates/views/src/shared/menu.rs
@@ -118,6 +118,20 @@ impl ItemMenu {
                 .icon("icons/link.svg")
                 .disabled(),
         };
+        let next = match track.playable {
+            true => {
+                let track = track.clone();
+                MenuItem::new("play-next", t!("menu-play-next"))
+                    .icon("icons/list-plus.svg")
+                    .on_click(move |_, _, cx| {
+                        let playback = Sonora::global(cx).playback.clone();
+                        playback.update(cx, |playback, cx| playback.play_next(track.clone(), cx));
+                    })
+            }
+            false => MenuItem::new("play-next", t!("menu-play-next"))
+                .icon("icons/list-plus.svg")
+                .disabled(),
+        };
         let queue = match track.playable {
             true => {
                 let track = track.clone();
@@ -213,6 +227,7 @@ impl ItemMenu {
                     .submenu(playlist_menu, self.playlist_submenu.clone()),
             )
             .item(library_action.unwrap_or(toggle_library))
+            .item(next)
             .item(queue)
             .item(
                 MenuItem::new("song-radio", t!("menu-song-radio"))
@@ -229,8 +244,10 @@ impl ItemMenu {
 pub(crate) fn album_menu(album_id: String, playback: Entity<Playback>, opened_here: bool) -> Menu {
     let opened = album_id.clone();
     let played = album_id.clone();
+    let next = album_id.clone();
     let queued = album_id;
     let playing = playback.clone();
+    let nexting = playback.clone();
     let queueing = playback;
 
     let menu = match opened_here {
@@ -250,6 +267,13 @@ pub(crate) fn album_menu(album_id: String, playback: Entity<Playback>, opened_he
             }),
     )
     .item(
+        MenuItem::new("play-album-next", t!("menu-play-next"))
+            .icon("icons/list-plus.svg")
+            .on_click(move |_, _, cx| {
+                nexting.update(cx, |playback, cx| playback.play_album_next(&next, cx));
+            }),
+    )
+    .item(
         MenuItem::new("enqueue-album", t!("menu-add-album-to-queue"))
             .icon("icons/list-end.svg")
             .on_click(move |_, _, cx| {
@@ -265,8 +289,10 @@ pub(crate) fn playlist_menu(
 ) -> Menu {
     let opened = playlist.id.clone();
     let played = playlist.id.clone();
+    let next = playlist.id.clone();
     let queued = playlist.id.clone();
     let playing = playback.clone();
+    let nexting = playback.clone();
     let queueing = playback;
     let id = playlist.id.clone();
     let public = playlist.public;
@@ -333,6 +359,13 @@ pub(crate) fn playlist_menu(
             .icon("icons/play.svg")
             .on_click(move |_, _, cx| {
                 playing.update(cx, |playback, cx| playback.play_playlist(&played, cx));
+            }),
+    )
+    .item(
+        MenuItem::new("play-playlist-next", t!("menu-play-next"))
+            .icon("icons/list-plus.svg")
+            .on_click(move |_, _, cx| {
+                nexting.update(cx, |playback, cx| playback.play_playlist_next(&next, cx));
             }),
     )
     .item(


### PR DESCRIPTION
## Summary

- add play next actions for tracks, albums, and playlists
- append add-to-queue actions after existing upcoming tracks
- localize the play next menu label across supported languages
- restore compilation for the settings team card
