### PR TITLE
feat(ui): add a separator primitive

### DIFF
--- a/crates/ui/src/info_card.rs
+++ b/crates/ui/src/info_card.rs
@@ -2,10 +2,11 @@
 
 use gpui::prelude::*;
 use gpui::{
-    AnyElement, App, Div, FontWeight, Interactivity, SharedString, StyleRefinement, Window, div, px,
+    AnyElement, App, Div, FontWeight, Interactivity, SharedString, StyleRefinement, Window, div,
 };
 
 use crate::label::eyebrow;
+use crate::separator::Separator;
 use crate::theme::ActiveTheme as _;
 
 #[derive(IntoElement)]
@@ -89,7 +90,7 @@ impl RenderOnce for InfoCard {
                     .items_center()
                     .gap_3()
                     .child(eyebrow(title, cx))
-                    .child(div().h(px(1.)).flex_1().bg(theme.border)),
+                    .child(Separator::horizontal().flex_1()),
             )
             .children(children);
 

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -22,6 +22,7 @@ mod popup;
 mod scrollbar;
 mod scroller;
 mod scrubber;
+mod separator;
 mod shield;
 mod skeleton;
 mod theme;
@@ -61,6 +62,7 @@ pub use popup::Popup;
 pub use scrollbar::{Scrollbar, scrolled};
 pub use scroller::Scroller;
 pub use scrubber::{Scrubber, ScrubberState};
+pub use separator::Separator;
 pub use shield::Shield;
 pub use skeleton::{Initials, Skeleton};
 pub use theme::{

--- a/crates/ui/src/menu.rs
+++ b/crates/ui/src/menu.rs
@@ -14,6 +14,7 @@ use gpui::{
 use crate::Artwork;
 use crate::metrics::snapped;
 use crate::scrollbar::Scrollbar;
+use crate::separator::Separator;
 use crate::shield::Shield;
 use crate::theme::ActiveTheme as _;
 
@@ -387,14 +388,7 @@ impl RenderOnce for Menu {
             }
 
             if separator {
-                return div()
-                    .id(id)
-                    .h(px(1.))
-                    .flex_none()
-                    .mx_2()
-                    .my_1()
-                    .bg(theme.border)
-                    .into_any_element();
+                return Separator::horizontal().mx_2().my_1().into_any_element();
             }
             let action = action.clone();
             let press_action = action.clone();

--- a/crates/ui/src/separator.rs
+++ b/crates/ui/src/separator.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use gpui::prelude::*;
+use gpui::{App, Div, Interactivity, Pixels, StyleRefinement, Window, div, px};
+
+use crate::theme::ActiveTheme as _;
+
+const THICKNESS: Pixels = px(1.);
+
+#[derive(Clone, Copy, PartialEq)]
+enum Axis {
+    Horizontal,
+    Vertical,
+}
+
+#[derive(IntoElement)]
+pub struct Separator {
+    base: Div,
+    axis: Axis,
+}
+
+impl Separator {
+    #[track_caller]
+    pub fn horizontal() -> Self {
+        Self {
+            base: div(),
+            axis: Axis::Horizontal,
+        }
+    }
+
+    #[track_caller]
+    pub fn vertical() -> Self {
+        Self {
+            base: div(),
+            axis: Axis::Vertical,
+        }
+    }
+}
+
+impl Styled for Separator {
+    fn style(&mut self) -> &mut StyleRefinement {
+        self.base.style()
+    }
+}
+
+impl InteractiveElement for Separator {
+    fn interactivity(&mut self) -> &mut Interactivity {
+        self.base.interactivity()
+    }
+}
+
+impl RenderOnce for Separator {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let Self { mut base, axis } = self;
+        let theme = cx.theme();
+        let overrides = std::mem::take(base.style());
+
+        let mut separator = base.flex_none().bg(theme.border).when_else(
+            axis == Axis::Horizontal,
+            |this| this.h(THICKNESS),
+            |this| this.w(THICKNESS),
+        );
+        separator.style().refine(&overrides);
+        separator
+    }
+}

--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -2,8 +2,8 @@
 
 use gpui::prelude::*;
 use gpui::{
-    AnyElement, App, Context, ElementId, Entity, FontWeight, Hsla, MouseButton, Pixels, Point,
-    Render, ScrollHandle, SharedString, Window, div, px,
+    AnyElement, App, Context, ElementId, Entity, FontWeight, MouseButton, Pixels, Point, Render,
+    ScrollHandle, SharedString, Window, div, px,
 };
 use i18n::t;
 use router::{Destination, navigate};
@@ -14,7 +14,7 @@ use crate::chrome::Chrome;
 use crate::shared::menu::ItemMenu;
 use state::{Hit, Kind, Playback, Search};
 use ui::ActiveTheme as _;
-use ui::{Card, Popup, Room, Scrollbar, Scroller, Text, Theme, VAST, clock, eyebrow};
+use ui::{Card, Popup, Room, Scrollbar, Scroller, Separator, Text, Theme, VAST, clock, eyebrow};
 
 use crate::shared::cells;
 use crate::shared::tracks::{PlaybackStatus, playback_status};
@@ -412,10 +412,6 @@ fn noun(kind: Kind) -> SharedString {
     }
 }
 
