### PR TITLE
fix(views): reserve room for the search result duration

### DIFF
--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -153,7 +153,9 @@ impl SearchView {
                     .trailing(
                         div()
                             .flex_none()
+                            .w(cells::TRAILING)
                             .whitespace_nowrap()
+                            .text_right()
                             .text_size(theme.text(Text::Small))
                             .text_color(theme.muted_foreground)
                             .child(clock(track.duration)),


### PR DESCRIPTION
## Summary

- give the search result duration a fixed slot so it stops wrapping onto a second line
- align the duration to the right of that slot