### PR TITLE
feat(views): surface radio suggestions and add control tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Copy link actions for tracks, albums, playlists and artists.
 - Monthly listeners on the artist page, and play counts beside an artist's popular tracks.
 - Toasts confirming queue and playlist additions.
+- Turning on radio in the queue lists what it will play under a Similar tracks section, picked from
+  the last track in the queue; clicking one plays it straight away.
+- Tooltips on icon-only controls across the player, title bar, toolbar and queue.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Copy link actions for tracks, albums, playlists and artists.
 - Monthly listeners on the artist page, and play counts beside an artist's popular tracks.
 - Toasts confirming queue and playlist additions.
-- Turning on radio in the queue lists what it will play under a Similar tracks section, picked from
-  the last track in the queue; clicking one plays it straight away.
+- Turning on radio appends what it will play to the queue and lists it under a Similar tracks
+  section, picked from the last track you queued. Those tracks play, reorder and can be removed like
+  any other queue entry.
 - Tooltips on icon-only controls across the player, title bar, toolbar and queue.
 
 ### Changed

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -10,6 +10,11 @@ common-not-available = Not available
 common-cancel = Cancel
 common-save = Save
 common-delete = Delete
+common-play = Play
+common-more = More
+common-previous = Previous
+common-next = Next
+common-dismiss = Dismiss
 number-group = { "," }
 
 # navigation
@@ -20,6 +25,9 @@ nav-settings = Settings
 nav-songs = Songs
 nav-albums = Albums
 nav-playlists = Playlists
+nav-back = Back
+nav-forward = Forward
+nav-sidebar = Toggle sidebar
 library-liked-songs = Liked Songs
 library-play-liked-songs = Play
 
@@ -82,10 +90,21 @@ queue-up-next = Up next
 queue-reset = Reset
 queue-clear = Clear
 queue-empty = Your queue is empty
+queue-similar = Similar tracks
+queue-radio = Autoplay similar tracks
 
 # player bar
 player-nothing-playing = Nothing playing
 player-percent = { $value }%
+player-shuffle = Shuffle
+player-repeat = Repeat
+player-repeat-all = Repeat all
+player-repeat-one = Repeat one
+player-mute = Mute
+player-unmute = Unmute
+player-previous = Previous track
+player-next = Next track
+player-fullscreen = Fullscreen
 
 # filters
 filter-library = Filter your library
@@ -99,6 +118,11 @@ filter-playable = Playable only
 # view
 view-list = List
 view-cards = Cards
+
+# toolbar
+tool-columns = Columns
+tool-sort = Sort
+tool-filters = Filters
 
 # login
 login-signed-out = Sign in to load your Spotify library

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -10,6 +10,11 @@ common-not-available = Brak danych
 common-cancel = Anuluj
 common-save = Zapisz
 common-delete = Usuń
+common-play = Odtwórz
+common-more = Więcej
+common-previous = Wstecz
+common-next = Dalej
+common-dismiss = Zamknij
 number-group = { "\u00A0" }
 
 # navigation
@@ -20,6 +25,9 @@ nav-settings = Ustawienia
 nav-songs = Utwory
 nav-albums = Albumy
 nav-playlists = Playlisty
+nav-back = Wstecz
+nav-forward = Dalej
+nav-sidebar = Pokaż lub ukryj panel boczny
 library-liked-songs = Polubione utwory
 library-play-liked-songs = Odtwórz
 
@@ -82,10 +90,21 @@ queue-up-next = Następne
 queue-reset = Resetuj
 queue-clear = Wyczyść
 queue-empty = Twoja kolejka jest pusta
+queue-similar = Podobne utwory
+queue-radio = Automatycznie odtwarzaj podobne utwory
 
 # player bar
 player-nothing-playing = Nic nie jest odtwarzane
 player-percent = { $value }%
+player-shuffle = Losowo
+player-repeat = Powtarzaj
+player-repeat-all = Powtarzaj wszystko
+player-repeat-one = Powtarzaj utwór
+player-mute = Wycisz
+player-unmute = Wyłącz wyciszenie
+player-previous = Poprzedni utwór
+player-next = Następny utwór
+player-fullscreen = Pełny ekran
 
 # filters
 filter-library = Filtruj bibliotekę
@@ -99,6 +118,11 @@ filter-playable = Tylko dostępne
 # view
 view-list = Lista
 view-cards = Kafelki
+
+# toolbar
+tool-columns = Kolumny
+tool-sort = Sortowanie
+tool-filters = Filtry
 
 # login
 login-signed-out = Zaloguj się, aby wczytać bibliotekę Spotify

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -10,6 +10,11 @@ common-not-available = Нет данных
 common-cancel = Отмена
 common-save = Сохранить
 common-delete = Удалить
+common-play = Воспроизвести
+common-more = Ещё
+common-previous = Назад
+common-next = Вперёд
+common-dismiss = Закрыть
 number-group = { "\u00A0" }
 
 # navigation
@@ -20,6 +25,9 @@ nav-settings = Настройки
 nav-songs = Треки
 nav-albums = Альбомы
 nav-playlists = Плейлисты
+nav-back = Назад
+nav-forward = Вперёд
+nav-sidebar = Показать или скрыть боковую панель
 library-liked-songs = Любимые треки
 library-play-liked-songs = Слушать
 
@@ -82,10 +90,21 @@ queue-up-next = Далее
 queue-reset = Сбросить
 queue-clear = Очистить
 queue-empty = Очередь пуста
+queue-similar = Похожие треки
+queue-radio = Автовоспроизведение похожих треков
 
 # player bar
 player-nothing-playing = Ничего не играет
 player-percent = { $value }%
+player-shuffle = Перемешать
+player-repeat = Повтор
+player-repeat-all = Повторять всё
+player-repeat-one = Повторять трек
+player-mute = Выключить звук
+player-unmute = Включить звук
+player-previous = Предыдущий трек
+player-next = Следующий трек
+player-fullscreen = Полноэкранный режим
 
 # filters
 filter-library = Фильтр медиатеки
@@ -99,6 +118,11 @@ filter-playable = Только доступные
 # view
 view-list = Список
 view-cards = Карточки
+
+# toolbar
+tool-columns = Колонки
+tool-sort = Сортировка
+tool-filters = Фильтры
 
 # login
 login-signed-out = Войдите, чтобы загрузить медиатеку Spotify

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -10,6 +10,11 @@ common-not-available = Немає даних
 common-cancel = Скасувати
 common-save = Зберегти
 common-delete = Видалити
+common-play = Відтворити
+common-more = Ще
+common-previous = Назад
+common-next = Вперед
+common-dismiss = Закрити
 number-group = { "\u00A0" }
 
 # navigation
@@ -20,6 +25,9 @@ nav-settings = Налаштування
 nav-songs = Треки
 nav-albums = Альбоми
 nav-playlists = Плейлисти
+nav-back = Назад
+nav-forward = Вперед
+nav-sidebar = Показати або сховати бічну панель
 library-liked-songs = Вподобані пісні
 library-play-liked-songs = Слухати
 
