### PR TITLE
feat(views): mark library removal with a crossed-out heart

### DIFF
--- a/assets/icons/heart-off.svg
+++ b/assets/icons/heart-off.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10.5 4.893a5.5 5.5 0 0 1 1.091.931.56.56 0 0 0 .818 0A5.49 5.49 0 0 1 22 9.5c0 1.872-1.002 3.356-2.187 4.655" />
+  <path d="m16.967 16.967-3.459 3.346a2 2 0 0 1-3 .019L5 15c-1.5-1.5-3-3.2-3-5.5a5.5 5.5 0 0 1 2.747-4.761" />
+  <path d="m2 2 20 20" />
+</svg>

--- a/crates/sonora/src/assets.rs
+++ b/crates/sonora/src/assets.rs
@@ -58,6 +58,7 @@ const ICONS: &[(&str, &[u8])] = icons![
     "circle-check",
     "heart",
     "heart-filled",
+    "heart-off",
     "house",
     "info",
     "layout-grid",

--- a/crates/views/src/shared/menu.rs
+++ b/crates/views/src/shared/menu.rs
@@ -206,7 +206,10 @@ impl ItemMenu {
                         false => t!("menu-add-to-library"),
                     },
                 )
-                .icon("icons/heart.svg")
+                .icon(match saved {
+                    true => "icons/heart-off.svg",
+                    false => "icons/heart.svg",
+                })
                 .on_click(move |_, _, cx| {
                     library.update(cx, |library, cx| library.toggle(track.clone(), cx));
                 })
@@ -416,7 +419,7 @@ pub(crate) fn playlist_menu(
         false => vec![
             MenuItem::separator("playlist-actions"),
             MenuItem::new("leave-playlist", t!("menu-remove-playlist-from-library"))
-                .icon("icons/heart.svg")
+                .icon("icons/heart-off.svg")
                 .on_click(move |_, _, cx| {
                     let library = Sonora::global(cx).library.clone();
                     library.update(cx, |library, cx| {


### PR DESCRIPTION
## Summary

- add the lucide heart-off icon
- use it for removing a track or a playlist from the library, keeping the plain heart for adding