### PR TITLE
chore: present the app as Sonora

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- The app presents itself as Sonora rather than sonora, in the window title, the application menu
+  and the Windows file properties.
+
 ## [0.5.0] - 2026-08-09
 
 ### Added

--- a/assets/linux/sonora.desktop
+++ b/assets/linux/sonora.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Name=sonora
+Name=Sonora
 GenericName=Music Player
 Comment=An unofficial minimal native Spotify client
 Icon=sonora

--- a/crates/sonora/build.rs
+++ b/crates/sonora/build.rs
@@ -10,6 +10,8 @@ fn main() {
         println!("cargo:rerun-if-changed={icon}");
         let mut resource = winresource::WindowsResource::new();
         resource.set_icon(icon);
+        resource.set("ProductName", "Sonora");
+        resource.set("FileDescription", "Sonora");
         if let Err(error) = resource.compile() {
             println!("cargo:warning=cannot embed the windows icon: {error}");
         }

--- a/crates/sonora/src/main.rs
+++ b/crates/sonora/src/main.rs
@@ -90,7 +90,7 @@ fn open_window(
             window_bounds: Some(WindowBounds::Windowed(bounds)),
             window_background: WindowBackgroundAppearance::Transparent,
             titlebar: Some(TitlebarOptions {
-                title: Some("sonora".into()),
+                title: Some("Sonora".into()),
                 appears_transparent: true,
                 traffic_light_position: Some(point(
                     px(9.),

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "sonora - a minimal native Spotify client";
+  description = "Sonora - a minimal native Spotify client";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";


### PR DESCRIPTION
## Summary

- capitalise the window title, the desktop entry name and the flake description
- name the product Sonora in the Windows executable properties

## Notes

Identifiers stay lowercase on purpose: the executable, `Exec`, `Icon`, `StartupWMClass`, the Wayland app id, the nix pname and the cask token all have to keep matching the files and each other. The macOS bundle already carried `Sonora` in `CFBundleName` and `CFBundleDisplayName`.