### PR TITLE
fix(sonora): give debug builds their own instance socket

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,7 @@ them unless the task is about them.
 | Settings          | `$XDG_CONFIG_HOME/sonora/settings.json`                            |
 | Credentials cache | `$XDG_CACHE_HOME/sonora/credentials.json`                          |
 | OAuth redirect    | `http://127.0.0.1:8989/login`, override with `SONORA_REDIRECT_URI` |
+| Instance socket   | `sonora.sock`, `sonora-dev.sock` in debug builds, so `cargo run` starts beside an installed Sonora rather than handing over to it |
 | Log file          | `$XDG_STATE_HOME/sonora/sonora.log`, rotated to `.1` past 8 MiB    |
 | Console logging   | `RUST_LOG`; default filter `warn,symphonia=error`                  |
 | File logging      | `SONORA_LOG`; default adds `sonora=debug,ui=debug`                 |

--- a/crates/sonora/src/single.rs
+++ b/crates/sonora/src/single.rs
@@ -7,7 +7,10 @@ use interprocess::local_socket::traits::{ListenerExt as _, Stream as _};
 use interprocess::local_socket::{GenericNamespaced, ListenerOptions, Stream, ToNsName};
 use tokio::sync::mpsc::UnboundedSender;
 
-const SOCKET: &str = "sonora.sock";
+const SOCKET: &str = match cfg!(debug_assertions) {
+    true => "sonora-dev.sock",
+    false => "sonora.sock",
+};
 
 pub enum Instance {
     First,


### PR DESCRIPTION
## Summary

- name the single-instance socket per build profile, so a debug build starts beside an installed Sonora instead of handing its arguments over and exiting
- leave `spotify:` link handover to the installed build, since a dev build now listens on its own socket
