### PR TITLE
fix(views): say when a list is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - The Play button on a page plays the list as it is shown, so filtering or sorting no longer starts
   a track that is not in view.
+- An empty library section says so instead of showing a bare table, and a filter that matches
+  nothing says that too.
+- Quick picks asks you to like a few songs once the library has loaded, instead of pulsing
+  placeholders forever.
+- The no-matches note in search lines up with the results above it.
 - Clicking a dropdown trigger below the title bar closes its menu instead of leaving it open.
 - Releases on the artist page answer to a right-click with the album menu.
 - The percentage and timecode bubbles no longer appear below a slider, where a click would not land.

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -30,6 +30,10 @@ nav-forward = Forward
 nav-sidebar = Toggle sidebar
 library-liked-songs = Liked Songs
 library-play-liked-songs = Play
+library-no-songs = No liked songs yet
+library-no-albums = No saved albums yet
+library-no-playlists = No playlists yet
+library-no-matches = No matches
 
 # app menu
 app-refresh-library = Refresh Library
@@ -169,6 +173,7 @@ release-meta = { $year } • { $kind }
 # home page
 home-quick-picks = Quick picks
 home-quick-picks-eyebrow = Start from a song
+home-quick-picks-empty = Like a few songs and they will show up here
 
 # search page
 search-placeholder = What do you want to listen to?

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -30,6 +30,10 @@ nav-forward = Dalej
 nav-sidebar = Pokaż lub ukryj panel boczny
 library-liked-songs = Polubione utwory
 library-play-liked-songs = Odtwórz
+library-no-songs = Brak polubionych utworów
+library-no-albums = Brak zapisanych albumów
+library-no-playlists = Brak playlist
+library-no-matches = Brak wyników
 
 # app menu
 app-refresh-library = Odśwież bibliotekę
@@ -170,6 +174,7 @@ release-meta = { $year } • { $kind }
 # home page
 home-quick-picks = Szybki wybór
 home-quick-picks-eyebrow = Zacznij od utworu
+home-quick-picks-empty = Polub kilka utworów, a pojawią się tutaj
 
 # search page
 search-placeholder = Czego chcesz posłuchać?

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -30,6 +30,10 @@ nav-forward = Вперёд
 nav-sidebar = Показать или скрыть боковую панель
 library-liked-songs = Любимые треки
 library-play-liked-songs = Слушать
+library-no-songs = Пока нет любимых треков
+library-no-albums = Пока нет сохранённых альбомов
+library-no-playlists = Пока нет плейлистов
+library-no-matches = Ничего не найдено
 
 # app menu
 app-refresh-library = Обновить медиатеку
@@ -170,6 +174,7 @@ release-meta = { $year } • { $kind }
 # home page
 home-quick-picks = Быстрый выбор
 home-quick-picks-eyebrow = Начните с трека
+home-quick-picks-empty = Добавьте несколько треков, и они появятся здесь
 
 # search page
 search-placeholder = Что хотите послушать?

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -30,6 +30,10 @@ nav-forward = Вперед
 nav-sidebar = Показати або сховати бічну панель
 library-liked-songs = Вподобані пісні
 library-play-liked-songs = Слухати
+library-no-songs = Поки немає вподобаних треків
+library-no-albums = Поки немає збережених альбомів
+library-no-playlists = Поки немає плейлистів
+library-no-matches = Нічого не знайдено
 
 # app menu
 app-refresh-library = Оновити медіатеку
@@ -170,6 +174,7 @@ release-meta = { $year } • { $kind }
 # home page
 home-quick-picks = Швидкий вибір
 home-quick-picks-eyebrow = Почніть із треку
+home-quick-picks-empty = Додайте кілька треків, і вони з'являться тут
 
 # search page
 search-placeholder = Що хочете послухати?

--- a/crates/state/src/home.rs
+++ b/crates/state/src/home.rs
@@ -12,6 +12,7 @@ const GROUP_SIZE: usize = 12;
 const LIMIT: usize = GROUP_SIZE * 3;
 
 pub struct Home {
+    library: Entity<Library>,
     quick_picks: Rc<Vec<Track>>,
     quick_picks_seed: u64,
 }
