### PR TITLE
feat(state): remember shuffle, repeat and the queue panel

### DIFF
--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -86,7 +86,7 @@ pub fn init(cx: &mut App, io: Io) {
     let settings = cx.new(|_| AppSettings::load());
     let session = cx.new(|_| Session::new(AuthConfig::from_env(), io.clone()));
     let library = cx.new(|cx| Library::new(session.clone(), io, cx));
-    let queue = cx.new(|_| Queue::new());
+    let queue = cx.new(|cx| Queue::new(settings.clone(), cx));
     let playback = cx.new(|cx| Playback::new(session.clone(), queue.clone(), settings.clone(), cx));
 
     cx.set_global(Sonora {

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -13,6 +13,8 @@ use spotify::{SpotifyApi, Track};
 type Fetch = Pin<Box<dyn Future<Output = Result<Vec<Track>>> + Send>>;
 
 use crate::queue::Queue;
+use serde::{Deserialize, Serialize};
+
 use crate::{AppSettings, Io, Session, SessionEvent, join};
 
 const POSITION_INTERVAL: Duration = Duration::from_millis(500);
@@ -41,7 +43,8 @@ pub enum PlaybackEvent {
     EndedPlayback,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Repeat {
     #[default]
     Off,
@@ -98,6 +101,7 @@ impl Playback {
 
         let level = settings.read(cx).volume();
         let normalisation = settings.read(cx).normalisation();
+        let repeat = settings.read(cx).repeat();
 
         Self {
             state: PlaybackState::Idle,
@@ -110,7 +114,7 @@ impl Playback {
             settings,
             level,
             normalisation,
-            repeat: Repeat::Off,
+            repeat,
             radio: false,
             task: None,
             load: None,
@@ -353,6 +357,9 @@ impl Playback {
             Repeat::All => Repeat::One,
             Repeat::One => Repeat::Off,
         };
+        let repeat = self.repeat;
+        self.settings
+            .update(cx, |settings, cx| settings.set_repeat(repeat, cx));
         cx.notify();
     }
 

--- a/crates/state/src/queue.rs
+++ b/crates/state/src/queue.rs
@@ -2,8 +2,10 @@
 
 use std::collections::{HashMap, VecDeque};
 
-use gpui::Context;
+use gpui::{Context, Entity};
 use spotify::Track;
+
+use crate::AppSettings;
 
 fn scramble(upcoming: &mut VecDeque<Track>) {
     let mut tracks: Vec<Track> = upcoming.drain(..).collect();
@@ -98,23 +100,21 @@ pub struct Queue {
     source: Vec<Track>,
     shuffle: bool,
     revision: u64,
-}
-
-impl Default for Queue {
-    fn default() -> Self {
-        Self::new()
-    }
+    settings: Entity<AppSettings>,
 }
 
 impl Queue {
-    pub fn new() -> Self {
+    pub fn new(settings: Entity<AppSettings>, cx: &mut Context<Self>) -> Self {
+        let shuffle = settings.read(cx).shuffle();
+
         Self {
             past: Vec::new(),
             current: None,
             upcoming: VecDeque::new(),
             source: Vec::new(),
-            shuffle: false,
+            shuffle,
             revision: 0,
+            settings,
         }
     }
 
@@ -127,6 +127,8 @@ impl Queue {
             return;
         }
         self.shuffle = on;
+        self.settings
+            .update(cx, |settings, cx| settings.set_shuffle(on, cx));
         match on {
             true => scramble(&mut self.upcoming),
             false => restore(&mut self.upcoming, &self.source),

--- a/crates/state/src/settings.rs
+++ b/crates/state/src/settings.rs
@@ -9,6 +9,8 @@ use gpui::{Context, Task};
 use serde::{Deserialize, Serialize};
 use ui::{Layout, Look, Mode, Rounding, Sorting, ThemeKind, ThemeOverrides};
 
+use crate::Repeat;
+
 const SAVE_DELAY: Duration = Duration::from_millis(300);
 const DEFAULT_VOLUME: f32 = 0.7;
 const DEFAULT_SIDEBAR_WIDTH: f32 = 220.;
@@ -24,6 +26,9 @@ struct Values {
     sidebar_width: f32,
     sidebar_open: bool,
     sidebar_right_width: f32,
+    queue_open: bool,
+    shuffle: bool,
+    repeat: Repeat,
     language: String,
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     hidden_columns: HashMap<String, Vec<String>>,
@@ -55,6 +60,9 @@ impl Default for Values {
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
             sidebar_open: true,
             sidebar_right_width: DEFAULT_SIDEBAR_RIGHT_WIDTH,
+            queue_open: false,
+            shuffle: false,
+            repeat: Repeat::Off,
             language: i18n::AUTO.to_owned(),
             hidden_columns: HashMap::new(),
             tables: HashMap::new(),
@@ -138,6 +146,18 @@ impl AppSettings {
 
     pub fn sidebar_right_width(&self) -> f32 {
         self.values.sidebar_right_width
+    }
+
+    pub fn queue_open(&self) -> bool {
+        self.values.queue_open
+    }
+
+    pub fn shuffle(&self) -> bool {
+        self.values.shuffle
+    }
+
+    pub fn repeat(&self) -> Repeat {
+        self.values.repeat
     }
 
     pub fn language(&self) -> &str {
@@ -249,6 +269,21 @@ impl AppSettings {
 
     pub fn set_sidebar_right_width(&mut self, width: f32, cx: &mut Context<Self>) {
         self.values.sidebar_right_width = width;
+        self.schedule_save(cx);
+    }
+
+    pub fn set_queue_open(&mut self, open: bool, cx: &mut Context<Self>) {
+        self.values.queue_open = open;
+        self.schedule_save(cx);
+    }
+
+    pub fn set_shuffle(&mut self, shuffle: bool, cx: &mut Context<Self>) {
+        self.values.shuffle = shuffle;
+        self.schedule_save(cx);
+    }
+
+    pub fn set_repeat(&mut self, repeat: Repeat, cx: &mut Context<Self>) {
+        self.values.repeat = repeat;
         self.schedule_save(cx);
     }
 

--- a/crates/views/src/chrome/sidebar_right.rs
+++ b/crates/views/src/chrome/sidebar_right.rs
@@ -223,6 +223,7 @@ impl SidebarRight {
         });
         let settings = Sonora::global(cx).settings.clone();
         let width = px(settings.read(cx).sidebar_right_width()).clamp(MIN_WIDTH, MAX_WIDTH);
+        let open = settings.read(cx).queue_open();
 
         Self {
             queue,
@@ -235,8 +236,8 @@ impl SidebarRight {
             settings,
             width,
             past_len: 0,
-            anchor: false,
-            open: false,
+            anchor: open,
+            open,
         }
     }
 
@@ -266,6 +267,7 @@ impl SidebarRight {
     pub(crate) fn toggle(&mut self, cx: &mut Context<Self>) {
         self.open = !self.open;
         self.anchor = self.open;
+        self.remember(cx);
         cx.notify();
     }
 
@@ -273,7 +275,14 @@ impl SidebarRight {
         self.track_menu.reset();
         self.context_menu = None;
         self.open = false;
+        self.remember(cx);
         cx.notify();
+    }
+
+    fn remember(&self, cx: &mut Context<Self>) {
+        let open = self.open;
+        self.settings
+            .update(cx, |settings, cx| settings.set_queue_open(open, cx));
     }
 
     fn dismiss_menu(&mut self, cx: &mut Context<Self>) {


### PR DESCRIPTION
## Summary

- remember shuffle and repeat between sessions
- remember whether the queue panel was open, and reopen it anchored to the current track