### PR TITLE
feat(spotify): fetch pathfinder query hashes at runtime

### DIFF
--- a/crates/spotify/src/auth.rs
+++ b/crates/spotify/src/auth.rs
@@ -51,7 +51,7 @@ impl AuthConfig {
     }
 }
 
-fn default_cache_dir() -> PathBuf {
+pub(crate) fn default_cache_dir() -> PathBuf {
     dirs::cache_dir()
         .unwrap_or_else(std::env::temp_dir)
         .join("sonora")

--- a/crates/spotify/src/pathfinder.rs
+++ b/crates/spotify/src/pathfinder.rs
@@ -9,6 +9,7 @@ use serde::de::DeserializeOwned;
 
 mod album;
 mod artist;
+mod hashes;
 mod plays;
 
 pub(crate) use album::album;
@@ -34,8 +35,30 @@ struct GraphqlError {
 async fn query<T: DeserializeOwned>(
     session: &Session,
     operation: &str,
-    hash: &str,
     variables: serde_json::Value,
+) -> Result<T> {
+    let hash = hashes::resolve(session, operation).await?;
+    let rejected = match send(session, operation, &hash.value, &variables).await {
+        Ok(data) => return Ok(data),
+        Err(error) => error,
+    };
+    if hash.tried {
+        return Err(rejected);
+    }
+    let Some(latest) = hashes::refresh(session, operation).await else {
+        return Err(rejected);
+    };
+    if latest == hash.value {
+        return Err(rejected);
+    }
+    send(session, operation, &latest, &variables).await
+}
+
+async fn send<T: DeserializeOwned>(
+    session: &Session,
+    operation: &str,
+    hash: &str,
+    variables: &serde_json::Value,
 ) -> Result<T> {
     let body = serde_json::to_vec(&serde_json::json!({
         "operationName": operation,

--- a/crates/spotify/src/pathfinder/album.rs
+++ b/crates/spotify/src/pathfinder/album.rs
@@ -9,7 +9,6 @@ use serde::Deserialize;
 use super::query;
 use crate::models::{Album, AlbumDetail, ArtistRef, ReleaseType, Track};
 
-const HASH: &str = "b9bfabef66ed756e5e13f68a942deb60bd4125ec1f1be8cc42769dc0259b4b10";
 const PAGE_LIMIT: usize = 50;
 const ALBUM_PREFIX: &str = "spotify:album:";
 const ARTIST_PREFIX: &str = "spotify:artist:";
@@ -157,7 +156,7 @@ pub(crate) async fn album(session: &Session, album_id: &str) -> Result<AlbumDeta
             "offset": offset,
             "limit": PAGE_LIMIT,
         });
-        let data = query::<Data>(session, "getAlbum", HASH, variables).await?;
+        let data = query::<Data>(session, "getAlbum", variables).await?;
         let page = page(data)?;
         album.get_or_insert(page.album);
         tracks.extend(page.tracks);

--- a/crates/spotify/src/pathfinder/artist.rs
+++ b/crates/spotify/src/pathfinder/artist.rs
@@ -9,8 +9,6 @@ use serde::Deserialize;
 use super::query;
 use crate::models::{Album, ArtistRef, ReleaseType};
 
-const HASH: &str = "ae0e2958a4ab645b35ca19ac04d0495ae12d9c5d7b7286217674801a9aab281a";
-
 pub(crate) struct Overview {
     pub(crate) name: String,
     pub(crate) cover_large: Option<String>,
@@ -159,7 +157,7 @@ struct Stats {
 
 pub(crate) async fn artist(session: &Session, artist_id: &str) -> Result<Overview> {
     let variables = variables(artist_id);
-    let data = query::<Data>(session, "queryArtistOverview", HASH, variables).await?;
+    let data = query::<Data>(session, "queryArtistOverview", variables).await?;
     overview(data, artist_id)
 }
 

--- a/crates/spotify/src/pathfinder/hashes.rs
+++ b/crates/spotify/src/pathfinder/hashes.rs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::{Mutex, OnceLock},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{Context as _, Result, bail};
+use bytes::Bytes;
+use http::{Method, Request, header};
+use librespot_core::Session;
+use serde::{Deserialize, Serialize};
+
+const WORKER: &str = "https://billowing-resonance-da83.johnwatson.workers.dev/hash";
+const MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+const FILE: &str = "pathfinder.json";
+
+pub(super) struct Hash {
+    pub(super) value: String,
+    pub(super) tried: bool,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+struct Entry {
+    hash: String,
+    fetched: u64,
+}
+
+#[derive(Deserialize)]
+struct Answer {
+    hash: String,
+}
+
+pub(super) async fn resolve(session: &Session, operation: &str) -> Result<Hash> {
+    let Some(entry) = cached(operation) else {
+        return Ok(Hash {
+            value: fetch(session, operation)
+                .await
+                .inspect(|hash| store(operation, hash))?,
+            tried: true,
+        });
+    };
+    match aged(&entry) < MAX_AGE {
+        true => Ok(Hash {
+            value: entry.hash,
+            tried: false,
+        }),
+        false => Ok(Hash {
+            value: refresh(session, operation).await.unwrap_or(entry.hash),
+            tried: true,
+        }),
+    }
+}
+
+pub(super) async fn refresh(session: &Session, operation: &str) -> Option<String> {
+    fetch(session, operation)
+        .await
+        .inspect(|hash| store(operation, hash))
+        .inspect_err(|error| {
+            log::warn!("pathfinder: cannot refresh the {operation} hash: {error:#}")
+        })
+        .ok()
+}
+
+async fn fetch(session: &Session, operation: &str) -> Result<String> {
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri(format!("{WORKER}/{operation}"))
+        .header(header::ACCEPT, "application/json")
+        .body(Bytes::new())
+        .with_context(|| format!("cannot build the {operation} hash request"))?;
+    let body = session
+        .http_client()
+        .request_body(request)
+        .await
+        .with_context(|| format!("cannot request the {operation} hash"))?;
+    let answer: Answer = serde_json::from_slice(&body)
+        .with_context(|| format!("cannot decode the {operation} hash response"))?;
+    if !sane(&answer.hash) {
+        bail!("received a malformed {operation} hash");
+    }
+    Ok(answer.hash)
+}
+
+fn sane(hash: &str) -> bool {
+    hash.len() == 64 && hash.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn aged(entry: &Entry) -> Duration {
+    Duration::from_secs(now().saturating_sub(entry.fetched))
+}
+
+fn now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn cached(operation: &str) -> Option<Entry> {
+    entries().lock().ok()?.get(operation).cloned()
+}
+
+fn store(operation: &str, hash: &str) {
+    let Ok(mut entries) = entries().lock() else {
+        return;
+    };
+    entries.insert(
+        operation.to_owned(),
+        Entry {
+            hash: hash.to_owned(),
+            fetched: now(),
+        },
+    );
+    write(&entries);
+}
+
+fn entries() -> &'static Mutex<HashMap<String, Entry>> {
+    static ENTRIES: OnceLock<Mutex<HashMap<String, Entry>>> = OnceLock::new();
+    ENTRIES.get_or_init(|| Mutex::new(read()))
+}
+
+fn read() -> HashMap<String, Entry> {
+    let Ok(body) = std::fs::read(path()) else {
+        return HashMap::new();
+    };
+    serde_json::from_slice(&body).unwrap_or_default()
+}
+
+fn write(entries: &HashMap<String, Entry>) {
+    let path = path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let written = serde_json::to_vec_pretty(entries)
+        .context("cannot encode")
+        .and_then(|body| std::fs::write(&path, body).context("cannot save"));
+    if let Err(error) = written {
+        log::warn!("pathfinder: {error:#} {}", path.display());
+    }
+}
+
+fn path() -> PathBuf {
+    crate::auth::default_cache_dir().join(FILE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_a_persisted_query_hash() {
+        assert!(sane(&"0123456789abcdef".repeat(4)));
+    }
+
+    #[test]
+    fn rejects_a_malformed_hash() {
+        assert!(!sane(""));
+        assert!(!sane("0123456789abcdef"));
+        assert!(!sane(&"z".repeat(64)));
+    }
+
+    #[test]
+    fn ages_from_the_fetch_time() {
+        let entry = Entry {
+            hash: String::new(),
+            fetched: now() - 60,
+        };
+        assert!(aged(&entry) >= Duration::from_secs(60));
+        assert!(aged(&entry) < MAX_AGE);
+    }
+}

--- a/crates/spotify/src/pathfinder/plays.rs
+++ b/crates/spotify/src/pathfinder/plays.rs
@@ -6,8 +6,6 @@ use serde::Deserialize;
 
 use super::query;
 
-const HASH: &str = "612585ae06ba435ad26369870deaae23b5c8800a256cd8a57e08eddc25a37294";
-
 #[derive(Deserialize)]
 struct Data {
     #[serde(rename = "trackUnion")]
@@ -21,7 +19,7 @@ struct Track {
 
 pub(crate) async fn track(session: &Session, track_id: &str) -> Result<Option<u64>> {
     let variables = serde_json::json!({ "uri": format!("spotify:track:{track_id}") });
-    let data = query::<Data>(session, "getTrack", HASH, variables).await?;
+    let data = query::<Data>(session, "getTrack", variables).await?;
     playcount(data)
 }
 


### PR DESCRIPTION
## Summary

- resolve pathfinder persisted-query hashes from the hash worker instead of shipping them in the binary
- cache resolved hashes in `$XDG_CACHE_HOME/sonora/pathfinder.json`, refreshing an entry once it is a day old
- retry a rejected query once against a freshly fetched hash, surfacing the original error only when the worker cannot help