### PR TITLE
refactor(ui): give the hero its own layout and fix card spacing

### DIFF
--- a/crates/ui/src/card.rs
+++ b/crates/ui/src/card.rs
@@ -22,6 +22,7 @@ const BAR_META: (Pixels, Pixels) = (px(90.), px(9.));
 const PLAY_RATIO: f32 = 0.34;
 const PLAY_MIN: Pixels = px(28.);
 const PLAY_INSET: Pixels = px(8.);
+const TIGHT: Pixels = px(2.);
 
 pub const CARD_GROUP: &str = "card";
 
@@ -36,7 +37,6 @@ pub struct Card {
     size: Option<Text>,
     weight: Option<FontWeight>,
     meta: Option<AnyElement>,
-    footer: Option<AnyElement>,
     bare: bool,
     trailing: Option<AnyElement>,
     cover: Option<String>,
@@ -44,12 +44,9 @@ pub struct Card {
     accent: bool,
     art: Option<Pixels>,
     art_radius: Option<Pixels>,
-    match_art_height: bool,
     circle: bool,
     tint: Option<Hsla>,
-    spacing: Option<Pixels>,
     explicit: bool,
-    explicit_gap: Option<Pixels>,
     fill: bool,
     hovered: Option<StyleRefinement>,
     press: Option<Press>,
@@ -72,7 +69,6 @@ impl Card {
             size: None,
             weight: None,
             meta: None,
-            footer: None,
             bare: false,
             trailing: None,
             cover: None,
@@ -80,12 +76,9 @@ impl Card {
             accent: false,
             art: None,
             art_radius: None,
-            match_art_height: false,
             circle: false,
             tint: None,
-            spacing: None,
             explicit: false,
-            explicit_gap: None,
             fill: true,
             hovered: None,
             press: None,
@@ -157,11 +150,6 @@ impl Card {
         self
     }
 
-    pub fn match_art_height(mut self) -> Self {
-        self.match_art_height = true;
-        self
-    }
-
     pub fn circle(mut self) -> Self {
         self.circle = true;
         self
@@ -182,11 +170,6 @@ impl Card {
         self
     }
 
-    pub fn spacing(mut self, spacing: Pixels) -> Self {
-        self.spacing = Some(spacing);
-        self
-    }
-
     pub fn tint(mut self, tint: Hsla) -> Self {
         self.tint = Some(tint);
         self
@@ -203,18 +186,8 @@ impl Card {
         self
     }
 
-    pub fn footer(mut self, footer: impl IntoElement) -> Self {
-        self.footer = Some(footer.into_any_element());
-        self
-    }
-
     pub fn explicit(mut self) -> Self {
         self.explicit = true;
-        self
-    }
-
-    pub fn explicit_gap(mut self, gap: Pixels) -> Self {
-        self.explicit_gap = Some(gap);
         self
     }
 
@@ -268,7 +241,6 @@ impl RenderOnce for Card {
             size,
             weight,
             meta,
-            footer,
             bare,
             trailing,
             cover,
@@ -276,12 +248,9 @@ impl RenderOnce for Card {
             accent,
             art,
             art_radius,
-            match_art_height,
             circle,
             tint,
-            spacing,
             explicit,
-            explicit_gap,
             fill,
             hovered,
             press,
@@ -385,10 +354,8 @@ impl RenderOnce for Card {
                     .flex_col()
                     .flex_1()
                     .min_w_0()
-                    .when(match_art_height, |this| this.h(art).justify_between())
                     .when(listed && !has_trailing, |this| this.min_w(TITLE))
                     .when(tile.is_some(), |this| this.w_full().flex_none().gap_1())
-                    .when_some(spacing, |this, spacing| this.gap(spacing))
                     .when_else(
                         loading,
                         |this| {
@@ -407,48 +374,58 @@ impl RenderOnce for Card {
                             .child(
                                 div()
                                     .flex()
-                                    .items_center()
-                                    .gap(explicit_gap.unwrap_or(px(6.)))
+                                    .flex_col()
                                     .min_w_0()
-                                    .text_color(tint.unwrap_or(theme.foreground))
-                                    .when_some(size, |this, size| this.text_size(theme.text(size)))
+                                    .gap(TIGHT)
                                     .child(
                                         div()
+                                            .flex()
+                                            .items_center()
+                                            .gap(px(3.))
                                             .min_w_0()
-                                            .truncate()
-                                            .when_some(grip, |this, grip| {
-                                                this.on_mouse_down(
-                                                    MouseButton::Right,
-                                                    move |event, window, cx| {
-                                                        grip(event, window, cx)
-                                                    },
+                                            .text_color(tint.unwrap_or(theme.foreground))
+                                            .when_some(size, |this, size| {
+                                                this.text_size(theme.text(size))
+                                            })
+                                            .child(
+                                                div()
+                                                    .min_w_0()
+                                                    .truncate()
+                                                    .when_some(grip, |this, grip| {
+                                                        this.on_mouse_down(
+                                                            MouseButton::Right,
+                                                            move |event, window, cx| {
+                                                                grip(event, window, cx)
+                                                            },
+                                                        )
+                                                    })
+                                                    .when_some(weight, |this, weight| {
+                                                        this.font_weight(weight)
+                                                    })
+                                                    .when(underline, |this| {
+                                                        this.group_hover(CARD_GROUP, |style| {
+                                                            style.underline()
+                                                        })
+                                                    })
+                                                    .child(title),
+                                            )
+                                            .when(explicit, |this| {
+                                                this.child(
+                                                    div().flex_none().child(ExplicitBadge::new()),
                                                 )
-                                            })
-                                            .when_some(weight, |this, weight| {
-                                                this.font_weight(weight)
-                                            })
-                                            .when(underline, |this| {
-                                                this.group_hover(CARD_GROUP, |style| {
-                                                    style.underline()
-                                                })
-                                            })
-                                            .child(title),
+                                            }),
                                     )
-                                    .when(explicit, |this| {
-                                        this.child(div().flex_none().child(ExplicitBadge::new()))
-                                    }),
+                                    .children(meta.map(|meta| {
+                                        match bare {
+                                            true => div().child(meta),
+                                            false => div()
+                                                .truncate()
+                                                .text_size(theme.text(Text::Small))
+                                                .text_color(theme.muted_foreground)
+                                                .child(meta),
+                                        }
+                                    })),
                             )
-                            .children(meta.map(|meta| {
-                                match bare {
-                                    true => div().child(meta),
-                                    false => div()
-                                        .truncate()
-                                        .text_size(theme.text(Text::Small))
-                                        .text_color(theme.muted_foreground)
-                                        .child(meta),
-                                }
-                            }))
-                            .children(footer.map(|footer| div().pt_1().child(footer)))
                         },
                     ),
             )

--- a/crates/ui/src/card.rs
+++ b/crates/ui/src/card.rs
@@ -5,14 +5,14 @@ use std::rc::Rc;
 use gpui::prelude::*;
 use gpui::{
     AnyElement, App, ClickEvent, Div, ElementId, FontWeight, Hsla, Interactivity, MouseButton,
-    MouseDownEvent, Pixels, SharedString, Stateful, StyleRefinement, Window, div, px,
+    MouseDownEvent, Pixels, SharedString, Stateful, StyleRefinement, Window, div, px, relative,
 };
 
 use crate::ExplicitBadge;
 use crate::artwork::{Artwork, Avatar};
 use crate::button::Button;
 use crate::label::upper;
-use crate::metrics::{Text, snapped};
+use crate::metrics::{LEADING, Text, snapped};
 use crate::skeleton::Skeleton;
 use crate::theme::ActiveTheme as _;
 
@@ -354,6 +354,7 @@ impl RenderOnce for Card {
                     .flex_col()
                     .flex_1()
                     .min_w_0()
+                    .line_height(relative(LEADING))
                     .when(listed && !has_trailing, |this| this.min_w(TITLE))
                     .when(tile.is_some(), |this| this.w_full().flex_none().gap_1())
                     .when_else(

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -52,7 +52,7 @@ pub use input::{
 pub use label::{eyebrow, heading, upper};
 pub use layout::{ALWAYS, MIN_CONTENT, ROOMY, Room, SNUG, VAST, WIDE};
 pub use menu::{Menu, MenuItem, SubmenuState};
-pub use metrics::{Metrics, Rounding, Text, snapped};
+pub use metrics::{LEADING, Metrics, Rounding, Text, snapped};
 pub use palette::tint;
 pub use panel::{Panel, Side};
 pub use popover::{Popover, Popovers};

--- a/crates/ui/src/metrics.rs
+++ b/crates/ui/src/metrics.rs
@@ -5,6 +5,8 @@ use i18n::t;
 
 const HEADER: f32 = 0.75;
 
+pub const LEADING: f32 = 1.25;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Rounding {
     Square,

--- a/crates/views/src/shared/hero.rs
+++ b/crates/views/src/shared/hero.rs
@@ -5,12 +5,12 @@ use std::rc::Rc;
 use gpui::prelude::*;
 use gpui::{
     AnyElement, App, Div, ElementId, Entity, FontWeight, MouseButton, MouseDownEvent, SharedString,
-    Window, div,
+    Window, div, relative,
 };
 use i18n::t;
 use spotify::Track;
 use state::{Playback, PlaybackState};
-use ui::{ActiveTheme as _, Artwork, Button, ExplicitBadge, Text, upper};
+use ui::{ActiveTheme as _, Artwork, Button, ExplicitBadge, LEADING, Text, upper};
 
 pub(crate) fn release_date_label(value: &str) -> SharedString {
     let parts: Vec<_> = value.split('-').collect();
@@ -278,6 +278,7 @@ impl RenderOnce for PageHero {
                     .h(art)
                     .justify_end()
                     .gap_2()
+                    .line_height(relative(LEADING))
                     .children(self.eyebrow.map(|eyebrow| eyebrow_label(eyebrow, cx)))
                     .child(
                         div()

--- a/crates/views/src/shared/hero.rs
+++ b/crates/views/src/shared/hero.rs
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use std::rc::Rc;
+
 use gpui::prelude::*;
 use gpui::{
-    AnyElement, App, ElementId, Entity, FontWeight, MouseDownEvent, SharedString, Window, div,
+    AnyElement, App, Div, ElementId, Entity, FontWeight, MouseButton, MouseDownEvent, SharedString,
+    Window, div,
 };
 use i18n::t;
 use spotify::Track;
 use state::{Playback, PlaybackState};
-use ui::{ActiveTheme as _, Button, Card, Text};
+use ui::{ActiveTheme as _, Artwork, Button, ExplicitBadge, Text, upper};
 
 pub(crate) fn release_date_label(value: &str) -> SharedString {
     let parts: Vec<_> = value.split('-').collect();
@@ -238,29 +241,80 @@ impl RenderOnce for PageHero {
     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
         let theme = *cx.theme();
 
-        Card::new(self.id, self.title)
-            .art(theme.metrics.cover)
-            .art_radius(theme.radius * 1.5)
-            .match_art_height()
-            .cover(self.cover)
-            .when_some(self.fallback, Card::fallback)
-            .when(self.accent, Card::accent)
-            .size(Text::Display)
-            .weight(FontWeight::BOLD)
-            .explicit_gap(theme.metrics.pad * 1.5)
-            .flat()
+        let art = theme.metrics.cover;
+        let grip = self.grip.map(Rc::from);
+        let held = grip.clone();
+
+        div()
+            .id(self.id)
+            .flex()
             .flex_none()
             .items_end()
             .gap_5()
-            .px_0()
             .pb_6()
-            .when_some(self.eyebrow, Card::eyebrow)
-            .when_some(self.meta, Card::bare_meta)
-            .when_some(self.actions, Card::footer)
-            .when_some(self.grip, |card, grip| {
-                card.grip(move |event, window, cx| grip(event, window, cx))
-            })
-            .when(self.circle, Card::circle)
-            .when(self.explicit, Card::explicit)
+            .child(
+                div()
+                    .flex_none()
+                    .when_some(held, |this, grip: Rc<Grip>| {
+                        this.on_mouse_down(MouseButton::Right, move |event, window, cx| {
+                            grip(event, window, cx)
+                        })
+                    })
+                    .child(
+                        Artwork::new(self.cover)
+                            .size(art)
+                            .corner_radius(theme.radius * 1.5)
+                            .when(self.circle, Artwork::circle)
+                            .when_some(self.fallback, Artwork::fallback)
+                            .when(self.accent, Artwork::accent),
+                    ),
+            )
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .flex_1()
+                    .min_w_0()
+                    .h(art)
+                    .justify_end()
+                    .gap_2()
+                    .children(self.eyebrow.map(|eyebrow| eyebrow_label(eyebrow, cx)))
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .gap_3()
+                            .min_w_0()
+                            .text_size(theme.text(Text::Display))
+                            .font_weight(FontWeight::BOLD)
+                            .child(
+                                div()
+                                    .min_w_0()
+                                    .truncate()
+                                    .when_some(grip, |this, grip: Rc<Grip>| {
+                                        this.on_mouse_down(
+                                            MouseButton::Right,
+                                            move |event, window, cx| grip(event, window, cx),
+                                        )
+                                    })
+                                    .child(self.title),
+                            )
+                            .when(self.explicit, |this| {
+                                this.child(div().flex_none().child(ExplicitBadge::new()))
+                            }),
+                    )
+                    .children(self.meta)
+                    .children(self.actions.map(|actions| div().pt_1().child(actions))),
+            )
     }
+}
+
+fn eyebrow_label(label: SharedString, cx: &App) -> Div {
+    let theme = cx.theme();
+
+    div()
+        .text_size(theme.text(Text::Small))
+        .text_color(theme.muted_foreground)
+        .font_weight(FontWeight::SEMIBOLD)
+        .child(upper(label))
 }


### PR DESCRIPTION
## Summary

- give the page hero its own layout instead of bending a card into one
- drop the card fields that only the hero used
- tighten line height so card and hero gaps control spacing