### PR TITLE
fix(views): play the list as it is shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The Play button on a page plays the list as it is shown, so filtering or sorting no longer starts
+  a track that is not in view.
 - Clicking a dropdown trigger below the title bar closes its menu instead of leaving it open.
 - Releases on the artist page answer to a right-click with the album menu.
 - The percentage and timecode bubbles no longer appear below a slider, where a click would not land.

--- a/crates/views/src/screens/artist.rs
+++ b/crates/views/src/screens/artist.rs
@@ -21,7 +21,9 @@ use crate::shared::album_grid::{AlbumGrid, CardGrid};
 use crate::shared::hero::{HeroMetaStrip, HeroPlayButton, PageHero};
 use crate::shared::menu::{album_menu, artist_menu};
 use crate::shared::page;
-use crate::shared::tracks::{PlaybackStatus, TrackField, TrackSource, Tracks, playback_status};
+use crate::shared::tracks::{
+    self, PlaybackStatus, TrackField, TrackSource, Tracks, playback_status,
+};
 
 const SECTION: &str = "artist";
 const END_WIDTH: Pixels = px(72.);
@@ -408,7 +410,7 @@ impl ArtistView {
             .child(HeroPlayButton::new(
                 "play-artist",
                 t!("artist-play"),
-                self.detail.read(cx).tracks().to_vec(),
+                tracks::ordered(&self.table, cx),
                 self.playback.clone(),
             ))
             .children(overflow);

--- a/crates/views/src/screens/detail.rs
+++ b/crates/views/src/screens/detail.rs
@@ -21,7 +21,7 @@ use crate::chrome::tools::{self, Sift, Sliders};
 use crate::chrome::{Chrome, Searchable, Toolbar, Tooled};
 use crate::shared::hero::{HeroMetaStrip, HeroPlayButton, PageHero, release_date_label};
 use crate::shared::tracks::{
-    PlaybackStatus, TrackField, TrackSieve, TrackSource, Tracks, playback_status,
+    self, PlaybackStatus, TrackField, TrackSieve, TrackSource, Tracks, playback_status,
 };
 use crate::shared::{cells, page};
 
@@ -242,8 +242,8 @@ impl DetailView {
             .unwrap_or_default();
         let release_date = header.and_then(|header| header.release_date.as_deref());
         let meta = header.map(|header| header.meta.clone()).unwrap_or_default();
-        let queued = self.detail.read(cx).tracks().to_vec();
-        let duration: std::time::Duration = queued.iter().map(|track| track.duration).sum();
+        let listed = self.detail.read(cx).tracks();
+        let duration: std::time::Duration = listed.iter().map(|track| track.duration).sum();
         let (eyebrow, label) = match kind {
             Collection::Playlist => (t!("detail-playlist"), t!("detail-play-playlist")),
             Collection::Album => (t!("detail-album"), t!("detail-play-album")),
@@ -286,7 +286,7 @@ impl DetailView {
             .child(HeroPlayButton::new(
                 "play-detail",
                 label,
-                queued,
+                tracks::ordered(&self.table, cx),
                 self.playback.clone(),
             ))
             .children(overflow);

--- a/crates/views/src/screens/library/mod.rs
+++ b/crates/views/src/screens/library/mod.rs
@@ -385,9 +385,9 @@ impl LibraryView {
     }
 
     fn liked_header(&self, cx: &Context<Self>) -> AnyElement {
-        let queued = self.liked(cx);
-        let duration: std::time::Duration = queued.iter().map(|track| track.duration).sum();
-        let mut strip = HeroMetaStrip::new().text(t!("count-songs", count = queued.len()));
+        let liked = self.liked(cx);
+        let duration: std::time::Duration = liked.iter().map(|track| track.duration).sum();
+        let mut strip = HeroMetaStrip::new().text(t!("count-songs", count = liked.len()));
         if !duration.is_zero() {
             strip = strip.text(clock(duration));
         }
@@ -400,7 +400,7 @@ impl LibraryView {
             .actions(HeroPlayButton::new(
                 "play-liked-songs",
                 t!("library-play-liked-songs"),
-                queued,
+                tracks::ordered(&self.tracks, cx),
                 self.playback.clone(),
             ))
             .into_any_element()


### PR DESCRIPTION
## Summary

- play the list as it is shown, so the Play button on library, album, playlist and artist pages
  respects the active filter and sort
- keep the song count and total duration in a page header reporting the full list

Closes #111
