### PR TITLE
fix(playback): keep radio from reseeding on every similar track

### DIFF
--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -501,7 +501,7 @@ impl Playback {
     }
 
     fn suggest_similar(&mut self, cx: &mut Context<Self>) {
-        if !self.radio {
+        if !self.radio || self.queue.read(cx).similar().len() > 0 {
             return;
         }
         let Some(id) = self.seed(cx).and_then(|seed| seed.id) else {


### PR DESCRIPTION
## Summary

- generate the similar-track set once per activation instead of per played track
- stop rewriting the queue panel radio list while it still has tracks