### PR TITLE
fix(playback): handle account-level audio key denial

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3717,8 +3717,7 @@ dependencies = [
 [[package]]
 name = "librespot-audio"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3fe76acb49f58165484303edf0e7bd778f0e6d96f5c59e9d6b6fde1a90d36ff"
+source = "git+https://github.com/nolight132/librespot?rev=81b99cf12a29ba2915894f24d67aec85a963dc06#81b99cf12a29ba2915894f24d67aec85a963dc06"
 dependencies = [
  "aes",
  "bytes",
@@ -3737,8 +3736,7 @@ dependencies = [
 [[package]]
 name = "librespot-core"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168bbe1c416980ddd9a969ebd6b50fb6c924eb1a3ded194285fa8ec0e2b1c68b"
+source = "git+https://github.com/nolight132/librespot?rev=81b99cf12a29ba2915894f24d67aec85a963dc06#81b99cf12a29ba2915894f24d67aec85a963dc06"
 dependencies = [
  "aes",
  "base64",
@@ -3794,8 +3792,7 @@ dependencies = [
 [[package]]
 name = "librespot-metadata"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9c688aa2acd3ed2498e31a95d6f2be49c0f18128db8958450ffd628aa88532"
+source = "git+https://github.com/nolight132/librespot?rev=81b99cf12a29ba2915894f24d67aec85a963dc06#81b99cf12a29ba2915894f24d67aec85a963dc06"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3812,8 +3809,7 @@ dependencies = [
 [[package]]
 name = "librespot-oauth"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d686417d49c9d2c363392ffe28d6e469daca20a82dc414740930e078f5829661"
+source = "git+https://github.com/nolight132/librespot?rev=81b99cf12a29ba2915894f24d67aec85a963dc06#81b99cf12a29ba2915894f24d67aec85a963dc06"
 dependencies = [
  "log",
  "oauth2",
@@ -3826,8 +3822,7 @@ dependencies = [
 [[package]]
 name = "librespot-playback"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88258620bf3e6808ea1fadd11639648d77c06280b9f5a4c9d14ea79f6f998af6"
+source = "git+https://github.com/nolight132/librespot?rev=81b99cf12a29ba2915894f24d67aec85a963dc06#81b99cf12a29ba2915894f24d67aec85a963dc06"
 dependencies = [
  "cpal",
  "form_urlencoded",
@@ -3850,8 +3845,7 @@ dependencies = [
 [[package]]
 name = "librespot-protocol"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e01f0b2d39f83fa162eb91d4a16313bcf99e77daf258abe8f7b7bcb1160b084"
+source = "git+https://github.com/nolight132/librespot?rev=81b99cf12a29ba2915894f24d67aec85a963dc06#81b99cf12a29ba2915894f24d67aec85a963dc06"
 dependencies = [
  "protobuf",
  "protobuf-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,14 @@ tokio = { version = "1.53", features = [
   "sync",
 ] }
 
+[patch.crates-io]
+librespot-audio = { git = "https://github.com/nolight132/librespot", rev = "81b99cf12a29ba2915894f24d67aec85a963dc06" }
+librespot-core = { git = "https://github.com/nolight132/librespot", rev = "81b99cf12a29ba2915894f24d67aec85a963dc06" }
+librespot-metadata = { git = "https://github.com/nolight132/librespot", rev = "81b99cf12a29ba2915894f24d67aec85a963dc06" }
+librespot-oauth = { git = "https://github.com/nolight132/librespot", rev = "81b99cf12a29ba2915894f24d67aec85a963dc06" }
+librespot-playback = { git = "https://github.com/nolight132/librespot", rev = "81b99cf12a29ba2915894f24d67aec85a963dc06" }
+librespot-protocol = { git = "https://github.com/nolight132/librespot", rev = "81b99cf12a29ba2915894f24d67aec85a963dc06" }
+
 [profile.dev]
 split-debuginfo = "unpacked"
 

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -339,3 +339,5 @@ toast-next-album = Album plays next
 toast-queued-playlist = Playlist added to the queue
 toast-next-playlist = Playlist plays next
 toast-queue-failed = That could not be added to the queue
+toast-keys-refused = Spotify is not granting this account playback keys
+toast-track-unplayable = { $name } could not be played

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -342,3 +342,5 @@ toast-next-album = Album zabrzmi następny
 toast-queued-playlist = Playlistę dodano do kolejki
 toast-next-playlist = Playlista zabrzmi następna
 toast-queue-failed = Nie udało się dodać do kolejki
+toast-keys-refused = Spotify nie udziela temu kontu kluczy odtwarzania
+toast-track-unplayable = Nie udało się odtworzyć { $name }

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -342,3 +342,5 @@ toast-next-album = Альбом прозвучит следующим
 toast-queued-playlist = Плейлист добавлен в очередь
 toast-next-playlist = Плейлист прозвучит следующим
 toast-queue-failed = Не удалось добавить в очередь
+toast-keys-refused = Spotify не выдаёт этому аккаунту ключи воспроизведения
+toast-track-unplayable = Не удалось воспроизвести { $name }

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -342,3 +342,5 @@ toast-next-album = Альбом прозвучить наступним
 toast-queued-playlist = Плейлист додано до черги
 toast-next-playlist = Плейлист прозвучить наступним
 toast-queue-failed = Не вдалося додати до черги
+toast-keys-refused = Spotify не надає цьому обліковому запису ключі відтворення
+toast-track-unplayable = Не вдалося відтворити { $name }

--- a/crates/audio/src/lib.rs
+++ b/crates/audio/src/lib.rs
@@ -32,6 +32,7 @@ pub enum AudioEvent {
     Position(Duration),
     Ended,
     Unavailable,
+    Refused,
 }
 
 pub struct AudioEvents(UnboundedReceiver<PlayerEvent>);
@@ -136,6 +137,7 @@ fn translate(event: PlayerEvent) -> Option<AudioEvent> {
             Some(AudioEvent::Position(millis(position_ms)))
         }
         PlayerEvent::Stopped { .. } | PlayerEvent::EndOfTrack { .. } => Some(AudioEvent::Ended),
+        PlayerEvent::Unavailable { denied: true, .. } => Some(AudioEvent::Refused),
         PlayerEvent::Unavailable { .. } => Some(AudioEvent::Unavailable),
         _ => None,
     }

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -107,6 +107,7 @@ pub struct Playback {
     preloaded: Option<String>,
     skipped: Option<Instant>,
     blocked_until: Option<Instant>,
+    refused: bool,
 }
 
 impl EventEmitter<PlaybackEvent> for Playback {}
@@ -159,6 +160,7 @@ impl Playback {
             preloaded: None,
             skipped: None,
             blocked_until: None,
+            refused: false,
         }
     }
 
@@ -190,6 +192,9 @@ impl Playback {
     fn load_after(&mut self, track: &Track, start: Start, cx: &mut Context<Self>) {
         if self.engine.is_none() {
             return;
+        }
+        if self.refused {
+            return self.refuse(cx);
         }
         let Some(id) = track.id.clone() else {
             return self.failed(format!("{} has no track id", track.name), cx);
@@ -854,16 +859,20 @@ impl Playback {
                 self.advance(ended, cx);
             }
             AudioEvent::Unavailable => {
-                let name = self.track.as_ref().map(|track| track.name.as_str());
+                let failed = self.track.take();
+                let name = failed.map_or_else(|| "?".to_owned(), |track| track.name);
                 log::warn!(
-                    "playback: {} failed to load, backing off {}s",
-                    name.unwrap_or("?"),
+                    "playback: {name} failed to load, backing off {}s",
                     KEY_COOLDOWN.as_secs()
                 );
                 self.blocked_until = Some(Instant::now() + KEY_COOLDOWN);
                 self.state = PlaybackState::Idle;
                 self.position = Duration::ZERO;
-                self.track = None;
+                Toasts::about(Note::Failed, "toast-track-unplayable", name, cx);
+                cx.emit(PlaybackEvent::EndedPlayback);
+            }
+            AudioEvent::Refused => {
+                self.refuse(cx);
                 cx.emit(PlaybackEvent::EndedPlayback);
             }
         }
@@ -880,6 +889,7 @@ impl Playback {
         self.preloaded = None;
         self.skipped = None;
         self.blocked_until = None;
+        self.refused = false;
         self.engine = None;
         self.track = None;
         self.origin = None;
@@ -891,6 +901,25 @@ impl Playback {
     fn failed(&mut self, problem: String, cx: &mut Context<Self>) {
         log::error!("playback: {problem}");
         self.state = PlaybackState::Failed(problem);
+        cx.notify();
+    }
+
+    fn refuse(&mut self, cx: &mut Context<Self>) {
+        let first = !self.refused;
+        self.refused = true;
+        self.track = None;
+        self.blocked_until = None;
+        self.state = PlaybackState::Failed(
+            "spotify denied an audio key for this account; nothing will play in this session"
+                .to_owned(),
+        );
+        if first {
+            log::error!(
+                "playback: spotify denied an audio key for this account; nothing will play in \
+                 this session"
+            );
+        }
+        Toasts::show(Note::Failed, "toast-keys-refused", cx);
         cx.notify();
     }
 }

--- a/crates/state/src/toast.rs
+++ b/crates/state/src/toast.rs
@@ -73,6 +73,14 @@ impl Toasts {
         name: Option<SharedString>,
         cx: &mut Context<Self>,
     ) {
+        let showing = self
+            .shown
+            .iter()
+            .any(|toast| toast.note == note && toast.key == key && toast.name == name);
+        if showing {
+            return;
+        }
+
         let id = self.next;
         self.next += 1;
         self.shown.push(Toast {


### PR DESCRIPTION
## Summary

- pin librespot to the `nolight132/librespot@81b99cf` fork, which preserves the `AesKeyError` code, maps a denial (`0x0001`) to `PermissionDenied`, and hardens packet parsing against short packets
- stop playback immediately when Spotify denies an audio key instead of downloading the file and feeding ciphertext to Symphonia
- surface an account-level key denial as a clear, localized toast and a fast, quiet failure rather than repeated multi-second skips
- dedupe identical toasts so a per-track failure notice cannot stack