@@ -36,6 +37,7 @@ impl Home {
         .detach();
 
         Self {
+            library,
             quick_picks,
             quick_picks_seed,
         }
@@ -43,6 +45,10 @@ impl Home {
 
     pub fn quick_picks(&self) -> Rc<Vec<Track>> {
         self.quick_picks.clone()
+    }
+
+    pub fn is_loading(&self, cx: &App) -> bool {
+        self.library.read(cx).is_loading()
     }
 }
 

--- a/crates/ui/src/grid/mod.rs
+++ b/crates/ui/src/grid/mod.rs
@@ -1000,6 +1000,8 @@ pub trait Table {
     fn set_sorting(&self, sorting: Option<Sorting>, cx: &mut App);
     fn sortables(&self, cx: &App) -> Vec<SortAxis>;
     fn cycle_sort(&self, column: &str, cx: &mut App);
+    fn row_count(&self, cx: &App) -> usize;
+    fn filtering(&self, cx: &App) -> bool;
     fn toggles(&self, cx: &App) -> Vec<Toggle>;
     fn set_width(&self, width: Pixels, cx: &mut App);
     fn set_filter(&self, query: &str, cx: &mut App);
@@ -1047,6 +1049,15 @@ impl<S: GridSource> Table for Entity<GridState<S>> {
 
     fn toggles(&self, cx: &App) -> Vec<Toggle> {
         self.read(cx).delegate().toggles()
+    }
+
+    fn row_count(&self, cx: &App) -> usize {
+        self.read(cx).delegate().row_count()
+    }
+
+    fn filtering(&self, cx: &App) -> bool {
+        let delegate = self.read(cx).delegate();
+        !delegate.query().is_empty() || delegate.source().filtered(cx)
     }
 
     fn set_width(&self, width: Pixels, cx: &mut App) {

--- a/crates/ui/src/label.rs
+++ b/crates/ui/src/label.rs
@@ -21,6 +21,21 @@ pub fn upper(label: impl Into<SharedString>) -> SharedString {
     label.into().to_uppercase().into()
 }
 
+pub fn vacant(label: impl Into<SharedString>, cx: &App) -> Div {
+    let theme = cx.theme();
+
+    div()
+        .flex()
+        .w_full()
+        .items_center()
+        .justify_center()
+        .p(theme.metrics.pad * 2.)
+        .text_align(gpui::TextAlign::Center)
+        .text_size(theme.text(Text::Body))
+        .text_color(theme.muted_foreground)
+        .child(label.into())
+}
+
 pub fn heading(label: impl Into<SharedString>, cx: &App) -> Div {
     div()
         .flex_none()

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -53,7 +53,7 @@ pub use input::{
     Input, Left, Paste, Right, SelectAll, SelectEnd, SelectHome, SelectLeft, SelectRight,
     SelectWordLeft, SelectWordRight, Space, WordLeft, WordRight,
 };
-pub use label::{eyebrow, heading, upper};
+pub use label::{eyebrow, heading, upper, vacant};
 pub use layout::{ALWAYS, MIN_CONTENT, ROOMY, Room, SNUG, VAST, WIDE};
 pub use menu::{Menu, MenuItem, SubmenuState};
 pub use metrics::{LEADING, Metrics, Rounding, Text, snapped};

--- a/crates/views/src/chrome/sidebar_right.rs
+++ b/crates/views/src/chrome/sidebar_right.rs
@@ -14,7 +14,7 @@ use spotify::Track;
 use state::{AppSettings, Playback, Queue, Sonora};
 use ui::{
     ActiveTheme as _, Button, Card, MIN_CONTENT, Panel, Popup, Room, Scrollbar, Side, Text,
-    eyebrow, snapped,
+    eyebrow, snapped, vacant,
 };
 
 use crate::chrome::Chrome;
@@ -673,15 +673,7 @@ impl Render for SidebarRight {
                     .flex_1()
                     .min_h_0()
                     .when(empty, |this| {
-                        this.child(
-                            div()
-                                .flex()
-                                .flex_1()
-                                .items_center()
-                                .justify_center()
-                                .text_color(theme.muted_foreground)
-                                .child(t!("queue-empty")),
-                        )
+                        this.child(vacant(t!("queue-empty"), cx).flex_1())
                     })
                     .when(!empty, |this| {
                         this.child(

--- a/crates/views/src/screens/home/mod.rs
+++ b/crates/views/src/screens/home/mod.rs
@@ -108,6 +108,7 @@ impl Render for HomeView {
                         available,
                         page,
                     )
+                    .loading(self.home.read(cx).is_loading(cx))
                     .on_previous(cx.listener(|this, _, _, cx| {
                         this.quick_picks_page = this.quick_picks_page.saturating_sub(1);
                         this.context_menu = None;

--- a/crates/views/src/screens/home/quick_picks.rs
+++ b/crates/views/src/screens/home/quick_picks.rs
@@ -9,7 +9,7 @@ use gpui::{
 use i18n::t;
 use spotify::Track;
 use state::Playback;
-use ui::{ActiveTheme as _, Button, Card, Text, eyebrow, heading};
+use ui::{ActiveTheme as _, Button, Card, Text, eyebrow, heading, vacant};
 
 use crate::shared::cells;
 
@@ -37,6 +37,7 @@ pub(crate) struct QuickPicks {
     active: Option<String>,
     width: Pixels,
     page: usize,
+    loading: bool,
     on_previous: Option<ClickHandler>,
     on_next: Option<ClickHandler>,
     on_context_menu: Option<ContextHandler>,
@@ -56,10 +57,16 @@ impl QuickPicks {
             active,
             width,
             page,
+            loading: false,
             on_previous: None,
             on_next: None,
             on_context_menu: None,
         }
+    }
+
+    pub(crate) fn loading(mut self, loading: bool) -> Self {
+        self.loading = loading;
+        self
     }
 
     pub(crate) fn on_previous(
@@ -98,6 +105,7 @@ impl RenderOnce for QuickPicks {
         let end = (start + page_size).min(self.tracks.len());
         let tracks = self.tracks;
         let empty = tracks.is_empty();
+        let barren = empty && !self.loading;
         let on_previous = self.on_previous;
         let on_next = self.on_next;
         let on_context_menu = self.on_context_menu;
@@ -161,37 +169,42 @@ impl RenderOnce for QuickPicks {
                             ),
                     ),
             )
-            .child(div().flex().gap_2().p_2().when_else(
-                empty,
-                |this| {
-                    this.children((0..columns).map(|column| {
-                        column_shell(column, theme.border).children(
-                            (0..ROWS_PER_COLUMN)
-                                .map(|row| skeleton(column * ROWS_PER_COLUMN + row)),
-                        )
-                    }))
-                },
-                |this| {
-                    this.children(tracks[start..end].chunks(ROWS_PER_COLUMN).enumerate().map(
-                        |(column, column_tracks)| {
+            .when(barren, |this| {
+                this.child(vacant(t!("home-quick-picks-empty"), cx))
+            })
+            .when(!barren, |this| {
+                this.child(div().flex().gap_2().p_2().when_else(
+                    empty,
+                    |this| {
+                        this.children((0..columns).map(|column| {
                             column_shell(column, theme.border).children(
-                                column_tracks.iter().enumerate().map(|(row, track)| {
-                                    let place = start + column * ROWS_PER_COLUMN + row;
-                                    pick(
-                                        track,
-                                        place,
-                                        tracks.clone(),
-                                        self.playback.clone(),
-                                        self.active.as_deref(),
-                                        on_context_menu.clone(),
-                                        cx,
-                                    )
-                                }),
+                                (0..ROWS_PER_COLUMN)
+                                    .map(|row| skeleton(column * ROWS_PER_COLUMN + row)),
                             )
-                        },
-                    ))
-                },
-            ))
+                        }))
+                    },
+                    |this| {
+                        this.children(tracks[start..end].chunks(ROWS_PER_COLUMN).enumerate().map(
+                            |(column, column_tracks)| {
+                                column_shell(column, theme.border).children(
+                                    column_tracks.iter().enumerate().map(|(row, track)| {
+                                        let place = start + column * ROWS_PER_COLUMN + row;
+                                        pick(
+                                            track,
+                                            place,
+                                            tracks.clone(),
+                                            self.playback.clone(),
+                                            self.active.as_deref(),
+                                            on_context_menu.clone(),
+                                            cx,
+                                        )
+                                    }),
+                                )
+                            },
+                        ))
+                    },
+                ))
+            })
     }
 }
 

--- a/crates/views/src/screens/library/mod.rs
+++ b/crates/views/src/screens/library/mod.rs
@@ -23,7 +23,7 @@ use state::{AppSettings, Library, LibraryState, Origin, Playback, PlaybackState,
 use ui::{
     ActiveTheme as _, Button, Card, FlagAxis, GridDelegate, GridEvent, GridSource, GridState, Menu,
     MenuItem, Mode, Popovers, Popup, RangeAxis, Scrollbar, Scroller, Sort, SortAxis, Text, Toggle,
-    Unit, Viewport, clock, grid, heading, scrolled,
+    Unit, Viewport, clock, grid, heading, scrolled, vacant,
 };
 
 use crate::shared::album_grid::{AlbumGrid, CARD_MAX, CardGrid};
@@ -99,6 +99,14 @@ impl Section {
             Section::Tracks => 0,
             Section::Albums => 1,
             Section::Playlists => 2,
+        }
+    }
+
+    fn vacancy(self) -> &'static str {
+        match self {
+            Section::Tracks => "library-no-songs",
+            Section::Albums => "library-no-albums",
+            Section::Playlists => "library-no-playlists",
         }
     }
 }
@@ -344,6 +352,22 @@ impl LibraryView {
 
     pub fn is_loading(&self, cx: &App) -> bool {
         self.library.read(cx).is_loading()
+    }
+
+    fn note(&self, cx: &App) -> Option<SharedString> {
+        let settled = !matches!(
+            self.library.read(cx).state(),
+            LibraryState::Loading | LibraryState::Failed(_)
+        );
+        let table = self.table(self.section);
+        if !settled || table.row_count(cx) > 0 {
+            return None;
+        }
+
+        Some(match table.filtering(cx) {
+            true => t!("library-no-matches"),
+            false => i18n::lookup(self.section.vacancy(), None),
+        })
     }
 
     pub fn refresh(&mut self, cx: &mut Context<Self>) {
@@ -732,17 +756,23 @@ impl Render for LibraryView {
         });
         let view = cx.entity().downgrade();
         let section = self.section;
+        let note = self.note(cx);
         let content = match (self.section, mode) {
             (Section::Tracks, Mode::List) => Scroller::new("library-page", &self.scrollbar)
                 .pt(inset)
                 .pb(inset)
                 .child(div().px(inset).child(self.liked_header(cx)))
                 .child(grid(&self.tracks))
+                .when_some(note, |this, note| this.child(vacant(note, cx)))
                 .into_any_element(),
             (_, Mode::List) => Scroller::new("library-page", &self.scrollbar)
                 .child(self.table(self.section).element())
+                .when_some(note, |this, note| this.child(vacant(note, cx)))
                 .into_any_element(),
-            (_, Mode::Cards) => self.cards(window, cx),
+            (_, Mode::Cards) => match note {
+                Some(note) => vacant(note, cx).size_full().into_any_element(),
+                None => self.cards(window, cx),
+            },
         };
 
         div()

--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -14,7 +14,9 @@ use crate::chrome::Chrome;
 use crate::shared::menu::ItemMenu;
 use state::{Hit, Kind, Playback, Search};
 use ui::ActiveTheme as _;
-use ui::{Card, Popup, Room, Scrollbar, Scroller, Separator, Text, Theme, VAST, clock, eyebrow};
+use ui::{
+    Card, Popup, Room, Scrollbar, Scroller, Separator, Text, Theme, VAST, clock, eyebrow, vacant,
+};
 
 use crate::shared::cells;
 use crate::shared::tracks::{PlaybackStatus, playback_status};
@@ -293,10 +295,8 @@ impl SearchView {
         cx: &Context<Self>,
     ) -> AnyElement {
         if rows.is_empty() {
-            return div()
+            return vacant(t!("search-no-matches"), cx)
                 .flex_none()
-                .text_color(cx.theme().muted_foreground)
-                .child(t!("search-no-matches"))
                 .into_any_element();
         }
 


### PR DESCRIPTION
## Summary

- say when a library section, the queue, search or quick picks has nothing to show, through one
  shared element so the wording and styling match everywhere
- tell an empty library section apart from a filter that matched nothing
- keep quick picks on placeholders only while the library is loading

Closes #61
Closes #62
