### PR TITLE
feat(views): add sidebar settings tabs

### DIFF
--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -15,6 +15,14 @@ pub enum LibraryTab {
     Playlists,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SettingsTab {
+    Appearance,
+    Playback,
+    Account,
+    About,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Destination {
     Home,
@@ -24,13 +32,14 @@ pub enum Destination {
     Playlist(SharedString),
     Artist(SharedString),
     Search,
-    Settings,
+    Settings(SettingsTab),
 }
 
 impl Destination {
     pub fn same_section(&self, other: &Destination) -> bool {
         match (self, other) {
-            (Destination::Library(_), Destination::Library(_)) => true,
+            (Destination::Library(_), Destination::Library(_))
+            | (Destination::Settings(_), Destination::Settings(_)) => true,
             _ => self == other,
         }
     }

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -26,6 +26,7 @@ mod separator;
 mod shield;
 mod skeleton;
 mod switch;
+mod tabs;
 mod theme;
 mod time;
 mod toast;
@@ -67,6 +68,7 @@ pub use separator::Separator;
 pub use shield::Shield;
 pub use skeleton::{Initials, Skeleton};
 pub use switch::Switch;
+pub use tabs::Tabs;
 pub use theme::{
     ActiveTheme, Look, MAX_FONT, MAX_TRANSPARENCY, MIN_FONT, Theme, ThemeKind, ThemeOverrides,
 };

--- a/crates/ui/src/tabs.rs
+++ b/crates/ui/src/tabs.rs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use gpui::prelude::*;
+use gpui::{AnyElement, App, Div, StyleRefinement, Window, div, px};
+
+use crate::theme::ActiveTheme as _;
+
+const LINE: f32 = 1.;
+const TICK: f32 = 6.;
+
+#[derive(IntoElement)]
+pub struct Tabs {
+    base: Div,
+    items: Vec<AnyElement>,
+}
+
+impl Tabs {
+    pub fn new() -> Self {
+        Self {
+            base: div(),
+            items: Vec::new(),
+        }
+    }
+
+    pub fn items(mut self, items: impl IntoIterator<Item = impl IntoElement>) -> Self {
+        self.items = items
+            .into_iter()
+            .map(IntoElement::into_any_element)
+            .collect();
+        self
+    }
+}
+
+impl Styled for Tabs {
+    fn style(&mut self) -> &mut StyleRefinement {
+        self.base.style()
+    }
+}
+
+impl RenderOnce for Tabs {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let Self { mut base, items } = self;
+        let theme = cx.theme();
+        let height = theme.metrics.control;
+        let middle = height / 2.;
+        let border = theme.sidebar_border;
+        let overrides = std::mem::take(base.style());
+
+        let mut tabs = base
+            .relative()
+            .flex()
+            .flex_col()
+            .gap_1()
+            .ml_4()
+            .child(
+                div()
+                    .absolute()
+                    .left_0()
+                    .top_0()
+                    .bottom(middle)
+                    .w(px(LINE))
+                    .bg(border),
+            )
+            .children(items.into_iter().map(|item| {
+                div()
+                    .relative()
+                    .flex()
+                    .items_center()
+                    .h(height)
+                    .pl_3()
+                    .child(
+                        div()
+                            .absolute()
+                            .left_0()
+                            .top(middle)
+                            .w(px(TICK))
+                            .h(px(LINE))
+                            .bg(border),
+                    )
+                    .child(div().flex().flex_1().child(item))
+            }));
+
+        tabs.style().refine(&overrides);
+        tabs
+    }
+}

--- a/crates/views/src/chrome/sidebar_left.rs
+++ b/crates/views/src/chrome/sidebar_left.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use ui::{ActiveTheme as _, Button, MIN_CONTENT, Panel, SNUG, Shield, Side};
+use ui::{ActiveTheme as _, Button, MIN_CONTENT, Panel, SNUG, Shield, Side, Tabs};
 
 use gpui::prelude::*;
 use gpui::{
     AnyElement, Context, ElementId, Entity, Hsla, MouseButton, MouseDownEvent, Pixels, Render,
 };
 use gpui::{Window, div, px};
-use router::{Destination, LibraryTab, Navigation, NavigationEvent, navigate};
+use router::{Destination, LibraryTab, Navigation, NavigationEvent, SettingsTab, navigate};
 use state::{AppSettings, Sonora};
 
 const NAV: [(&str, &str, Option<Destination>); 4] = [
@@ -21,14 +21,21 @@ const NAV: [(&str, &str, Option<Destination>); 4] = [
     (
         "nav-settings",
         "icons/settings.svg",
-        Some(Destination::Settings),
+        Some(Destination::Settings(SettingsTab::Appearance)),
     ),
 ];
 
-const TABS: [(&str, LibraryTab); 3] = [
+const LIBRARY_TABS: [(&str, LibraryTab); 3] = [
     ("nav-songs", LibraryTab::Songs),
     ("nav-albums", LibraryTab::Albums),
     ("nav-playlists", LibraryTab::Playlists),
+];
+
+const SETTINGS_TABS: [(&str, SettingsTab); 4] = [
+    ("settings-tab-appearance", SettingsTab::Appearance),
+    ("settings-tab-playback", SettingsTab::Playback),
+    ("settings-tab-account", SettingsTab::Account),
+    ("settings-tab-about", SettingsTab::About),
 ];
 
 const MIN_WIDTH: Pixels = px(160.);
@@ -43,6 +50,7 @@ pub(crate) struct SidebarLeft {
     cramped: bool,
     forced: Option<bool>,
     library_open: bool,
+    settings_open: bool,
 }
 
 impl SidebarLeft {
@@ -65,6 +73,7 @@ impl SidebarLeft {
             forced: None,
             cramped: false,
             library_open: true,
+            settings_open: false,
         }
     }
 
@@ -149,7 +158,7 @@ impl Render for SidebarLeft {
         let muted = theme.muted_foreground;
         let sidebar_bg = theme.sidebar;
         let sidebar_border = theme.sidebar_border;
-        let nav = theme.metrics.control;
+
         let current = self.trail.read(cx).current();
         self.adapt(window, cx);
 
@@ -175,51 +184,60 @@ impl Render for SidebarLeft {
                 );
 
                 if self.library_open {
-                    let middle = nav / 2.;
-
                     rows.push(
-                        div()
-                            .relative()
-                            .flex()
-                            .flex_col()
-                            .gap_1()
-                            .ml_4()
-                            .child(
-                                div()
-                                    .absolute()
-                                    .left_0()
-                                    .top_0()
-                                    .bottom(middle)
-                                    .w(px(1.))
-                                    .bg(sidebar_border),
-                            )
-                            .children(TABS.into_iter().map(|(name, tab)| {
+                        Tabs::new()
+                            .items(LIBRARY_TABS.into_iter().map(|(name, tab)| {
                                 let chosen = current == Destination::Library(tab);
                                 let tint = if chosen { foreground } else { muted };
 
-                                div()
-                                    .relative()
-                                    .flex()
-                                    .items_center()
-                                    .h(nav)
-                                    .pl_3()
-                                    .child(
-                                        div()
-                                            .absolute()
-                                            .left_0()
-                                            .top(middle)
-                                            .w(px(6.))
-                                            .h(px(1.))
-                                            .bg(sidebar_border),
-                                    )
-                                    .child(
-                                        nav_row(name, name, tint, sidebar_accent)
-                                            .flex_1()
-                                            .when(chosen, |button| button.bg(sidebar_accent))
-                                            .on_click(move |_, _, cx| {
-                                                navigate(Destination::Library(tab), cx)
-                                            }),
-                                    )
+                                nav_row(name, name, tint, sidebar_accent)
+                                    .flex_1()
+                                    .when(chosen, |button| button.bg(sidebar_accent))
+                                    .on_click(move |_, _, cx| {
+                                        navigate(Destination::Library(tab), cx)
+                                    })
+                            }))
+                            .into_any_element(),
+                    );
+                }
+                continue;
+            }
+
+            if matches!(destination, Some(Destination::Settings(_))) {
+                let inside = matches!(current, Destination::Settings(_));
+                let text = if inside { foreground } else { muted };
+                let link_destination = if inside { None } else { destination };
+                let target = link_destination.unwrap_or(current.clone());
+
+                rows.push(
+                    nav_row(index, key, text, sidebar_accent)
+                        .icon(icon)
+                        .on_click(cx.listener(move |this, _, _, cx| match inside {
+                            true => {
+                                this.settings_open = !this.settings_open;
+                                cx.notify();
+                            }
+                            false => {
+                                this.settings_open = true;
+                                navigate(target.clone(), cx);
+                            }
+                        }))
+                        .into_any_element(),
+                );
+
+                if self.settings_open {
+                    rows.push(
+                        Tabs::new()
+                            .items(SETTINGS_TABS.into_iter().map(|(name, tab)| {
+                                let chosen = current == Destination::Settings(tab);
+                                let tint = if chosen { foreground } else { muted };
+
+                                nav_row(name, name, tint, sidebar_accent)
+                                    .flex_1()
+                                    .when(chosen, |button| button.bg(sidebar_accent))
+                                    .on_click(move |_, _, cx| {
+                                        navigate(Destination::Settings(tab), cx)
+                                    })
                             }))
                             .into_any_element(),
                     );

--- a/crates/views/src/root.rs
+++ b/crates/views/src/root.rs
@@ -4,7 +4,7 @@ use gpui::{AnyView, Context, Entity, MouseButton, NavigationDirection, Render};
 use gpui::{Window, div};
 use gpui::{font, prelude::*};
 use input::{OpenFilter, OpenSearch, OpenSettings, ToggleFullscreen};
-use router::{Destination, NavigationEvent, back, forward, navigate};
+use router::{Destination, NavigationEvent, SettingsTab, back, forward, navigate};
 use state::{
     ArtistDetail, Detail, Home, Io, Library, Playback, Queue, Search, Session, SessionState,
     SongDetail,
@@ -228,7 +228,7 @@ impl Root {
     }
 
     fn open_settings(&mut self, cx: &mut Context<Self>) {
-        navigate(Destination::Settings, cx);
+        navigate(Destination::Settings(SettingsTab::Appearance), cx);
         self.pending = Some(Focus::Workspace);
         cx.notify();
     }
@@ -279,7 +279,12 @@ impl Root {
                 artist.into()
             }
             Destination::Search => self.screens.search.clone().into(),
-            Destination::Settings => self.screens.settings.clone().into(),
+            Destination::Settings(tab) => {
+                self.screens
+                    .settings
+                    .update(cx, |settings, cx| settings.select(tab, cx));
+                self.screens.settings.clone().into()
+            }
         };
 
         self.toolbar = toolbar;

--- a/crates/views/src/screens/settings.rs
+++ b/crates/views/src/screens/settings.rs
@@ -8,6 +8,7 @@ use gpui::{
 };
 use gpui::{ScrollHandle, prelude::*};
 use i18n::{Language, t};
+use router::SettingsTab;
 use state::{AppSettings, Playback, Session, SessionState, Sonora};
 use ui::{ActiveTheme as _, Scrollbar, Scroller};
 use ui::{
@@ -68,41 +69,11 @@ const MEMBERS: [Member; 5] = [
     member!("imizgun", Role::Contributor),
 ];
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum Tab {
-    Appearance,
-    Playback,
-    Account,
-    About,
-}
-
-impl Tab {
-    const ALL: [Self; 4] = [Self::Appearance, Self::Playback, Self::Account, Self::About];
-
-    fn id(self) -> &'static str {
-        match self {
-            Self::Appearance => "tab-appearance",
-            Self::Playback => "tab-playback",
-            Self::Account => "tab-account",
-            Self::About => "tab-about",
-        }
-    }
-
-    fn label(self) -> SharedString {
-        match self {
-            Self::Appearance => t!("settings-tab-appearance"),
-            Self::Playback => t!("settings-tab-playback"),
-            Self::Account => t!("settings-tab-account"),
-            Self::About => t!("settings-tab-about"),
-        }
-    }
-}
-
 pub struct SettingsView {
     session: Entity<Session>,
     playback: Entity<Playback>,
     settings: Entity<AppSettings>,
-    tab: Tab,
+    tab: SettingsTab,
     scrollbar: Entity<Scrollbar>,
     transparency: ScrubberState,
     popovers: Popovers,
@@ -121,30 +92,22 @@ impl SettingsView {
             session,
             playback,
             settings,
-            tab: Tab::Appearance,
+            tab: SettingsTab::Appearance,
             scrollbar: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
             transparency: ScrubberState::new("transparency"),
             popovers: Popovers::default(),
         }
     }
 
-    fn tabs(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        div().flex().gap_1().children(Tab::ALL.map(|tab| {
-            Button::new(tab.id())
-                .label(tab.label())
-                .small()
-                .selected(self.tab == tab)
-                .on_click(cx.listener(move |this, _, _, cx| {
-                    this.tab = tab;
-                    this.popovers.close();
-                    cx.notify();
-                }))
-        }))
+    pub(crate) fn select(&mut self, tab: SettingsTab, cx: &mut Context<Self>) {
+        self.tab = tab;
+        self.popovers.close();
+        cx.notify();
     }
 
     fn panel(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let rows: Vec<AnyElement> = match self.tab {
-            Tab::Appearance => vec![
+            SettingsTab::Appearance => vec![
                 self.theme_row(cx).into_any_element(),
                 self.transparent_row(cx).into_any_element(),
             ]
@@ -165,12 +128,12 @@ impl SettingsView {
             .chain(decorated().then(|| self.decorations_row(cx).into_any_element()))
             .chain(decorated().then(|| self.side_row(cx).into_any_element()))
             .collect(),
-            Tab::Playback => vec![
+            SettingsTab::Playback => vec![
                 self.playback_row(cx).into_any_element(),
                 self.gapless_row(cx).into_any_element(),
             ],
-            Tab::Account => vec![self.account_row(cx).into_any_element()],
-            Tab::About => vec![
+            SettingsTab::Account => vec![self.account_row(cx).into_any_element()],
+            SettingsTab::About => vec![
                 self.version_row(cx).into_any_element(),
                 self.license_row(cx).into_any_element(),
                 self.source_row(cx).into_any_element(),
@@ -870,9 +833,8 @@ impl Render for SettingsView {
                     .p_6()
                     .child(self.profile(cx))
                     .child(Separator::horizontal().w_full())
-                    .child(self.tabs(cx))
                     .child(self.panel(cx))
-                    .when(self.tab == Tab::About, |this| {
+                    .when(self.tab == SettingsTab::About, |this| {
                         this.child(self.team(cx)).child(self.notice(cx))
                     }),
             )


### PR DESCRIPTION
## Summary

- extract nested sidebar tabs into a reusable UI component
- add routed appearance, playback, account, and about settings tabs
- keep library tabs expanded and settings tabs collapsed by default
- expand settings tabs when opening settings from the sidebar