### PR TITLE
fix(views): stop the side panels from resizing each other

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,7 +302,7 @@ Two modules own the measurement:
 use crate::chrome::Chrome;
 Chrome::content(window, cx)   // viewport width − both sidebars, floored at ui::MIN_CONTENT
 Chrome::room(window, cx)      // the same, classified into a Room
-Chrome::sidebar_left(cx) / Chrome::sidebar_right(cx)   // one panel's cut, for the other panel
+chrome::cap(min, max, window) // a panel's ceiling: never eat ui::MIN_CONTENT
 ```
 
 `Chrome::room` is how a view classifies its width: never rebuild `Room::of(…)` from a width you
@@ -314,16 +314,23 @@ Rules:
   ignores both side panels, so tables overflow under the right sidebar and grids pick a column count
   that does not fit. Raw viewport width is legitimate in exactly two places: chrome that spans the
   whole window (`PlayerBar`, `TitleBar`, and `Menu`'s submenu flip), and a side panel deciding *its
-  own* size — `SidebarLeft` measures the room left over once its own width is taken, `SidebarRight`
-  subtracts `Chrome::sidebar_left`. `Chrome::content` would be circular for either, because each is
-  a term in it; reading the *other* panel's cut is not.
+  own* size. `Chrome::content` would be circular for a panel, because the panel is a term in it.
+- **One panel never sets another's width.** Each clamps itself against the viewport through
+  `chrome::cap`, so neither can squeeze content below `ui::MIN_CONTENT` on its own, and neither
+  panel's size is ever a function of the other's.
+- **Hiding is a different question from sizing, and it does look at both panels.** `SidebarLeft`
+  auto-hides once the room left for content — viewport minus its own width *and*
+  `Chrome::sidebar_right` — drops below `Room::Wide`, so opening the queue pushes it out of the way
+  without resizing it. It reads last frame's publish, which cannot loop: the decision changes
+  visibility, never width. `SidebarRight` decides its own takeover from the viewport alone.
+- **A panel's width changes only when the user drags it.** `chrome::cap` feeds `Panel::reach`, which
+  bounds the *drag*, not the render — narrowing the window must never silently shrink a panel the
+  user sized. `Panel::limits` stays the static floor and ceiling.
 - `Workspace::render` publishes the widths every frame via `Chrome::publish`; it notifies only when
   a width actually changed, so it cannot loop.
 - **`Chrome` is only current after that publish.** `Workspace` renders *before* it and owns both
   panels, so it reads them directly; everything it renders into — content views and both panels —
-  sees this frame's values. `SidebarRight` is the one exception: it reads `Chrome::sidebar_left`
-  while `Workspace` is still assembling this frame's publish, so a left-panel change reaches it one
-  frame late, and its `Chrome` observation repaints it on the next.
+  sees this frame's values.
 - **A view whose layout depends on width must observe the chrome**, or it will not repaint when a
   panel is resized or toggled:
   ```rust

--- a/crates/ui/src/button.rs
+++ b/crates/ui/src/button.rs
@@ -256,7 +256,9 @@ impl RenderOnce for Button {
                         .text_color(tint.unwrap_or(palette.foreground)),
                 )
             })