@@ -82,10 +90,21 @@ queue-up-next = Далі
 queue-reset = Скинути
 queue-clear = Очистити
 queue-empty = Черга порожня
+queue-similar = Схожі треки
+queue-radio = Автовідтворення схожих треків
 
 # player bar
 player-nothing-playing = Нічого не грає
 player-percent = { $value }%
+player-shuffle = Перемішати
+player-repeat = Повтор
+player-repeat-all = Повторювати все
+player-repeat-one = Повторювати трек
+player-mute = Вимкнути звук
+player-unmute = Увімкнути звук
+player-previous = Попередній трек
+player-next = Наступний трек
+player-fullscreen = Повноекранний режим
 
 # filters
 filter-library = Фільтр медіатеки
@@ -99,6 +118,11 @@ filter-playable = Лише доступні
 # view
 view-list = Список
 view-cards = Картки
+
+# toolbar
+tool-columns = Колонки
+tool-sort = Сортування
+tool-filters = Фільтри
 
 # login
 login-signed-out = Увійдіть, щоб завантажити медіатеку Spotify

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -27,6 +27,7 @@ const POSITION_INTERVAL: Duration = Duration::from_millis(500);
 const SKIP_DEBOUNCE: Duration = Duration::from_millis(250);
 const KEY_COOLDOWN: Duration = Duration::from_secs(6);
 const TAPER_DB: f32 = 50.;
+const SIMILAR_LIMIT: usize = 20;
 
 fn gain(level: f32) -> f32 {
     match level.clamp(0., 1.) {
@@ -78,10 +79,13 @@ pub struct Playback {
     normalisation: bool,
     repeat: Repeat,
     radio: bool,
+    similar: Vec<Track>,
+    seeded: Option<String>,
     task: Option<Task<()>>,
     load: Option<Task<()>>,
     fetch: Option<Task<()>>,
     enqueue: Option<Task<()>>,
+    suggest: Option<Task<()>>,
     blocked_until: Option<Instant>,
 }
 
@@ -104,6 +108,8 @@ impl Playback {
             SessionEvent::SignedOut => this.teardown(cx),
         })
         .detach();
+        cx.observe(&queue, |this, _, cx| this.suggest_similar(cx))
+            .detach();
 
         let level = settings.read(cx).volume();
         let normalisation = settings.read(cx).normalisation();
@@ -122,10 +128,13 @@ impl Playback {
             normalisation,
             repeat,
             radio: false,
+            similar: Vec::new(),
+            seeded: None,
             task: None,
             load: None,
             fetch: None,
             enqueue: None,
+            suggest: None,
             blocked_until: None,
         }
     }
