### PR TITLE
release 0.4.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,7 +302,7 @@ Two modules own the measurement:
 use crate::chrome::Chrome;
 Chrome::content(window, cx)   // viewport width − both sidebars, floored at ui::MIN_CONTENT
 Chrome::room(window, cx)      // the same, classified into a Room
-Chrome::sidebar_left(cx) / Chrome::sidebar_right(cx)   // one panel's cut, for the other panel
+chrome::cap(min, max, window) // a panel's ceiling: never eat ui::MIN_CONTENT
 ```
 
 `Chrome::room` is how a view classifies its width: never rebuild `Room::of(…)` from a width you
@@ -314,16 +314,23 @@ Rules:
   ignores both side panels, so tables overflow under the right sidebar and grids pick a column count
   that does not fit. Raw viewport width is legitimate in exactly two places: chrome that spans the
   whole window (`PlayerBar`, `TitleBar`, and `Menu`'s submenu flip), and a side panel deciding *its
-  own* size — `SidebarLeft` measures the room left over once its own width is taken, `SidebarRight`
-  subtracts `Chrome::sidebar_left`. `Chrome::content` would be circular for either, because each is
-  a term in it; reading the *other* panel's cut is not.
+  own* size. `Chrome::content` would be circular for a panel, because the panel is a term in it.
+- **One panel never sets another's width.** Each clamps itself against the viewport through
+  `chrome::cap`, so neither can squeeze content below `ui::MIN_CONTENT` on its own, and neither
+  panel's size is ever a function of the other's.
+- **Hiding is a different question from sizing, and it does look at both panels.** `SidebarLeft`
+  auto-hides once the room left for content — viewport minus its own width *and*
+  `Chrome::sidebar_right` — drops below `Room::Wide`, so opening the queue pushes it out of the way
+  without resizing it. It reads last frame's publish, which cannot loop: the decision changes
+  visibility, never width. `SidebarRight` decides its own takeover from the viewport alone.
+- **A panel's width changes only when the user drags it.** `chrome::cap` feeds `Panel::reach`, which
+  bounds the *drag*, not the render — narrowing the window must never silently shrink a panel the
+  user sized. `Panel::limits` stays the static floor and ceiling.
 - `Workspace::render` publishes the widths every frame via `Chrome::publish`; it notifies only when
   a width actually changed, so it cannot loop.
 - **`Chrome` is only current after that publish.** `Workspace` renders *before* it and owns both
   panels, so it reads them directly; everything it renders into — content views and both panels —
-  sees this frame's values. `SidebarRight` is the one exception: it reads `Chrome::sidebar_left`
-  while `Workspace` is still assembling this frame's publish, so a left-panel change reaches it one
-  frame late, and its `Chrome` observation repaints it on the next.
+  sees this frame's values.
 - **A view whose layout depends on width must observe the chrome**, or it will not repaint when a
   panel is resized or toggled:
   ```rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "audio"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "cpal",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "i18n"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "fluent-bundle",
  "gpui",
@@ -3303,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "input"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "gpui",
  "ui",