-fn divider(color: Hsla) -> impl IntoElement {
-    div().flex_none().w(px(1.)).bg(color)
-}
-
 impl Render for SearchView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = *cx.theme();
@@ -443,9 +439,9 @@ impl Render for SearchView {
                 .flex_1()
                 .min_h_0()
                 .child(self.column(Kind::Song, cx))
-                .child(divider(theme.border))
+                .child(Separator::vertical())
                 .child(self.column(Kind::Artist, cx))
-                .child(divider(theme.border))
+                .child(Separator::vertical())
                 .child(self.column(Kind::Album, cx))
                 .into_any_element(),
         };

--- a/crates/views/src/screens/settings.rs
+++ b/crates/views/src/screens/settings.rs
@@ -12,7 +12,8 @@ use state::{AppSettings, Playback, Session, SessionState, Sonora};
 use ui::{ActiveTheme as _, Scrollbar, Scroller};
 use ui::{
     Avatar, Button, InfoCard, Initials, Look, MAX_FONT, MAX_TRANSPARENCY, MIN_FONT, Menu, MenuItem,
-    Popover, Popovers, Rounding, Scrubber, ScrubberState, Skeleton, Text, Theme, ThemeKind,
+    Popover, Popovers, Rounding, Scrubber, ScrubberState, Separator, Skeleton, Text, Theme,
+    ThemeKind,
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -142,7 +143,6 @@ impl SettingsView {
     }
 
     fn panel(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let border = cx.theme().border;
         let rows: Vec<AnyElement> = match self.tab {
             Tab::Appearance => vec![
                 self.theme_row(cx).into_any_element(),
@@ -180,7 +180,7 @@ impl SettingsView {
         let mut panel = div().flex().flex_col();
         for (index, row) in rows.into_iter().enumerate() {
             if index > 0 {
-                panel = panel.child(div().h(px(1.)).w_full().bg(border));
+                panel = panel.child(Separator::horizontal().w_full());
             }
             panel = panel.child(row);
         }
@@ -876,8 +876,6 @@ fn open_settings_file(path: &Path) -> std::io::Result<()> {
 
 impl Render for SettingsView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let border = cx.theme().border;
-
         Scroller::new("settings", &self.scrollbar)
             .flex()
             .flex_col()
@@ -891,7 +889,7 @@ impl Render for SettingsView {
                     .max_w(px(640.))
                     .p_6()
                     .child(self.profile(cx))
-                    .child(div().h(px(1.)).w_full().bg(border))
+                    .child(Separator::horizontal().w_full())
                     .child(self.tabs(cx))
                     .child(self.panel(cx))
                     .when(self.tab == Tab::About, |this| {


### PR DESCRIPTION
## Summary

- add a horizontal and vertical separator element to the design system
- replace the ad-hoc divider divs in search, settings, info cards and menus with it