### PR TITLE
fix(views): restore the theme binding in the team card

### DIFF
--- a/crates/views/src/screens/settings.rs
+++ b/crates/views/src/screens/settings.rs
@@ -656,6 +656,8 @@ impl SettingsView {
     }
 
     fn team(&self, cx: &Context<Self>) -> impl IntoElement {
+        let theme = *cx.theme();
+
         InfoCard::new(t!("settings-team")).flex_none().child(
             div()
                 .flex()


### PR DESCRIPTION
## Summary

- restore the theme binding the team card still reads, which currently fails to build