@@ -409,7 +418,80 @@ impl Playback {
 
     pub fn toggle_radio(&mut self, cx: &mut Context<Self>) {
         self.radio = !self.radio;
+        match self.radio {
+            true => self.suggest_similar(cx),
+            false => self.forget_similar(cx),
+        }
+    }
+
+    pub fn similar(&self) -> &[Track] {
+        &self.similar
+    }
+
+    pub fn play_similar(&mut self, index: usize, cx: &mut Context<Self>) {
+        if index >= self.similar.len() {
+            return;
+        }
+        let track = self.similar.remove(index);
+        self.fetch = None;
+        self.queue.update(cx, |queue, cx| queue.prepend(track, cx));
+        self.follow_queue(cx);
+    }
+
+    fn forget_similar(&mut self, cx: &mut Context<Self>) {
+        self.similar.clear();
+        self.seeded = None;
+        self.suggest = None;
         cx.notify();
+    }
+
+    fn seed(&self, cx: &Context<Self>) -> Option<Track> {
+        let queue = self.queue.read(cx);
+        queue.upcoming().last().or_else(|| queue.current()).cloned()
+    }
+
+    fn suggest_similar(&mut self, cx: &mut Context<Self>) {
+        if !self.radio {
+            return;
+        }
+        let Some(id) = self.seed(cx).and_then(|seed| seed.id) else {
+            return self.forget_similar(cx);
+        };
+        if self.seeded.as_deref() == Some(id.as_str()) {
+            return;
+        }
+        let Some(client) = self.session.read(cx).client() else {
+            return self.forget_similar(cx);
+        };
+
+        let queued = self.queue.read(cx).ids();
+        self.seeded = Some(id.clone());
+        let io = Io::global(cx);
+        self.suggest = Some(cx.spawn(async move |this, cx| {
+            let loaded = join(io.spawn(async move {
+                let mut tracks = client.track_radio(&id).await?;
+                tracks.retain(|track| {
+                    track.playable
+                        && track
+                            .id
+                            .as_ref()
+                            .is_some_and(|id| !queued.contains(id.as_str()))
+                });
+                fastrand::shuffle(&mut tracks);
+                tracks.truncate(SIMILAR_LIMIT);
+                anyhow::Ok(tracks)
+            }))
+            .await;
+
+            this.update(cx, |this, cx| match loaded {
+                Ok(tracks) => {
+                    this.similar = tracks;
+                    cx.notify();
+                }
+                Err(error) => log::warn!("playback: cannot load similar tracks: {error:#}"),
+            })
+            .ok();
+        }));
     }
 
     pub fn repeat(&self) -> Repeat {
@@ -441,6 +523,9 @@ impl Playback {
                 }
             }
             _ if self.radio && !self.queue.read(cx).has_next() => {
+                if !self.similar.is_empty() {
+                    return self.follow_similar(cx);
+                }
                 match ended.or_else(|| self.track.clone()) {
                     Some(seed) => self.extend_radio(&seed, cx),
                     None => self.next(cx),
@@ -448,6 +533,14 @@ impl Playback {
             }
             _ => self.next(cx),
         }
+    }
+
+    fn follow_similar(&mut self, cx: &mut Context<Self>) {
+        self.fetch = None;
+        let tracks = std::mem::take(&mut self.similar);
+        self.queue
+            .update(cx, |queue, cx| queue.append_all(tracks, cx));
+        self.follow_queue(cx);
     }
 
     fn extend_radio(&mut self, seed: &Track, cx: &mut Context<Self>) {
@@ -706,6 +799,9 @@ impl Playback {
         self.load = None;
         self.fetch = None;
         self.enqueue = None;
+        self.suggest = None;
+        self.similar.clear();
+        self.seeded = None;
         self.blocked_until = None;
         self.engine = None;
         self.track = None;

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -79,7 +79,6 @@ pub struct Playback {
     normalisation: bool,
     repeat: Repeat,
     radio: bool,
-    similar: Vec<Track>,
     seeded: Option<String>,
     task: Option<Task<()>>,
     load: Option<Task<()>>,
@@ -128,7 +127,6 @@ impl Playback {
             normalisation,
             repeat,
             radio: false,
-            similar: Vec::new(),
             seeded: None,
             task: None,
             load: None,
@@ -424,24 +422,21 @@ impl Playback {
         }
     }
 
-    pub fn similar(&self) -> &[Track] {
-        &self.similar
-    }
-
     pub fn play_similar(&mut self, index: usize, cx: &mut Context<Self>) {
-        if index >= self.similar.len() {
-            return;
-        }
-        let track = self.similar.remove(index);
         self.fetch = None;
-        self.queue.update(cx, |queue, cx| queue.prepend(track, cx));
-        self.follow_queue(cx);
+        let Some(track) = self
+            .queue
+            .update(cx, |queue, cx| queue.play_similar(index, cx))
+        else {
+            return;
+        };
+        self.load_after(&track, SKIP_DEBOUNCE, cx);
     }
 
     fn forget_similar(&mut self, cx: &mut Context<Self>) {
-        self.similar.clear();
         self.seeded = None;
         self.suggest = None;
+        self.queue.update(cx, |queue, cx| queue.clear_similar(cx));
         cx.notify();
     }
 
@@ -484,10 +479,8 @@ impl Playback {
             .await;
 
             this.update(cx, |this, cx| match loaded {
-                Ok(tracks) => {
-                    this.similar = tracks;
-                    cx.notify();
-                }
+                Ok(_) if !this.radio => {}
+                Ok(tracks) => this.queue.update(cx, |queue, cx| queue.suggest(tracks, cx)),
                 Err(error) => log::warn!("playback: cannot load similar tracks: {error:#}"),
             })
             .ok();
@@ -523,9 +516,6 @@ impl Playback {
                 }
             }
             _ if self.radio && !self.queue.read(cx).has_next() => {
-                if !self.similar.is_empty() {
-                    return self.follow_similar(cx);
-                }
                 match ended.or_else(|| self.track.clone()) {
                     Some(seed) => self.extend_radio(&seed, cx),
                     None => self.next(cx),
@@ -533,14 +523,6 @@ impl Playback {
             }
             _ => self.next(cx),
         }
-    }
-
-    fn follow_similar(&mut self, cx: &mut Context<Self>) {
-        self.fetch = None;
-        let tracks = std::mem::take(&mut self.similar);
-        self.queue
-            .update(cx, |queue, cx| queue.append_all(tracks, cx));
-        self.follow_queue(cx);
     }
 
     fn extend_radio(&mut self, seed: &Track, cx: &mut Context<Self>) {
@@ -800,7 +782,6 @@ impl Playback {
         self.fetch = None;
         self.enqueue = None;
         self.suggest = None;
-        self.similar.clear();
         self.seeded = None;
         self.blocked_until = None;
         self.engine = None;

--- a/crates/state/src/queue.rs
+++ b/crates/state/src/queue.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use gpui::{Context, Entity};
 use spotify::Track;
@@ -159,6 +159,15 @@ impl Queue {
 
     pub fn upcoming(&self) -> impl ExactSizeIterator<Item = &Track> {
         self.upcoming.iter()
+    }
+
+    pub fn ids(&self) -> HashSet<String> {
+        self.past
+            .iter()
+            .chain(self.current.as_ref())
+            .chain(self.upcoming.iter())
+            .filter_map(|track| track.id.clone())
+            .collect()
     }
 
     pub fn len(&self) -> usize {

--- a/crates/state/src/queue.rs
+++ b/crates/state/src/queue.rs
@@ -98,6 +98,7 @@ pub struct Queue {
     current: Option<Track>,
     upcoming: VecDeque<Track>,
     source: Vec<Track>,
+    similar: usize,
     shuffle: bool,
     revision: u64,
     settings: Entity<AppSettings>,
@@ -112,6 +113,7 @@ impl Queue {
             current: None,
             upcoming: VecDeque::new(),
             source: Vec::new(),
+            similar: 0,
             shuffle,
             revision: 0,
             settings,
@@ -129,10 +131,12 @@ impl Queue {
         self.shuffle = on;
         self.settings
             .update(cx, |settings, cx| settings.set_shuffle(on, cx));
+        let mut suggested = self.upcoming.split_off(self.queued());
         match on {
             true => scramble(&mut self.upcoming),
             false => restore(&mut self.upcoming, &self.source),
         }
+        self.upcoming.append(&mut suggested);
         self.changed(cx);
     }
 
@@ -157,8 +161,32 @@ impl Queue {
         self.current.as_ref()
     }
 
+    fn queued(&self) -> usize {
+        self.upcoming.len() - self.similar
+    }
+
     pub fn upcoming(&self) -> impl ExactSizeIterator<Item = &Track> {
-        self.upcoming.iter()
+        self.upcoming.range(..self.queued())
+    }
+
+    pub fn similar(&self) -> impl ExactSizeIterator<Item = &Track> {
+        self.upcoming.range(self.queued()..)
+    }
+
+    pub fn suggest(&mut self, tracks: Vec<Track>, cx: &mut Context<Self>) {
+        self.upcoming.truncate(self.queued());
+        self.similar = tracks.len();
+        self.upcoming.extend(tracks);
+        self.changed(cx);
+    }
+
+    pub fn clear_similar(&mut self, cx: &mut Context<Self>) {
+        if self.similar == 0 {
+            return;
+        }
+        self.upcoming.truncate(self.queued());
+        self.similar = 0;
+        self.changed(cx);
     }
 
     pub fn ids(&self) -> HashSet<String> {
@@ -187,10 +215,10 @@ impl Queue {
     }
 
     pub fn clear_upcoming(&mut self, cx: &mut Context<Self>) {
-        if self.upcoming.is_empty() {
+        if self.queued() == 0 {
             return;
         }
-        self.upcoming.clear();
+        self.upcoming.drain(..self.queued());
         self.changed(cx);
     }
 
@@ -199,6 +227,7 @@ impl Queue {
         self.current = None;
         self.upcoming.clear();
         self.source.clear();
+        self.similar = 0;
         self.changed(cx);
     }
 
@@ -239,6 +268,7 @@ impl Queue {
         self.source = tracks.clone();
         let mut past = tracks;
         self.upcoming = past.split_off(index + 1).into();
+        self.similar = 0;
         if self.shuffle {
             scramble(&mut self.upcoming);
         }
@@ -253,7 +283,10 @@ impl Queue {
     }
 
     pub fn append_all(&mut self, tracks: impl IntoIterator<Item = Track>, cx: &mut Context<Self>) {
-        self.upcoming.extend(tracks);
+        let at = self.queued();
+        for (offset, track) in tracks.into_iter().enumerate() {
+            self.upcoming.insert(at + offset, track);
+        }
         self.changed(cx);
     }
 
@@ -275,17 +308,28 @@ impl Queue {
     }
 
     pub fn move_upcoming_to_gap(&mut self, from: usize, gap: usize, cx: &mut Context<Self>) {
-        let to = gap_target(from, gap, self.upcoming.len());
+        let to = gap_target(from, gap, self.queued());
         self.move_upcoming(from, to, cx);
     }
 
     pub fn remove_upcoming(&mut self, index: usize, cx: &mut Context<Self>) {
-        if self.upcoming.remove(index).is_some() {
+        if index < self.queued() && self.upcoming.remove(index).is_some() {
+            self.changed(cx);
+        }
+    }
+
+    pub fn remove_similar(&mut self, index: usize, cx: &mut Context<Self>) {
+        if index >= self.similar {
+            return;
+        }
+        if self.upcoming.remove(self.queued() + index).is_some() {
+            self.similar -= 1;
             self.changed(cx);
         }
     }
 
     pub fn next(&mut self, cx: &mut Context<Self>) -> Option<Track> {
+        self.similar -= usize::from(self.queued() == 0 && self.similar > 0);
         let next = self.upcoming.pop_front()?;
         if let Some(played) = self.current.replace(next) {
             self.past.push(played);
@@ -295,6 +339,8 @@ impl Queue {
     }
 
     pub fn rewind(&mut self, cx: &mut Context<Self>) -> Option<Track> {
+        self.upcoming.truncate(self.queued());
+        self.similar = 0;
         let mut tracks = std::mem::take(&mut self.past);
         tracks.extend(self.current.take());
         tracks.extend(self.upcoming.drain(..));
@@ -319,9 +365,29 @@ impl Queue {
     }
 
     pub fn play_upcoming(&mut self, index: usize, cx: &mut Context<Self>) -> Option<Track> {
-        if !select_upcoming(&mut self.past, &mut self.current, &mut self.upcoming, index) {
+        if index >= self.queued()
+            || !select_upcoming(&mut self.past, &mut self.current, &mut self.upcoming, index)
+        {
             return None;
         }
+        self.changed(cx);
+        self.current.clone()
+    }
+
+    pub fn play_similar(&mut self, index: usize, cx: &mut Context<Self>) -> Option<Track> {
+        if index >= self.similar {
+            return None;
+        }
+        let target = self.queued() + index;
+        if !select_upcoming(
+            &mut self.past,
+            &mut self.current,
+            &mut self.upcoming,
+            target,
+        ) {
+            return None;
+        }
+        self.similar -= index + 1;
         self.changed(cx);
         self.current.clone()
     }

--- a/crates/ui/src/button.rs
+++ b/crates/ui/src/button.rs
@@ -8,6 +8,7 @@ use gpui::{
 
 use crate::metrics::Text;
 use crate::theme::ActiveTheme as _;
+use crate::tooltip::Tooltip;
 
 enum Variant {
     Secondary,
@@ -31,6 +32,7 @@ pub struct Button {
     hovered: Option<StyleRefinement>,
     pressed: Option<StyleRefinement>,
     tint: Option<Hsla>,
+    tooltip: Option<SharedString>,
     on_click: Option<Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>>,
 }
 
@@ -50,6 +52,7 @@ impl Button {
             hovered: None,
             pressed: None,
             tint: None,
+            tooltip: None,
             on_click: None,
         }
     }
@@ -114,6 +117,11 @@ impl Button {
         self
     }
 
+    pub fn tooltip(mut self, key: impl Into<SharedString>) -> Self {
+        self.tooltip = Some(key.into());
+        self
+    }
+
     pub fn on_click(
         mut self,
         handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
@@ -170,6 +178,7 @@ impl RenderOnce for Button {
             hovered,
             pressed,
             tint,
+            tooltip,
             on_click,
         } = self;
 
@@ -245,6 +254,7 @@ impl RenderOnce for Button {
                 this.border_1().border_color(border)
             })
             .when(interactive, |this| this.cursor_pointer())
+            .when_some(tooltip, |this, key| this.tooltip(Tooltip::build(key)))
             .when_some(hovered, |this, style| this.hover(move |_| style))
             .when_some(pressed, |this, style| this.active(move |_| style))
             .when_some(icon, |this, path| {

--- a/crates/ui/src/button.rs
+++ b/crates/ui/src/button.rs
@@ -8,7 +8,7 @@ use gpui::{
 
 use crate::metrics::Text;
 use crate::theme::ActiveTheme as _;
-use crate::tooltip::Tooltip;
+use crate::tooltip::{Perch, Tooltip};
 
 enum Variant {
     Secondary,
@@ -32,7 +32,7 @@ pub struct Button {
     hovered: Option<StyleRefinement>,
     pressed: Option<StyleRefinement>,
     tint: Option<Hsla>,
-    tooltip: Option<SharedString>,
+    tooltip: Option<(SharedString, Perch)>,
     on_click: Option<Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>>,
 }
 
@@ -118,7 +118,12 @@ impl Button {
     }
 
     pub fn tooltip(mut self, key: impl Into<SharedString>) -> Self {
-        self.tooltip = Some(key.into());
+        self.tooltip = Some((key.into(), Perch::Pointer));
+        self
+    }
+
+    pub fn tooltip_above(mut self, key: impl Into<SharedString>) -> Self {
+        self.tooltip = Some((key.into(), Perch::Above));
         self
     }
 
@@ -254,7 +259,9 @@ impl RenderOnce for Button {
                 this.border_1().border_color(border)
             })
             .when(interactive, |this| this.cursor_pointer())
-            .when_some(tooltip, |this, key| this.tooltip(Tooltip::build(key)))
+            .when_some(tooltip, |this, (key, perch)| {
+                this.tooltip(Tooltip::build(key, perch))
+            })
             .when_some(hovered, |this, style| this.hover(move |_| style))
             .when_some(pressed, |this, style| this.active(move |_| style))
             .when_some(icon, |this, path| {

--- a/crates/ui/src/card.rs
+++ b/crates/ui/src/card.rs
@@ -311,6 +311,10 @@ impl RenderOnce for Card {
                                     true => "icons/pause.svg",
                                     false => "icons/play.svg",
                                 })
+                                .tooltip(match playing {
+                                    true => "play-pause",
+                                    false => "common-play",
+                                })
                                 .size(px((art / px(1.) * PLAY_RATIO).round()).max(PLAY_MIN))
                                 .rounded_full()
                                 .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -66,5 +66,5 @@ pub use skeleton::{Initials, Skeleton};
 pub use theme::{ActiveTheme, Look, MAX_FONT, MIN_FONT, Theme, ThemeKind, ThemeOverrides};
 pub use time::clock;
 pub use toast::Toast;
-pub use tooltip::Tooltip;
+pub use tooltip::{Perch, Tooltip};
 pub use view::Mode;

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -27,6 +27,7 @@ mod skeleton;
 mod theme;
 mod time;
 mod toast;
+mod tooltip;
 mod view;
 
 pub use artwork::{Artwork, Avatar};
@@ -65,4 +66,5 @@ pub use skeleton::{Initials, Skeleton};
 pub use theme::{ActiveTheme, Look, MAX_FONT, MIN_FONT, Theme, ThemeKind, ThemeOverrides};
 pub use time::clock;
 pub use toast::Toast;
+pub use tooltip::Tooltip;
 pub use view::Mode;

--- a/crates/ui/src/toast.rs
+++ b/crates/ui/src/toast.rs
@@ -101,6 +101,7 @@ impl RenderOnce for Toast {
                     .ghost()
                     .small()
                     .icon("icons/x.svg")
+                    .tooltip("common-dismiss")
                     .on_click(move |event, window, cx| dismiss(event, window, cx))
             }))
     }

--- a/crates/ui/src/tooltip.rs
+++ b/crates/ui/src/tooltip.rs
@@ -50,7 +50,7 @@ impl Render for Tooltip {
         let (position, anchor) = match self.perch {
             Perch::Pointer => (at + point(-OFFSET, OFFSET), Anchor::TopRight),
             Perch::Above => (
-                point(at.x, at.y - theme.metrics.control_small),
+                point(at.x, at.y - theme.metrics.control_small / 2.),
                 Anchor::BottomCenter,
             ),
         };

--- a/crates/ui/src/tooltip.rs
+++ b/crates/ui/src/tooltip.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use gpui::prelude::*;
+use gpui::{Anchor, AnyView, App, Context, Pixels, SharedString, Window, anchored, div, point, px};
+
+use crate::metrics::Text;
+use crate::theme::ActiveTheme as _;
+
+const MARGIN: Pixels = px(8.);
+const OFFSET: Pixels = px(6.);
+
+pub struct Tooltip {
+    key: SharedString,
+}
+
+impl Tooltip {
+    pub fn new(key: impl Into<SharedString>) -> Self {
+        Self { key: key.into() }
+    }
+
+    pub fn build(
+        key: impl Into<SharedString>,
+    ) -> impl Fn(&mut Window, &mut App) -> AnyView + 'static {
+        let key = key.into();
+        move |_, cx| cx.new(|_| Self::new(key.clone())).into()
+    }
+}
+
+impl Render for Tooltip {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = *cx.theme();
+        let at = window.mouse_position() + point(-OFFSET, OFFSET);
+
+        anchored()
+            .position(at)
+            .anchor(Anchor::TopRight)
+            .snap_to_window_with_margin(MARGIN)
+            .child(
+                div()
+                    .px_2()
+                    .py_1()
+                    .rounded(theme.radius)
+                    .border_1()
+                    .border_color(theme.border)
+                    .bg(theme.popover)
+                    .text_size(theme.text(Text::Small))
+                    .text_color(theme.popover_foreground)
+                    .child(i18n::lookup(&self.key, None)),
+            )
+    }
+}

--- a/crates/ui/src/tooltip.rs
+++ b/crates/ui/src/tooltip.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use gpui::prelude::*;
-use gpui::{Anchor, AnyView, App, Context, Pixels, SharedString, Window, anchored, div, point, px};
+use gpui::{
+    Anchor, AnyView, App, Context, Pixels, Point, SharedString, Window, anchored, div, point, px,
+};
 
 use crate::metrics::Text;
 use crate::theme::ActiveTheme as _;
@@ -19,13 +21,15 @@ pub enum Perch {
 pub struct Tooltip {
     key: SharedString,
     perch: Perch,
+    at: Point<Pixels>,
 }
 
 impl Tooltip {
-    pub fn new(key: impl Into<SharedString>) -> Self {
+    pub fn new(key: impl Into<SharedString>, at: Point<Pixels>) -> Self {
         Self {
             key: key.into(),
             perch: Perch::default(),
+            at,
         }
     }
 
@@ -39,14 +43,17 @@ impl Tooltip {
         perch: Perch,
     ) -> impl Fn(&mut Window, &mut App) -> AnyView + 'static {
         let key = key.into();
-        move |_, cx| cx.new(|_| Self::new(key.clone()).perch(perch)).into()
+        move |window, cx| {
+            let at = window.mouse_position();
+            cx.new(|_| Self::new(key.clone(), at).perch(perch)).into()
+        }
     }
 }
 
 impl Render for Tooltip {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = *cx.theme();
-        let at = window.mouse_position();
+        let at = self.at;
         let (position, anchor) = match self.perch {
             Perch::Pointer => (at + point(-OFFSET, OFFSET), Anchor::TopRight),
             Perch::Above => (

--- a/crates/ui/src/tooltip.rs
+++ b/crates/ui/src/tooltip.rs
@@ -9,31 +9,55 @@ use crate::theme::ActiveTheme as _;
 const MARGIN: Pixels = px(8.);
 const OFFSET: Pixels = px(6.);
 
+#[derive(Clone, Copy, Default, PartialEq)]
+pub enum Perch {
+    #[default]
+    Pointer,
+    Above,
+}
+
 pub struct Tooltip {
     key: SharedString,
+    perch: Perch,
 }
 
 impl Tooltip {
     pub fn new(key: impl Into<SharedString>) -> Self {
-        Self { key: key.into() }
+        Self {
+            key: key.into(),
+            perch: Perch::default(),
+        }
+    }
+
+    pub fn perch(mut self, perch: Perch) -> Self {
+        self.perch = perch;
+        self
     }
 
     pub fn build(
         key: impl Into<SharedString>,
+        perch: Perch,
     ) -> impl Fn(&mut Window, &mut App) -> AnyView + 'static {
         let key = key.into();
-        move |_, cx| cx.new(|_| Self::new(key.clone())).into()
+        move |_, cx| cx.new(|_| Self::new(key.clone()).perch(perch)).into()
     }
 }
 
 impl Render for Tooltip {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = *cx.theme();
-        let at = window.mouse_position() + point(-OFFSET, OFFSET);
+        let at = window.mouse_position();
+        let (position, anchor) = match self.perch {
+            Perch::Pointer => (at + point(-OFFSET, OFFSET), Anchor::TopRight),
+            Perch::Above => (
+                point(at.x, at.y - theme.metrics.control_small),
+                Anchor::BottomCenter,
+            ),
+        };
 
         anchored()
-            .position(at)
-            .anchor(Anchor::TopRight)
+            .position(position)
+            .anchor(anchor)
             .snap_to_window_with_margin(MARGIN)
             .child(
                 div()

--- a/crates/views/src/chrome/player_bar.rs
+++ b/crates/views/src/chrome/player_bar.rs
@@ -145,7 +145,7 @@ impl PlayerBar {
             .ghost()
             .small()
             .icon("icons/shuffle.svg")
-            .tooltip("player-shuffle")
+            .tooltip_above("player-shuffle")
             .tint(match on {
                 true => theme.primary,
                 false => theme.muted_foreground,
@@ -166,7 +166,7 @@ impl PlayerBar {
                 Repeat::One => "icons/repeat-one.svg",
                 _ => "icons/repeat.svg",
             })
-            .tooltip(match repeat {
+            .tooltip_above(match repeat {
                 Repeat::Off => "player-repeat",
                 Repeat::All => "player-repeat-all",
                 Repeat::One => "player-repeat-one",
@@ -198,7 +198,7 @@ impl PlayerBar {
                     .ghost()
                     .small()
                     .icon(volume_icon(level))
-                    .tooltip(match level <= 0.001 {
+                    .tooltip_above(match level <= 0.001 {
                         true => "player-unmute",
                         false => "player-mute",
                     })
@@ -238,7 +238,7 @@ impl PlayerBar {
             .ghost()
             .small()
             .icon("icons/skip-back.svg")
-            .tooltip("player-previous")
+            .tooltip_above("player-previous")
             .disabled(!enabled)
             .on_click(cx.listener(|this, _, _, cx| {
                 this.playback
@@ -253,7 +253,7 @@ impl PlayerBar {
             .ghost()
             .small()
             .icon("icons/skip-forward.svg")
-            .tooltip("player-next")
+            .tooltip_above("player-next")
             .disabled(!enabled)
             .on_click(cx.listener(|this, _, _, cx| {
                 this.playback.update(cx, |playback, cx| playback.next(cx));
@@ -270,7 +270,7 @@ impl PlayerBar {
                 .hoverless()
                 .small()
                 .icon("icons/list.svg")
-                .tooltip("queue-title")
+                .tooltip_above("queue-title")
                 .selected(open)
                 .on_click(cx.listener(|this, _, _, cx| {
                     if let Some(sidebar_right) = &this.sidebar_right {
@@ -286,6 +286,7 @@ impl PlayerBar {
             .ghost()
             .small()
             .icon("icons/maximize.svg")
+            .tooltip_above("player-fullscreen")
             .on_click(|_, window, cx| window.dispatch_action(Box::new(ToggleFullscreen), cx))
     }
 
@@ -294,16 +295,17 @@ impl PlayerBar {
         let playing = matches!(state, PlaybackState::Playing);
         let idle = matches!(state, PlaybackState::Idle | PlaybackState::Failed(_));
 
-        let (id, icon) = if playing {
-            ("pause", "icons/pause.svg")
+        let (id, icon, tooltip) = if playing {
+            ("pause", "icons/pause.svg", "play-pause")
         } else {
-            ("play", "icons/play.svg")
+            ("play", "icons/play.svg", "play-resume")
         };
 
         Button::new(id)
             .ghost()
             .small()
             .icon(icon)
+            .tooltip_above(tooltip)
             .disabled(idle)
             .on_click(cx.listener(|this, _, _, cx| {
                 this.playback
@@ -324,6 +326,10 @@ impl PlayerBar {
             .icon(match saved {
                 true => "icons/heart-filled.svg",
                 false => "icons/heart.svg",
+            })
+            .tooltip_above(match saved {
+                true => "menu-remove-from-library",
+                false => "menu-add-to-library",
             })
             .tint(match saved {
                 true => theme.primary,

--- a/crates/views/src/chrome/player_bar.rs
+++ b/crates/views/src/chrome/player_bar.rs
@@ -145,6 +145,7 @@ impl PlayerBar {
             .ghost()
             .small()
             .icon("icons/shuffle.svg")
+            .tooltip("player-shuffle")
             .tint(match on {
                 true => theme.primary,
                 false => theme.muted_foreground,
@@ -164,6 +165,11 @@ impl PlayerBar {
             .icon(match repeat {
                 Repeat::One => "icons/repeat-one.svg",
                 _ => "icons/repeat.svg",
+            })
+            .tooltip(match repeat {
+                Repeat::Off => "player-repeat",
+                Repeat::All => "player-repeat-all",
+                Repeat::One => "player-repeat-one",
             })
             .tint(match repeat {
                 Repeat::Off => theme.muted_foreground,
@@ -192,6 +198,10 @@ impl PlayerBar {
                     .ghost()
                     .small()
                     .icon(volume_icon(level))
+                    .tooltip(match level <= 0.001 {
+                        true => "player-unmute",
+                        false => "player-mute",
+                    })
                     .tint(theme.muted_foreground)
                     .on_click(cx.listener(move |this, _, _, cx| {
                         let wanted = match level <= 0.001 {
@@ -228,6 +238,7 @@ impl PlayerBar {
             .ghost()
             .small()
             .icon("icons/skip-back.svg")
+            .tooltip("player-previous")
             .disabled(!enabled)
             .on_click(cx.listener(|this, _, _, cx| {
                 this.playback
@@ -242,6 +253,7 @@ impl PlayerBar {
             .ghost()
             .small()
             .icon("icons/skip-forward.svg")
+            .tooltip("player-next")
             .disabled(!enabled)
             .on_click(cx.listener(|this, _, _, cx| {
                 this.playback.update(cx, |playback, cx| playback.next(cx));
@@ -258,6 +270,7 @@ impl PlayerBar {
                 .hoverless()
                 .small()
                 .icon("icons/list.svg")
+                .tooltip("queue-title")
                 .selected(open)
                 .on_click(cx.listener(|this, _, _, cx| {
                     if let Some(sidebar_right) = &this.sidebar_right {

--- a/crates/views/src/chrome/sidebar_right.rs
+++ b/crates/views/src/chrome/sidebar_right.rs
@@ -39,11 +39,12 @@ fn section_label(key: &'static str, window: &Window, cx: &App) -> Div {
         .child(eyebrow(i18n::lookup(key, None), cx))
 }
 
-fn track(queue: &Queue, position: QueuePosition) -> Option<Track> {
+fn track(queue: &Queue, similar: &[Track], position: QueuePosition) -> Option<Track> {
     match position {
         QueuePosition::Past(index) => queue.past().nth(index).cloned(),
         QueuePosition::Current => queue.current().cloned(),
         QueuePosition::Upcoming(index) => queue.upcoming().nth(index).cloned(),
+        QueuePosition::Similar(index) => similar.get(index).cloned(),
     }
 }
 
@@ -67,6 +68,7 @@ enum QueuePosition {
     Past(usize),
     Current,
     Upcoming(usize),
+    Similar(usize),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -80,6 +82,7 @@ struct Sections {
     past: usize,
     current: bool,
     upcoming: usize,
+    similar: usize,
 }
 
 impl Sections {
@@ -94,9 +97,17 @@ impl Sections {
         self.past_end() + 2 * usize::from(self.current)
     }
 
-    fn len(self) -> usize {
+    fn upcoming_end(self) -> usize {
         self.current_end()
             + match self.upcoming {
+                0 => 0,
+                count => count + 1,
+            }
+    }
+
+    fn len(self) -> usize {
+        self.upcoming_end()
+            + match self.similar {
                 0 => 0,
                 count => count + 1,
             }
@@ -119,9 +130,15 @@ impl Sections {
                 false => Slot::Track(QueuePosition::Current),
             };
         }
-        match index == self.current_end() {
-            true => Slot::Header("queue-up-next"),
-            false => Slot::Track(QueuePosition::Upcoming(index - self.current_end() - 1)),
+        if index < self.upcoming_end() {
+            return match index == self.current_end() {
+                true => Slot::Header("queue-up-next"),
+                false => Slot::Track(QueuePosition::Upcoming(index - self.current_end() - 1)),
+            };
+        }
+        match index == self.upcoming_end() {
+            true => Slot::Header("queue-similar"),
+            false => Slot::Track(QueuePosition::Similar(index - self.upcoming_end() - 1)),
         }
     }
 }
@@ -144,14 +161,21 @@ impl QueuePosition {
     fn past(self) -> Option<usize> {
         match self {
             Self::Past(index) => Some(index),
-            Self::Current | Self::Upcoming(_) => None,
+            _ => None,
         }
     }
 
     fn upcoming(self) -> Option<usize> {
         match self {
             Self::Upcoming(index) => Some(index),
-            Self::Past(_) | Self::Current => None,
+            _ => None,
+        }
+    }
+
+    fn similar(self) -> Option<usize> {
+        match self {
+            Self::Similar(index) => Some(index),
+            _ => None,
         }
     }
 }
@@ -211,6 +235,7 @@ impl SidebarRight {
             cx.notify();
         })
         .detach();
+        cx.observe(&playback, |_, _, cx| cx.notify()).detach();
         let chrome = Chrome::entity(cx);
         cx.observe(&chrome, |_, _, cx| cx.notify()).detach();
 
@@ -302,10 +327,11 @@ impl SidebarRight {
         let theme = *cx.theme();
         let past_index = position.past();
         let queue_index = position.upcoming();
+        let similar_index = position.similar();
         let title = match position {
             QueuePosition::Past(_) => theme.muted_foreground,
             QueuePosition::Current => theme.primary,
-            QueuePosition::Upcoming(_) => theme.foreground,
+            QueuePosition::Upcoming(_) | QueuePosition::Similar(_) => theme.foreground,
         };
         let dragged = queue_index.map(|index| DraggedTrack {
             index,
@@ -366,6 +392,7 @@ impl SidebarRight {
                     .ghost()
                     .small()
                     .icon("icons/x.svg")
+                    .tooltip("menu-remove-from-queue")
                     .tint(theme.muted_foreground)
                     .on_click(cx.listener(move |this, _, _, cx| {
                         cx.stop_propagation();
@@ -403,6 +430,12 @@ impl SidebarRight {
                         }
                     });
                 }
+            }))
+        })
+        .when_some(similar_index, |this, target| {
+            this.press(cx.listener(move |this, _, _, cx| {
+                this.playback
+                    .update(cx, |playback, cx| playback.play_similar(target, cx));
             }))
         })
         .when_some(dragged, |this, dragged| {
@@ -466,6 +499,7 @@ impl SidebarRight {
                             .ghost()
                             .small()
                             .icon("icons/radio.svg")
+                            .tooltip("queue-radio")
                             .tint(match self.playback.read(cx).radio() {
                                 true => theme.primary,
                                 false => theme.muted_foreground,
@@ -521,6 +555,7 @@ impl SidebarRight {
 
     fn rows(&self, sections: Sections, cx: &mut Context<Self>) -> gpui::UniformList {
         let queue = self.queue.clone();
+        let playback = self.playback.clone();
         let drop_gap = self.drop_gap;
         let upcoming = sections.upcoming;
 
@@ -530,13 +565,14 @@ impl SidebarRight {
             cx.processor(move |_, range: Range<usize>, window, cx| {
                 let (revision, slots) = {
                     let queue = queue.read(cx);
+                    let similar = playback.read(cx).similar();
                     let slots = range
                         .clone()
                         .map(|index| {
                             let slot = sections.slot(index);
                             let found = match slot {
                                 Slot::Header(_) => None,
-                                Slot::Track(position) => track(queue, position),
+                                Slot::Track(position) => track(queue, similar, position),
                             };
                             (index, slot, found)
                         })
@@ -582,6 +618,7 @@ impl Render for SidebarRight {
             past: queue.past().len(),
             current: queue.current().is_some(),
             upcoming: queue.upcoming().len(),
+            similar: self.playback.read(cx).similar().len(),
         };
         let empty = sections.len() == 0;
         if !cx.has_active_drag() {
@@ -674,6 +711,7 @@ mod tests {
             past: 2,
             current: true,
             upcoming: 2,
+            similar: 2,
         };
 
         assert_eq!(sections.current_index(), Some(4));
@@ -688,6 +726,29 @@ mod tests {
                 Slot::Header("queue-up-next"),
                 Slot::Track(QueuePosition::Upcoming(0)),
                 Slot::Track(QueuePosition::Upcoming(1)),
+                Slot::Header("queue-similar"),
+                Slot::Track(QueuePosition::Similar(0)),
+                Slot::Track(QueuePosition::Similar(1)),
+            ]
+        );
+    }
+
+    #[test]
+    fn suggests_similar_tracks_without_anything_up_next() {
+        let sections = Sections {
+            past: 0,
+            current: true,
+            upcoming: 0,
+            similar: 1,
+        };
+
+        assert_eq!(
+            slots(sections),
+            [
+                Slot::Header("queue-now-playing"),
+                Slot::Track(QueuePosition::Current),
+                Slot::Header("queue-similar"),
+                Slot::Track(QueuePosition::Similar(0)),
             ]
         );
     }
@@ -698,6 +759,7 @@ mod tests {
             past: 0,
             current: true,
             upcoming: 1,
+            similar: 0,
         };
 
         assert_eq!(sections.current_index(), Some(1));
@@ -718,6 +780,7 @@ mod tests {
             past: 1,
             current: false,
             upcoming: 0,
+            similar: 0,
         };
 
         assert_eq!(sections.current_index(), None);
@@ -736,6 +799,7 @@ mod tests {
             past: 0,
             current: false,
             upcoming: 0,
+            similar: 0,
         };
 
         assert_eq!(sections.len(), 0);

--- a/crates/views/src/chrome/sidebar_right.rs
+++ b/crates/views/src/chrome/sidebar_right.rs
@@ -39,12 +39,12 @@ fn section_label(key: &'static str, window: &Window, cx: &App) -> Div {
         .child(eyebrow(i18n::lookup(key, None), cx))
 }
 
-fn track(queue: &Queue, similar: &[Track], position: QueuePosition) -> Option<Track> {
+fn track(queue: &Queue, position: QueuePosition) -> Option<Track> {
     match position {
         QueuePosition::Past(index) => queue.past().nth(index).cloned(),
         QueuePosition::Current => queue.current().cloned(),
         QueuePosition::Upcoming(index) => queue.upcoming().nth(index).cloned(),
-        QueuePosition::Similar(index) => similar.get(index).cloned(),
+        QueuePosition::Similar(index) => queue.similar().nth(index).cloned(),
     }
 }
 
@@ -434,9 +434,27 @@ impl SidebarRight {
         })
         .when_some(similar_index, |this, target| {
             this.press(cx.listener(move |this, _, _, cx| {
-                this.playback
-                    .update(cx, |playback, cx| playback.play_similar(target, cx));
+                if this.queue.read(cx).revision() == queue_revision {
+                    this.playback
+                        .update(cx, |playback, cx| playback.play_similar(target, cx));
+                }
             }))
+            .action(
+                Button::new(("remove-similar-track", index))
+                    .ghost()
+                    .small()
+                    .icon("icons/x.svg")
+                    .tooltip("menu-remove-from-queue")
+                    .tint(theme.muted_foreground)
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        cx.stop_propagation();
+                        this.queue.update(cx, |queue, cx| {
+                            if queue.revision() == queue_revision {
+                                queue.remove_similar(target, cx);
+                            }
+                        });
+                    })),
+            )
         })
         .when_some(dragged, |this, dragged| {
             this.on_drag(dragged, |dragged, position, _, cx| {
@@ -555,7 +573,6 @@ impl SidebarRight {
 
     fn rows(&self, sections: Sections, cx: &mut Context<Self>) -> gpui::UniformList {
         let queue = self.queue.clone();
-        let playback = self.playback.clone();
         let drop_gap = self.drop_gap;
         let upcoming = sections.upcoming;
 
@@ -565,14 +582,13 @@ impl SidebarRight {
             cx.processor(move |_, range: Range<usize>, window, cx| {
                 let (revision, slots) = {
                     let queue = queue.read(cx);
-                    let similar = playback.read(cx).similar();
                     let slots = range
                         .clone()
                         .map(|index| {
                             let slot = sections.slot(index);
                             let found = match slot {
                                 Slot::Header(_) => None,
-                                Slot::Track(position) => track(queue, similar, position),
+                                Slot::Track(position) => track(queue, position),
                             };
                             (index, slot, found)
                         })
@@ -618,7 +634,7 @@ impl Render for SidebarRight {
             past: queue.past().len(),
             current: queue.current().is_some(),
             upcoming: queue.upcoming().len(),
-            similar: self.playback.read(cx).similar().len(),
+            similar: queue.similar().len(),
         };
         let empty = sections.len() == 0;
         if !cx.has_active_drag() {

--- a/crates/views/src/chrome/title_bar.rs
+++ b/crates/views/src/chrome/title_bar.rs
@@ -86,6 +86,7 @@ impl TitleBar {
                 Button::new("history-back")
                     .ghost()
                     .icon("icons/chevron-left.svg")
+                    .tooltip("nav-back")
                     .tint(muted)
                     .disabled(!can_back)
                     .size_8()
@@ -103,6 +104,7 @@ impl TitleBar {
                 Button::new("history-forward")
                     .ghost()
                     .icon("icons/chevron-right.svg")
+                    .tooltip("nav-forward")
                     .tint(muted)
                     .disabled(!can_forward)
                     .size_8()
@@ -136,6 +138,7 @@ impl TitleBar {
                     .flex()
                     .small()
                     .icon(icon)
+                    .tooltip("nav-sidebar")
                     .on_click(cx.listener(|_, _, _, cx| cx.emit(TitleBarEvent::ToggleSidebar))),
             )
     }

--- a/crates/views/src/chrome/toolbar.rs
+++ b/crates/views/src/chrome/toolbar.rs
@@ -142,6 +142,10 @@ impl Render for Toolbar {
                             true => "icons/x.svg",
                             false => "icons/search.svg",
                         })
+                        .tooltip(match self.open {
+                            true => "common-dismiss",
+                            false => "common-search",
+                        })
                         .small()
                         .ghost()
                         .on_click(cx.listener(|this, _, window, cx| this.toggle(window, cx))),

--- a/crates/views/src/chrome/tools.rs
+++ b/crates/views/src/chrome/tools.rs
@@ -51,6 +51,7 @@ pub(crate) fn columns(
         .button(
             Button::new("columns-toggle")
                 .icon("icons/columns-3.svg")
+                .tooltip("tool-columns")
                 .small()
                 .ghost(),
         )
@@ -85,6 +86,7 @@ pub(crate) fn sorts(
         .button(
             Button::new("sort-toggle")
                 .icon("icons/arrow-up-down.svg")
+                .tooltip("tool-sort")
                 .small()
                 .ghost()
                 .tint(match sorted {
@@ -190,6 +192,7 @@ pub(crate) fn filters(
         .button(
             Button::new("filters-toggle")
                 .icon("icons/funnel.svg")
+                .tooltip("tool-filters")
                 .small()
                 .ghost()
                 .tint(match narrowed {
@@ -226,6 +229,7 @@ pub(crate) fn views(
 
     Button::new("view-toggle")
         .icon(next.icon())
+        .tooltip(next.key())
         .small()
         .ghost()
         .on_click(move |_, _, cx| {

--- a/crates/views/src/screens/artist.rs
+++ b/crates/views/src/screens/artist.rs
@@ -217,7 +217,8 @@ impl ArtistView {
                 .button(
                     Button::new("artist-overflow-button")
                         .outline()
-                        .icon("icons/ellipsis.svg"),
+                        .icon("icons/ellipsis.svg")
+                        .tooltip("common-more"),
                 )
                 .menu(
                     artist_menu(id.to_owned())

--- a/crates/views/src/screens/detail.rs
+++ b/crates/views/src/screens/detail.rs
@@ -274,7 +274,8 @@ impl DetailView {
                 .button(
                     Button::new("detail-overflow-button")
                         .outline()
-                        .icon("icons/ellipsis.svg"),
+                        .icon("icons/ellipsis.svg")
+                        .tooltip("common-more"),
                 )
                 .menu(menu.top(theme.metrics.control).left_0())
         });

--- a/crates/views/src/screens/home/quick_picks.rs
+++ b/crates/views/src/screens/home/quick_picks.rs
@@ -138,6 +138,7 @@ impl RenderOnce for QuickPicks {
                                     .small()
                                     .outline()
                                     .icon("icons/chevron-left.svg")
+                                    .tooltip("common-previous")
                                     .disabled(empty || page == 0)
                                     .when_some(on_previous, |button, handler| {
                                         button.on_click(move |event, window, cx| {
@@ -150,6 +151,7 @@ impl RenderOnce for QuickPicks {
                                     .small()
                                     .outline()
                                     .icon("icons/chevron-right.svg")
+                                    .tooltip("common-next")
                                     .disabled(empty || page + 1 >= pages)
                                     .when_some(on_next, |button, handler| {
                                         button.on_click(move |event, window, cx| {

--- a/crates/views/src/screens/library/mod.rs
+++ b/crates/views/src/screens/library/mod.rs
@@ -810,6 +810,7 @@ impl Tooled for LibraryView {
         let create = (self.section == Section::Playlists).then(|| {
             Button::new("new-playlist")
                 .icon("icons/plus.svg")
+                .tooltip("menu-new-playlist")
                 .small()
                 .ghost()
                 .on_click(move |_, window, cx| {

--- a/crates/views/src/shared/tracks/mod.rs
+++ b/crates/views/src/shared/tracks/mod.rs
@@ -238,6 +238,10 @@ impl TrackSource {
                     true => "icons/heart-filled.svg",
                     false => "icons/heart.svg",
                 })
+                .tooltip(match saved {
+                    true => "menu-remove-from-library",
+                    false => "menu-add-to-library",
+                })
                 .tint(match saved {
                     true => theme.primary,
                     false => theme.muted_foreground,


### PR DESCRIPTION
## Summary

- show what radio will play next under a Similar tracks section in the queue panel, seeded from the last queued track
- play a suggested track immediately when it is clicked, and consume the suggestions when the queue runs out
- add a tooltip primitive anchored top-right of the pointer and snapped inside the window
- add a `tooltip` builder to the button primitive and put tooltips on every icon-only control
- closes #52