-            .when_some(label, |this, label| this.child(label))
+            .when_some(label, |this, label| {
+                this.child(div().min_w_0().truncate().child(label))
+            })
             .when(interactive, |this| {
                 this.when_some(on_click, |this, handler| {
                     this.on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())

--- a/crates/ui/src/panel.rs
+++ b/crates/ui/src/panel.rs
@@ -22,6 +22,7 @@ pub enum Side {
 }
 
 struct Grab {
+    panel: ElementId,
     width: Pixels,
     origin: Cell<Pixels>,
 }
@@ -29,10 +30,12 @@ struct Grab {
 #[derive(IntoElement)]
 pub struct Panel {
     base: Stateful<Div>,
+    key: ElementId,
     side: Side,
     width: Pixels,
     min: Pixels,
     max: Pixels,
+    reach: Option<Pixels>,
     fill: bool,
     resize: Option<Resize>,
     children: Vec<AnyElement>,
@@ -41,12 +44,15 @@ pub struct Panel {
 impl Panel {
     #[track_caller]
     pub fn new(id: impl Into<ElementId>, side: Side, width: Pixels) -> Self {
+        let key: ElementId = id.into();
         Self {
-            base: div().id(id),
+            base: div().id(key.clone()),
+            key,
             side,
             width,
             min: Pixels::ZERO,
             max: Pixels::MAX,
+            reach: None,
             fill: false,
             resize: None,
             children: Vec::new(),
@@ -56,6 +62,11 @@ impl Panel {
     pub fn limits(mut self, min: Pixels, max: Pixels) -> Self {
         self.min = min;
         self.max = max;
+        self
+    }
+
+    pub fn reach(mut self, reach: Pixels) -> Self {
+        self.reach = Some(reach);
         self
     }
 
@@ -94,10 +105,12 @@ impl RenderOnce for Panel {
     fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
         let Self {
             mut base,
+            key,
             side,
             width,
             min,
             max,
+            reach,
             fill,
             resize,
             children,
@@ -107,7 +120,7 @@ impl RenderOnce for Panel {
         let handle = (!fill)
             .then_some(resize)
             .flatten()
-            .map(|resize| grip(side, width, min, max, resize));
+            .map(|resize| grip(key, side, width, min, reach.unwrap_or(max), resize));
 
         let mut panel = base
             .relative()
@@ -128,7 +141,16 @@ impl RenderOnce for Panel {
     }
 }
 
-fn grip(side: Side, width: Pixels, min: Pixels, max: Pixels, resize: Resize) -> impl IntoElement {
+fn grip(
+    key: ElementId,
+    side: Side,
+    width: Pixels,
+    min: Pixels,
+    max: Pixels,
+    resize: Resize,
+) -> impl IntoElement {
+    let dragged = key.clone();
+
     div()
         .id("panel-grip")
         .absolute()
@@ -142,6 +164,9 @@ fn grip(side: Side, width: Pixels, min: Pixels, max: Pixels, resize: Resize) -> 
         })
         .on_drag_move(move |event: &DragMoveEvent<Grab>, window, cx| {
             let grab = event.drag(cx);
+            if grab.panel != dragged {
+                return;
+            }
             let (start, origin) = (grab.width, grab.origin.get());
             let travel = event.event.position.x - origin;
             let dragged = match side {
@@ -153,6 +178,7 @@ fn grip(side: Side, width: Pixels, min: Pixels, max: Pixels, resize: Resize) -> 
         })
         .on_drag(
             Grab {
+                panel: key,
                 width,
                 origin: Cell::new(Pixels::ZERO),
             },

--- a/crates/views/src/chrome/mod.rs
+++ b/crates/views/src/chrome/mod.rs
@@ -18,6 +18,11 @@ pub(crate) use toolbar::{Searchable, Toolbar, Tooled};
 use gpui::{App, AppContext as _, Entity, Global, Pixels, Window};
 use ui::{MIN_CONTENT, Room};
 
+pub(crate) fn cap(min: Pixels, max: Pixels, keep: Pixels, window: &Window) -> Pixels {
+    let room = window.viewport_size().width - keep;
+    max.min(room.max(min))
+}
+
 #[derive(Clone, Copy, Default, PartialEq)]
 pub(crate) struct Chrome {
     sidebar_left: Pixels,
@@ -57,11 +62,6 @@ impl Chrome {
             .unwrap_or_default()
     }
 
-    pub fn sidebar_left(cx: &App) -> Pixels {
-        Self::get(cx).sidebar_left
-    }
-
-    #[allow(dead_code)]
     pub fn sidebar_right(cx: &App) -> Pixels {
         Self::get(cx).sidebar_right
     }

--- a/crates/views/src/chrome/sidebar_left.rs
+++ b/crates/views/src/chrome/sidebar_left.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use ui::{ActiveTheme as _, Button, Panel, Room, Shield, Side};
+use ui::{ActiveTheme as _, Button, MIN_CONTENT, Panel, SNUG, Shield, Side};
 
 use gpui::prelude::*;
 use gpui::{
@@ -31,7 +31,7 @@ const TABS: [(&str, LibraryTab); 3] = [
     ("nav-playlists", LibraryTab::Playlists),
 ];
 
-const MIN_WIDTH: Pixels = px(130.);
+const MIN_WIDTH: Pixels = px(160.);
 const MAX_WIDTH: Pixels = px(400.);
 
 pub(crate) struct SidebarLeft {
@@ -39,6 +39,7 @@ pub(crate) struct SidebarLeft {
     trail: Entity<Navigation>,
     width: Pixels,
     open: bool,
+    fit: bool,
     cramped: bool,
     forced: Option<bool>,
     library_open: bool,
@@ -60,6 +61,7 @@ impl SidebarLeft {
             trail,
             width,
             open,
+            fit: open,
             forced: None,
             cramped: false,
             library_open: true,
@@ -97,15 +99,34 @@ impl SidebarLeft {
                 self.persist(cx);
             }
         }
+        self.fit = self.is_open();
         cx.notify();
+    }
+
+    fn keep(&self, cx: &Context<Self>) -> Pixels {
+        match self.settings.read(cx).auto_hide_sidebar() {
+            true => SNUG,
+            false => MIN_CONTENT,
+        }
+    }
+
+    fn ceiling(&self, window: &Window, cx: &Context<Self>) -> Pixels {
+        let reserved = self.keep(cx) + super::Chrome::sidebar_right(cx);
+        super::cap(MIN_WIDTH, MAX_WIDTH, reserved, window)
     }
 
     pub fn adapt(&mut self, window: &Window, cx: &mut Context<Self>) {
         self.width = ui::snapped(self.width, window);
 
+        if std::mem::take(&mut self.fit) {
+            self.width = self.width.min(self.ceiling(window, cx));
+            self.persist(cx);
+        }
+
         let auto_hide = self.settings.read(cx).auto_hide_sidebar();
-        let space_left = window.viewport_size().width - self.width;
-        let cramped = auto_hide && !Room::of(space_left).fits(Room::Wide);
+        let taken = self.width + super::Chrome::sidebar_right(cx);
+        let space_left = window.viewport_size().width - taken;
+        let cramped = auto_hide && space_left < self.keep(cx);
         if cramped != self.cramped {
             self.cramped = cramped;
             self.forced = None;
@@ -225,6 +246,7 @@ impl Render for SidebarLeft {
         let overlaid = self.overlays();
         let panel = Panel::new("sidebar-left", Side::Left, self.width)
             .limits(MIN_WIDTH, MAX_WIDTH)
+            .reach(self.ceiling(window, cx))
             .on_resize(cx.listener(|this, width: &Pixels, _, cx| {
                 this.width = *width;
                 this.persist(cx);

--- a/crates/views/src/chrome/sidebar_right.rs
+++ b/crates/views/src/chrome/sidebar_right.rs
@@ -13,7 +13,8 @@ use i18n::t;
 use spotify::Track;
 use state::{AppSettings, Playback, Queue, Sonora};
 use ui::{
-    ActiveTheme as _, Button, Card, Panel, Popup, Room, Scrollbar, Side, Text, eyebrow, snapped,
+    ActiveTheme as _, Button, Card, MIN_CONTENT, Panel, Popup, Room, Scrollbar, Side, Text,
+    eyebrow, snapped,
 };
 
 use crate::chrome::Chrome;
@@ -243,17 +244,14 @@ impl SidebarRight {
         self.open
     }
 
-    pub(crate) fn covers_content(&self, window: &Window, cx: &App) -> bool {
-        let content = window.viewport_size().width - Chrome::sidebar_left(cx);
-        self.open && fills_content(content)
+    pub(crate) fn covers_content(&self, window: &Window) -> bool {
+        self.open && fills_content(window.viewport_size().width)
     }
 
-    pub(crate) fn occupied_width(&self, window: &Window, cx: &App) -> Pixels {
+    pub(crate) fn occupied_width(&self, window: &Window) -> Pixels {
         match self.open {
             false => Pixels::ZERO,
-            true if self.covers_content(window, cx) => {
-                window.viewport_size().width - Chrome::sidebar_left(cx)
-            }
+            true if self.covers_content(window) => window.viewport_size().width,
             true => self.width,
         }
     }
@@ -570,8 +568,7 @@ impl Render for SidebarRight {
         }
 
         let theme = *cx.theme();
-        let content_width = window.viewport_size().width - Chrome::sidebar_left(cx);
-        let fullscreen = fills_content(content_width);
+        let fullscreen = fills_content(window.viewport_size().width);
         let queue = self.queue.read(cx);
         let sections = Sections {
             past: queue.past().len(),
@@ -593,6 +590,7 @@ impl Render for SidebarRight {
 
         Panel::new("sidebar-right", Side::Right, self.width)
             .limits(MIN_WIDTH, MAX_WIDTH)
+            .reach(super::cap(MIN_WIDTH, MAX_WIDTH, MIN_CONTENT, window))
             .fill(fullscreen)
             .on_resize(cx.listener(|this, width: &Pixels, _, cx| {
                 this.width = *width;

--- a/crates/views/src/shells/workspace.rs
+++ b/crates/views/src/shells/workspace.rs
@@ -92,9 +92,9 @@ impl Render for Workspace {
         self.sidebar
             .update(cx, |sidebar, cx| sidebar.adapt(window, cx));
         let left = self.sidebar.read(cx).occupied_width();
-        let right = self.sidebar_right.read(cx).occupied_width(window, cx);
+        let right = self.sidebar_right.read(cx).occupied_width(window);
         Chrome::publish(left, right, cx);
-        let covered = self.sidebar_right.read(cx).covers_content(window, cx);
+        let covered = self.sidebar_right.read(cx).covers_content(window);
         let overlay = self.sidebar.read(cx).overlays();
 
         div()


### PR DESCRIPTION
## Summary

- give each panel its own drag, so dragging one grip no longer resizes the other panel
- size each panel against the window alone, never against the other panel
- bound the drag rather than the rendered width, so a panel keeps the width you gave it
- stop the drag at the point where the left panel would auto-hide, counting the queue's cut
- fit the left panel to the room available when it is opened from the button
- hide the left panel once content runs out of room, without changing its width
- truncate a button label instead of letting it overflow