@@ -5806,7 +5806,7 @@ dependencies = [
 
 [[package]]
 name = "router"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "gpui",
  "ui",
@@ -6496,7 +6496,7 @@ dependencies = [
 
 [[package]]
 name = "sonora"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -6562,7 +6562,7 @@ dependencies = [
 
 [[package]]
 name = "spotify"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6621,7 +6621,7 @@ dependencies = [
 
 [[package]]
 name = "state"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "audio",
@@ -7565,7 +7565,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "gpui",
  "i18n",
@@ -7868,7 +7868,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "views"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "gpui",
  "i18n",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/nolight132/sonora"

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -261,8 +261,8 @@ settings-source-detail = The corresponding source for this build
 settings-source-view = Open the repository
 settings-team = Team
 settings-team-github = GitHub
+settings-role-lead-maintainer = Lead Maintainer
 settings-role-maintainer = Maintainer
-settings-role-developer = Developer
 settings-role-contributor = Contributor
 settings-notice = Copyright © 2026 nolight132. Sonora comes with absolutely no warranty. It is free software, and you are welcome to redistribute it under the terms of the GNU General Public License version 3 or later. Sonora is unofficial and is not affiliated with Spotify AB.
 

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -46,6 +46,7 @@ menu-no-playlists = No playlists
 menu-add-to-library = Add to Library
 menu-remove-from-library = Remove from Library
 menu-remove-from-playlist = Remove from playlist
+menu-play-next = Play next
 menu-add-to-queue = Add to queue
 menu-song-radio = Go to song radio
 menu-go-to-album = Go to album

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -263,8 +263,8 @@ settings-source-detail = Kod źródłowy odpowiadający temu wydaniu
 settings-source-view = Otwórz repozytorium
 settings-team = Zespół
 settings-team-github = GitHub
+settings-role-lead-maintainer = Główny opiekun
 settings-role-maintainer = Opiekun
-settings-role-developer = Programista
 settings-role-contributor = Współtwórca
 settings-notice = Copyright © 2026 nolight132. Sonora jest dostarczana bez żadnej gwarancji. To wolne oprogramowanie, które możesz rozpowszechniać na warunkach GNU General Public License w wersji 3 lub nowszej. Sonora jest nieoficjalnym klientem i nie jest powiązana ze Spotify AB.
 

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -46,6 +46,7 @@ menu-no-playlists = Brak playlist
 menu-add-to-library = Dodaj do biblioteki
 menu-remove-from-library = Usuń z biblioteki
 menu-remove-from-playlist = Usuń z playlisty
+menu-play-next = Odtwórz jako następny
 menu-add-to-queue = Dodaj do kolejki
 menu-song-radio = Radio utworu
 menu-go-to-album = Przejdź do albumu

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -46,6 +46,7 @@ menu-no-playlists = Нет плейлистов
 menu-add-to-library = Добавить в медиатеку
 menu-remove-from-library = Удалить из медиатеки
 menu-remove-from-playlist = Удалить из плейлиста
+menu-play-next = Воспроизвести следующим
 menu-add-to-queue = Добавить в очередь
 menu-song-radio = Радио по треку
 menu-go-to-album = Перейти к альбому

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -263,8 +263,8 @@ settings-source-detail = Исходный код, соответствующий
 settings-source-view = Открыть репозиторий
 settings-team = Команда
 settings-team-github = GitHub
+settings-role-lead-maintainer = Ведущий сопровождающий
 settings-role-maintainer = Сопровождающий
-settings-role-developer = Разработчик
 settings-role-contributor = Участник
 settings-notice = Copyright © 2026 nolight132. Sonora поставляется без каких-либо гарантий. Это свободное программное обеспечение, и вы можете распространять его на условиях GNU General Public License версии 3 или новее. Sonora — неофициальный клиент и не связан со Spotify AB.
 

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -46,6 +46,7 @@ menu-no-playlists = Немає плейлистів
 menu-add-to-library = Додати до медіатеки
 menu-remove-from-library = Вилучити з медіатеки
 menu-remove-from-playlist = Вилучити з плейлиста
+menu-play-next = Відтворити наступним
 menu-add-to-queue = Додати до черги
 menu-song-radio = Радіо за треком
 menu-go-to-album = Перейти до альбому

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -263,8 +263,8 @@ settings-source-detail = Початковий код, що відповідає 
 settings-source-view = Відкрити репозиторій
 settings-team = Команда
 settings-team-github = GitHub
+settings-role-lead-maintainer = Провідний супровідник
 settings-role-maintainer = Супровідник
-settings-role-developer = Розробник
 settings-role-contributor = Учасник
 settings-notice = Copyright © 2026 nolight132. Sonora постачається без жодних гарантій. Це вільне програмне забезпечення, і ви можете поширювати його на умовах GNU General Public License версії 3 або новішої. Sonora — неофіційний клієнт і не пов'язаний зі Spotify AB.
 

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -86,7 +86,7 @@ pub fn init(cx: &mut App, io: Io) {
     let settings = cx.new(|_| AppSettings::load());
     let session = cx.new(|_| Session::new(AuthConfig::from_env(), io.clone()));
     let library = cx.new(|cx| Library::new(session.clone(), io, cx));
-    let queue = cx.new(|_| Queue::new());
+    let queue = cx.new(|cx| Queue::new(settings.clone(), cx));
     let playback = cx.new(|cx| Playback::new(session.clone(), queue.clone(), settings.clone(), cx));
 
     cx.set_global(Sonora {

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -13,6 +13,8 @@ use spotify::{SpotifyApi, Track};
 type Fetch = Pin<Box<dyn Future<Output = Result<Vec<Track>>> + Send>>;
 
 use crate::queue::Queue;
+use serde::{Deserialize, Serialize};
+
 use crate::{AppSettings, Io, Session, SessionEvent, join};
 
 const POSITION_INTERVAL: Duration = Duration::from_millis(500);
@@ -41,7 +43,8 @@ pub enum PlaybackEvent {
     EndedPlayback,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Repeat {
     #[default]
     Off,
@@ -98,6 +101,7 @@ impl Playback {
 
         let level = settings.read(cx).volume();
         let normalisation = settings.read(cx).normalisation();
+        let repeat = settings.read(cx).repeat();
 
         Self {
             state: PlaybackState::Idle,
@@ -110,7 +114,7 @@ impl Playback {
             settings,
             level,
             normalisation,
-            repeat: Repeat::Off,
+            repeat,
             radio: false,
             task: None,
             load: None,
@@ -353,6 +357,9 @@ impl Playback {
             Repeat::All => Repeat::One,
             Repeat::One => Repeat::Off,
         };
+        let repeat = self.repeat;
+        self.settings
+            .update(cx, |settings, cx| settings.set_repeat(repeat, cx));
         cx.notify();
     }
 

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -12,6 +12,12 @@ use spotify::{SpotifyApi, Track};
 
 type Fetch = Pin<Box<dyn Future<Output = Result<Vec<Track>>> + Send>>;
 
+#[derive(Clone, Copy)]
+enum QueuePlacement {
+    Next,
+    End,
+}
+
 use crate::queue::Queue;
 use serde::{Deserialize, Serialize};
 
@@ -211,10 +217,30 @@ impl Playback {
             self.begin(vec![track], 0, None, cx);
             return;
         }
+        self.queue.update(cx, |queue, cx| queue.append(track, cx));
+    }
+
+    pub fn play_next(&mut self, track: Track, cx: &mut Context<Self>) {
+        if self.queue.read(cx).current().is_none() {
+            self.begin(vec![track], 0, None, cx);
+            return;
+        }
         self.queue.update(cx, |queue, cx| queue.prepend(track, cx));
     }
 
     pub fn enqueue_all(&mut self, tracks: Vec<Track>, cx: &mut Context<Self>) {
+        if tracks.is_empty() {
+            return;
+        }
+        if self.queue.read(cx).current().is_none() {
+            self.begin(tracks, 0, None, cx);
+            return;
+        }
+        self.queue
+            .update(cx, |queue, cx| queue.append_all(tracks, cx));
+    }
+
+    pub fn play_next_all(&mut self, tracks: Vec<Track>, cx: &mut Context<Self>) {
         if tracks.is_empty() {
             return;
         }
@@ -228,7 +254,14 @@ impl Playback {
 
     pub fn enqueue_album(&mut self, album: &str, cx: &mut Context<Self>) {
         let album = album.to_owned();
-        self.enqueue_from("album", cx, move |client| {
+        self.enqueue_from("album", QueuePlacement::End, cx, move |client| {
+            Box::pin(async move { client.album_tracks(&album).await })
+        });
+    }
+
+    pub fn play_album_next(&mut self, album: &str, cx: &mut Context<Self>) {
+        let album = album.to_owned();
+        self.enqueue_from("album", QueuePlacement::Next, cx, move |client| {
             Box::pin(async move { client.album_tracks(&album).await })
         });
     }
@@ -243,7 +276,14 @@ impl Playback {
 
     pub fn enqueue_playlist(&mut self, playlist: &str, cx: &mut Context<Self>) {
         let playlist = playlist.to_owned();
-        self.enqueue_from("playlist", cx, move |client| {
+        self.enqueue_from("playlist", QueuePlacement::End, cx, move |client| {
+            Box::pin(async move { client.playlist_tracks(&playlist).await })
+        });
+    }
+
+    pub fn play_playlist_next(&mut self, playlist: &str, cx: &mut Context<Self>) {
+        let playlist = playlist.to_owned();
+        self.enqueue_from("playlist", QueuePlacement::Next, cx, move |client| {
             Box::pin(async move { client.playlist_tracks(&playlist).await })
         });
     }
@@ -256,8 +296,13 @@ impl Playback {
         });
     }
 
-    fn enqueue_from<F>(&mut self, source: &'static str, cx: &mut Context<Self>, tracks: F)
-    where
+    fn enqueue_from<F>(
+        &mut self,
+        source: &'static str,
+        placement: QueuePlacement,
+        cx: &mut Context<Self>,
+        tracks: F,
+    ) where
         F: FnOnce(Arc<dyn SpotifyApi>) -> Fetch + Send + 'static,
     {
         if self.enqueue.is_some() {
@@ -272,7 +317,10 @@ impl Playback {
             this.update(cx, |this, cx| {
                 this.enqueue = None;
                 match loaded {
-                    Ok(tracks) => this.enqueue_all(tracks, cx),
+                    Ok(tracks) => match placement {
+                        QueuePlacement::Next => this.play_next_all(tracks, cx),
+                        QueuePlacement::End => this.enqueue_all(tracks, cx),
+                    },
                     Err(error) => log::error!("playback: cannot enqueue {source}: {error:#}"),
                 }
             })

--- a/crates/state/src/queue.rs
+++ b/crates/state/src/queue.rs
@@ -2,8 +2,10 @@
 
 use std::collections::{HashMap, VecDeque};
 
-use gpui::Context;
+use gpui::{Context, Entity};
 use spotify::Track;
+
+use crate::AppSettings;
 
 fn scramble(upcoming: &mut VecDeque<Track>) {
     let mut tracks: Vec<Track> = upcoming.drain(..).collect();
@@ -98,23 +100,21 @@ pub struct Queue {
     source: Vec<Track>,
     shuffle: bool,
     revision: u64,
-}
-
-impl Default for Queue {
-    fn default() -> Self {
-        Self::new()
-    }
+    settings: Entity<AppSettings>,
 }
 
 impl Queue {
-    pub fn new() -> Self {
+    pub fn new(settings: Entity<AppSettings>, cx: &mut Context<Self>) -> Self {
+        let shuffle = settings.read(cx).shuffle();
+
         Self {
             past: Vec::new(),
             current: None,
             upcoming: VecDeque::new(),
             source: Vec::new(),
-            shuffle: false,
+            shuffle,
             revision: 0,
+            settings,
         }
     }
 
@@ -127,6 +127,8 @@ impl Queue {
             return;
         }
         self.shuffle = on;
+        self.settings
+            .update(cx, |settings, cx| settings.set_shuffle(on, cx));
         match on {
             true => scramble(&mut self.upcoming),
             false => restore(&mut self.upcoming, &self.source),

--- a/crates/state/src/settings.rs
+++ b/crates/state/src/settings.rs
@@ -9,6 +9,8 @@ use gpui::{Context, Task};
 use serde::{Deserialize, Serialize};
 use ui::{Layout, Look, Mode, Rounding, Sorting, ThemeKind, ThemeOverrides};
 
+use crate::Repeat;
+
 const SAVE_DELAY: Duration = Duration::from_millis(300);
 const DEFAULT_VOLUME: f32 = 0.7;
 const DEFAULT_SIDEBAR_WIDTH: f32 = 220.;
@@ -24,6 +26,9 @@ struct Values {
     sidebar_width: f32,
     sidebar_open: bool,
     sidebar_right_width: f32,
+    queue_open: bool,
+    shuffle: bool,
+    repeat: Repeat,
     language: String,
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     hidden_columns: HashMap<String, Vec<String>>,
@@ -55,6 +60,9 @@ impl Default for Values {
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
             sidebar_open: true,
             sidebar_right_width: DEFAULT_SIDEBAR_RIGHT_WIDTH,
+            queue_open: false,
+            shuffle: false,
+            repeat: Repeat::Off,
             language: i18n::AUTO.to_owned(),
             hidden_columns: HashMap::new(),
             tables: HashMap::new(),
@@ -138,6 +146,18 @@ impl AppSettings {
 
     pub fn sidebar_right_width(&self) -> f32 {
         self.values.sidebar_right_width
+    }
+
+    pub fn queue_open(&self) -> bool {
+        self.values.queue_open
+    }
+
+    pub fn shuffle(&self) -> bool {
+        self.values.shuffle
+    }
+
+    pub fn repeat(&self) -> Repeat {
+        self.values.repeat
     }
 
     pub fn language(&self) -> &str {
@@ -249,6 +269,21 @@ impl AppSettings {
 
     pub fn set_sidebar_right_width(&mut self, width: f32, cx: &mut Context<Self>) {
         self.values.sidebar_right_width = width;
+        self.schedule_save(cx);
+    }
+
+    pub fn set_queue_open(&mut self, open: bool, cx: &mut Context<Self>) {
+        self.values.queue_open = open;
+        self.schedule_save(cx);
+    }
+
+    pub fn set_shuffle(&mut self, shuffle: bool, cx: &mut Context<Self>) {
+        self.values.shuffle = shuffle;
+        self.schedule_save(cx);
+    }
+
+    pub fn set_repeat(&mut self, repeat: Repeat, cx: &mut Context<Self>) {
+        self.values.repeat = repeat;
         self.schedule_save(cx);
     }
 

--- a/crates/ui/src/button.rs
+++ b/crates/ui/src/button.rs
@@ -256,7 +256,9 @@ impl RenderOnce for Button {
                         .text_color(tint.unwrap_or(palette.foreground)),
                 )
             })
-            .when_some(label, |this, label| this.child(label))
+            .when_some(label, |this, label| {
+                this.child(div().min_w_0().truncate().child(label))
+            })
             .when(interactive, |this| {
                 this.when_some(on_click, |this, handler| {
                     this.on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())

--- a/crates/ui/src/panel.rs
+++ b/crates/ui/src/panel.rs
@@ -22,6 +22,7 @@ pub enum Side {
 }
 
 struct Grab {
+    panel: ElementId,
     width: Pixels,
     origin: Cell<Pixels>,
 }
@@ -29,10 +30,12 @@ struct Grab {
 #[derive(IntoElement)]
 pub struct Panel {
     base: Stateful<Div>,
+    key: ElementId,
     side: Side,
     width: Pixels,
     min: Pixels,
     max: Pixels,
+    reach: Option<Pixels>,
     fill: bool,
     resize: Option<Resize>,
     children: Vec<AnyElement>,
@@ -41,12 +44,15 @@ pub struct Panel {
 impl Panel {
     #[track_caller]
     pub fn new(id: impl Into<ElementId>, side: Side, width: Pixels) -> Self {
+        let key: ElementId = id.into();
         Self {
-            base: div().id(id),
+            base: div().id(key.clone()),
+            key,
             side,
             width,
             min: Pixels::ZERO,
             max: Pixels::MAX,
+            reach: None,
             fill: false,
             resize: None,
             children: Vec::new(),
@@ -56,6 +62,11 @@ impl Panel {
     pub fn limits(mut self, min: Pixels, max: Pixels) -> Self {
         self.min = min;
         self.max = max;
+        self
+    }
+
+    pub fn reach(mut self, reach: Pixels) -> Self {
+        self.reach = Some(reach);
         self
     }
 
@@ -94,10 +105,12 @@ impl RenderOnce for Panel {
     fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
         let Self {
             mut base,
+            key,
             side,
             width,
             min,
             max,
+            reach,
             fill,
             resize,
             children,
@@ -107,7 +120,7 @@ impl RenderOnce for Panel {
         let handle = (!fill)
             .then_some(resize)
             .flatten()
-            .map(|resize| grip(side, width, min, max, resize));
+            .map(|resize| grip(key, side, width, min, reach.unwrap_or(max), resize));
 
         let mut panel = base
             .relative()
@@ -128,7 +141,16 @@ impl RenderOnce for Panel {
     }
 }
 
-fn grip(side: Side, width: Pixels, min: Pixels, max: Pixels, resize: Resize) -> impl IntoElement {
+fn grip(
+    key: ElementId,
+    side: Side,
+    width: Pixels,
+    min: Pixels,
+    max: Pixels,
+    resize: Resize,
+) -> impl IntoElement {
+    let dragged = key.clone();
+
     div()
         .id("panel-grip")
         .absolute()
@@ -142,6 +164,9 @@ fn grip(side: Side, width: Pixels, min: Pixels, max: Pixels, resize: Resize) -> 
         })
         .on_drag_move(move |event: &DragMoveEvent<Grab>, window, cx| {
             let grab = event.drag(cx);
+            if grab.panel != dragged {
+                return;
+            }
             let (start, origin) = (grab.width, grab.origin.get());
             let travel = event.event.position.x - origin;
             let dragged = match side {
@@ -153,6 +178,7 @@ fn grip(side: Side, width: Pixels, min: Pixels, max: Pixels, resize: Resize) -> 
         })
         .on_drag(
             Grab {
+                panel: key,
                 width,
                 origin: Cell::new(Pixels::ZERO),
             },

--- a/crates/views/src/chrome/mod.rs
+++ b/crates/views/src/chrome/mod.rs
@@ -18,6 +18,11 @@ pub(crate) use toolbar::{Searchable, Toolbar, Tooled};
 use gpui::{App, AppContext as _, Entity, Global, Pixels, Window};
 use ui::{MIN_CONTENT, Room};
 
+pub(crate) fn cap(min: Pixels, max: Pixels, keep: Pixels, window: &Window) -> Pixels {
+    let room = window.viewport_size().width - keep;
+    max.min(room.max(min))
+}
+
 #[derive(Clone, Copy, Default, PartialEq)]
 pub(crate) struct Chrome {
     sidebar_left: Pixels,
@@ -57,11 +62,6 @@ impl Chrome {
             .unwrap_or_default()
     }
 
-    pub fn sidebar_left(cx: &App) -> Pixels {
-        Self::get(cx).sidebar_left
-    }
-
-    #[allow(dead_code)]
     pub fn sidebar_right(cx: &App) -> Pixels {
         Self::get(cx).sidebar_right
     }

--- a/crates/views/src/chrome/sidebar_left.rs
+++ b/crates/views/src/chrome/sidebar_left.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use ui::{ActiveTheme as _, Button, Panel, Room, Shield, Side};
+use ui::{ActiveTheme as _, Button, MIN_CONTENT, Panel, SNUG, Shield, Side};
 
 use gpui::prelude::*;
 use gpui::{
@@ -31,7 +31,7 @@ const TABS: [(&str, LibraryTab); 3] = [
     ("nav-playlists", LibraryTab::Playlists),
 ];
 
-const MIN_WIDTH: Pixels = px(130.);
+const MIN_WIDTH: Pixels = px(160.);
 const MAX_WIDTH: Pixels = px(400.);
 
 pub(crate) struct SidebarLeft {
@@ -39,6 +39,7 @@ pub(crate) struct SidebarLeft {
     trail: Entity<Navigation>,
     width: Pixels,
     open: bool,
+    fit: bool,
     cramped: bool,
     forced: Option<bool>,
     library_open: bool,
@@ -60,6 +61,7 @@ impl SidebarLeft {
             trail,
             width,
             open,
+            fit: open,
             forced: None,
             cramped: false,
             library_open: true,
@@ -97,15 +99,34 @@ impl SidebarLeft {
                 self.persist(cx);
             }
         }
+        self.fit = self.is_open();
         cx.notify();
+    }
+
+    fn keep(&self, cx: &Context<Self>) -> Pixels {
+        match self.settings.read(cx).auto_hide_sidebar() {
+            true => SNUG,
+            false => MIN_CONTENT,
+        }
+    }
+
+    fn ceiling(&self, window: &Window, cx: &Context<Self>) -> Pixels {
+        let reserved = self.keep(cx) + super::Chrome::sidebar_right(cx);
+        super::cap(MIN_WIDTH, MAX_WIDTH, reserved, window)
     }
 
     pub fn adapt(&mut self, window: &Window, cx: &mut Context<Self>) {
         self.width = ui::snapped(self.width, window);
 
+        if std::mem::take(&mut self.fit) {
+            self.width = self.width.min(self.ceiling(window, cx));
+            self.persist(cx);
+        }
+
         let auto_hide = self.settings.read(cx).auto_hide_sidebar();
-        let space_left = window.viewport_size().width - self.width;
-        let cramped = auto_hide && !Room::of(space_left).fits(Room::Wide);
+        let taken = self.width + super::Chrome::sidebar_right(cx);
+        let space_left = window.viewport_size().width - taken;
+        let cramped = auto_hide && space_left < self.keep(cx);
         if cramped != self.cramped {
             self.cramped = cramped;
             self.forced = None;
@@ -225,6 +246,7 @@ impl Render for SidebarLeft {
         let overlaid = self.overlays();
         let panel = Panel::new("sidebar-left", Side::Left, self.width)
             .limits(MIN_WIDTH, MAX_WIDTH)
+            .reach(self.ceiling(window, cx))
             .on_resize(cx.listener(|this, width: &Pixels, _, cx| {
                 this.width = *width;
                 this.persist(cx);

--- a/crates/views/src/chrome/sidebar_right.rs
+++ b/crates/views/src/chrome/sidebar_right.rs
@@ -223,6 +223,7 @@ impl SidebarRight {
         });
         let settings = Sonora::global(cx).settings.clone();
         let width = px(settings.read(cx).sidebar_right_width()).clamp(MIN_WIDTH, MAX_WIDTH);
+        let open = settings.read(cx).queue_open();
 
         Self {
             queue,
@@ -235,8 +236,8 @@ impl SidebarRight {
             settings,
             width,
             past_len: 0,
-            anchor: false,
-            open: false,
+            anchor: open,
+            open,
         }
     }
 
@@ -266,6 +267,7 @@ impl SidebarRight {
     pub(crate) fn toggle(&mut self, cx: &mut Context<Self>) {
         self.open = !self.open;
         self.anchor = self.open;
+        self.remember(cx);
         cx.notify();
     }
 
@@ -273,7 +275,14 @@ impl SidebarRight {
         self.track_menu.reset();
         self.context_menu = None;
         self.open = false;
+        self.remember(cx);
         cx.notify();
+    }
+
+    fn remember(&self, cx: &mut Context<Self>) {
+        let open = self.open;
+        self.settings
+            .update(cx, |settings, cx| settings.set_queue_open(open, cx));
     }
 
     fn dismiss_menu(&mut self, cx: &mut Context<Self>) {

--- a/crates/views/src/chrome/sidebar_right.rs
+++ b/crates/views/src/chrome/sidebar_right.rs
@@ -13,7 +13,8 @@ use i18n::t;
 use spotify::Track;
 use state::{AppSettings, Playback, Queue, Sonora};
 use ui::{
-    ActiveTheme as _, Button, Card, Panel, Popup, Room, Scrollbar, Side, Text, eyebrow, snapped,
+    ActiveTheme as _, Button, Card, MIN_CONTENT, Panel, Popup, Room, Scrollbar, Side, Text,
+    eyebrow, snapped,
 };
 
 use crate::chrome::Chrome;
@@ -243,17 +244,14 @@ impl SidebarRight {
         self.open
     }
 
-    pub(crate) fn covers_content(&self, window: &Window, cx: &App) -> bool {
-        let content = window.viewport_size().width - Chrome::sidebar_left(cx);
-        self.open && fills_content(content)
+    pub(crate) fn covers_content(&self, window: &Window) -> bool {
+        self.open && fills_content(window.viewport_size().width)
     }
 
-    pub(crate) fn occupied_width(&self, window: &Window, cx: &App) -> Pixels {
+    pub(crate) fn occupied_width(&self, window: &Window) -> Pixels {
         match self.open {
             false => Pixels::ZERO,
-            true if self.covers_content(window, cx) => {
-                window.viewport_size().width - Chrome::sidebar_left(cx)
-            }
+            true if self.covers_content(window) => window.viewport_size().width,
             true => self.width,
         }
     }
@@ -570,8 +568,7 @@ impl Render for SidebarRight {
         }
 
         let theme = *cx.theme();
-        let content_width = window.viewport_size().width - Chrome::sidebar_left(cx);
-        let fullscreen = fills_content(content_width);
+        let fullscreen = fills_content(window.viewport_size().width);
         let queue = self.queue.read(cx);
         let sections = Sections {
             past: queue.past().len(),
@@ -593,6 +590,7 @@ impl Render for SidebarRight {
 
         Panel::new("sidebar-right", Side::Right, self.width)
             .limits(MIN_WIDTH, MAX_WIDTH)
+            .reach(super::cap(MIN_WIDTH, MAX_WIDTH, MIN_CONTENT, window))
             .fill(fullscreen)
             .on_resize(cx.listener(|this, width: &Pixels, _, cx| {
                 this.width = *width;

--- a/crates/views/src/screens/settings.rs
+++ b/crates/views/src/screens/settings.rs
@@ -656,6 +656,8 @@ impl SettingsView {
     }
 
     fn team(&self, cx: &Context<Self>) -> impl IntoElement {
+        let theme = *cx.theme();
+
         InfoCard::new(t!("settings-team")).flex_none().child(
             div()
                 .flex()

--- a/crates/views/src/screens/settings.rs
+++ b/crates/views/src/screens/settings.rs
@@ -51,7 +51,7 @@ impl Role {
 macro_rules! member {
     ($login:literal, $role:expr) => {
         Member {
-            login: concat!("@", $login),
+            login: $login,
             avatar: concat!("https://github.com/", $login, ".png"),
             profile: concat!("https://github.com/", $login),
             role: $role,
@@ -656,14 +656,11 @@ impl SettingsView {
     }
 
     fn team(&self, cx: &Context<Self>) -> impl IntoElement {
-        let theme = *cx.theme();
-
-        InfoCard::new(t!("settings-team")).child(
+        InfoCard::new(t!("settings-team")).flex_none().child(
             div()
                 .flex()
                 .flex_col()
                 .gap_3()
-                .pb(theme.metrics.pad)
                 .children(MEMBERS.into_iter().enumerate().map(|(index, member)| {
                     div()
                         .id(("team-member", index))

--- a/crates/views/src/screens/settings.rs
+++ b/crates/views/src/screens/settings.rs
@@ -33,16 +33,16 @@ struct Member {
 
 #[derive(Clone, Copy)]
 enum Role {
+    LeadMaintainer,
     Maintainer,
-    Developer,
     Contributor,
 }
 
 impl Role {
     fn label(self) -> SharedString {
         match self {
+            Self::LeadMaintainer => t!("settings-role-lead-maintainer"),
             Self::Maintainer => t!("settings-role-maintainer"),
-            Self::Developer => t!("settings-role-developer"),
             Self::Contributor => t!("settings-role-contributor"),
         }
     }
@@ -60,9 +60,9 @@ macro_rules! member {
 }
 
 const MEMBERS: [Member; 5] = [
-    member!("nolight132", Role::Maintainer),
-    member!("zxsleebu", Role::Developer),
-    member!("fx-got", Role::Developer),
+    member!("nolight132", Role::LeadMaintainer),
+    member!("zxsleebu", Role::Maintainer),
+    member!("fx-got", Role::Maintainer),
     member!("Makakashan", Role::Contributor),
     member!("imizgun", Role::Contributor),
 ];
@@ -658,45 +658,50 @@ impl SettingsView {
     fn team(&self, cx: &Context<Self>) -> impl IntoElement {
         let theme = *cx.theme();
 
-        InfoCard::new(t!("settings-team")).child(div().flex().flex_col().gap_3().children(
-            MEMBERS.into_iter().enumerate().map(|(index, member)| {
-                div()
-                    .id(("team-member", index))
-                    .flex()
-                    .items_center()
-                    .gap_3()
-                    .px(theme.metrics.pad)
-                    .py(theme.metrics.pad / 2.)
-                    .rounded(theme.radius)
-                    .cursor_pointer()
-                    .hover(|style| style.bg(theme.secondary_hover))
-                    .on_click(move |_, _, cx| cx.open_url(member.profile))
-                    .child(Avatar::new(Some(member.avatar)).size(theme.metrics.thumb))
-                    .child(
-                        div()
-                            .flex()
-                            .flex_col()
-                            .flex_1()
-                            .min_w_0()
-                            .gap_0p5()
-                            .child(div().font_weight(FontWeight::MEDIUM).child(member.login))
-                            .child(
-                                div()
-                                    .text_size(theme.text(Text::Small))
-                                    .text_color(theme.muted_foreground)
-                                    .child(t!("settings-team-github")),
-                            ),
-                    )
-                    .child(
-                        div()
-                            .flex_none()
-                            .text_size(theme.text(Text::Small))
-                            .font_weight(FontWeight::MEDIUM)
-                            .text_color(theme.muted_foreground)
-                            .child(member.role.label()),
-                    )
-            }),
-        ))
+        InfoCard::new(t!("settings-team")).child(
+            div()
+                .flex()
+                .flex_col()
+                .gap_3()
+                .pb(theme.metrics.pad)
+                .children(MEMBERS.into_iter().enumerate().map(|(index, member)| {
+                    div()
+                        .id(("team-member", index))
+                        .flex()
+                        .items_center()
+                        .gap_3()
+                        .px(theme.metrics.pad)
+                        .py(theme.metrics.pad / 2.)
+                        .rounded(theme.radius)
+                        .cursor_pointer()
+                        .hover(|style| style.bg(theme.secondary_hover))
+                        .on_click(move |_, _, cx| cx.open_url(member.profile))
+                        .child(Avatar::new(Some(member.avatar)).size(theme.metrics.thumb))
+                        .child(
+                            div()
+                                .flex()
+                                .flex_col()
+                                .flex_1()
+                                .min_w_0()
+                                .gap_0p5()
+                                .child(div().font_weight(FontWeight::MEDIUM).child(member.login))
+                                .child(
+                                    div()
+                                        .text_size(theme.text(Text::Small))
+                                        .text_color(theme.muted_foreground)
+                                        .child(t!("settings-team-github")),
+                                ),
+                        )
+                        .child(
+                            div()
+                                .flex_none()
+                                .text_size(theme.text(Text::Small))
+                                .font_weight(FontWeight::MEDIUM)
+                                .text_color(theme.muted_foreground)
+                                .child(member.role.label()),
+                        )
+                })),
+        )
     }
 
     fn row(

--- a/crates/views/src/shared/menu.rs
+++ b/crates/views/src/shared/menu.rs
@@ -118,6 +118,20 @@ impl ItemMenu {
                 .icon("icons/link.svg")
                 .disabled(),
         };
+        let next = match track.playable {
+            true => {
+                let track = track.clone();
+                MenuItem::new("play-next", t!("menu-play-next"))
+                    .icon("icons/list-plus.svg")
+                    .on_click(move |_, _, cx| {
+                        let playback = Sonora::global(cx).playback.clone();
+                        playback.update(cx, |playback, cx| playback.play_next(track.clone(), cx));
+                    })
+            }
+            false => MenuItem::new("play-next", t!("menu-play-next"))
+                .icon("icons/list-plus.svg")
+                .disabled(),
+        };
         let queue = match track.playable {
             true => {
                 let track = track.clone();
@@ -213,6 +227,7 @@ impl ItemMenu {
                     .submenu(playlist_menu, self.playlist_submenu.clone()),
             )
             .item(library_action.unwrap_or(toggle_library))
+            .item(next)
             .item(queue)
             .item(
                 MenuItem::new("song-radio", t!("menu-song-radio"))
@@ -229,8 +244,10 @@ impl ItemMenu {
 pub(crate) fn album_menu(album_id: String, playback: Entity<Playback>, opened_here: bool) -> Menu {
     let opened = album_id.clone();
     let played = album_id.clone();
+    let next = album_id.clone();
     let queued = album_id;
     let playing = playback.clone();
+    let nexting = playback.clone();
     let queueing = playback;
 
     let menu = match opened_here {
@@ -250,6 +267,13 @@ pub(crate) fn album_menu(album_id: String, playback: Entity<Playback>, opened_he
             }),
     )
     .item(
+        MenuItem::new("play-album-next", t!("menu-play-next"))
+            .icon("icons/list-plus.svg")
+            .on_click(move |_, _, cx| {
+                nexting.update(cx, |playback, cx| playback.play_album_next(&next, cx));
+            }),
+    )
+    .item(
         MenuItem::new("enqueue-album", t!("menu-add-album-to-queue"))
             .icon("icons/list-end.svg")
             .on_click(move |_, _, cx| {
@@ -265,8 +289,10 @@ pub(crate) fn playlist_menu(
 ) -> Menu {
     let opened = playlist.id.clone();
     let played = playlist.id.clone();
+    let next = playlist.id.clone();
     let queued = playlist.id.clone();
     let playing = playback.clone();
+    let nexting = playback.clone();
     let queueing = playback;
     let id = playlist.id.clone();
     let public = playlist.public;
@@ -333,6 +359,13 @@ pub(crate) fn playlist_menu(
             .icon("icons/play.svg")
             .on_click(move |_, _, cx| {
                 playing.update(cx, |playback, cx| playback.play_playlist(&played, cx));
+            }),
+    )
+    .item(
+        MenuItem::new("play-playlist-next", t!("menu-play-next"))
+            .icon("icons/list-plus.svg")
+            .on_click(move |_, _, cx| {
+                nexting.update(cx, |playback, cx| playback.play_playlist_next(&next, cx));
             }),
     )
     .item(

--- a/crates/views/src/shells/workspace.rs
+++ b/crates/views/src/shells/workspace.rs
@@ -92,9 +92,9 @@ impl Render for Workspace {
         self.sidebar
             .update(cx, |sidebar, cx| sidebar.adapt(window, cx));
         let left = self.sidebar.read(cx).occupied_width();
-        let right = self.sidebar_right.read(cx).occupied_width(window, cx);
+        let right = self.sidebar_right.read(cx).occupied_width(window);
         Chrome::publish(left, right, cx);
-        let covered = self.sidebar_right.read(cx).covers_content(window, cx);
+        let covered = self.sidebar_right.read(cx).covers_content(window);
         let overlay = self.sidebar.read(cx).overlays();
 
         div()


### PR DESCRIPTION
## Summary

- stop the side panels from resizing each other, and give each panel its own drag
- keep a panel at the width you gave it, bounding the drag instead of the rendered size
- hide the left panel when content runs out of room, without changing its width
- remember shuffle, repeat and whether the queue panel was open
- truncate a button label instead of letting it overflow
- restore the theme binding in the team card