### PR TITLE
fix: make YouTube Music playlist editing work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   mistake no longer leaves the login screen waiting for input.
 - Signing out of one service switches to another service still connected, and only falls back to the
   login screen once nothing is connected.
+- YouTube Music playlists you own are recognised as yours, so renaming, changing visibility and
+  deleting are offered instead of an unsupported "remove from library" that always failed.
+- Creating a YouTube Music playlist reports success instead of an error, and the new playlist
+  appears straight away rather than after a refresh.
+- Removing a track from a YouTube Music playlist works for tracks whose music video was swapped for
+  its album audio.
+- A YouTube Music playlist you own no longer lists its privacy setting as its owner.
 - The player switches to the next YouTube Music track the moment the previous one ends, instead of
   lagging up to half a second behind the audio.
 - A YouTube Music session whose saved cookies stopped working falls back to guest browsing or the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9233,7 +9233,7 @@ dependencies = [
 [[package]]
 name = "ytmusic"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/ytmusic-rs?rev=33268d6d8ad7fcfe19ae560d3fdc150608b84b92#33268d6d8ad7fcfe19ae560d3fdc150608b84b92"
+source = "git+https://github.com/nolight132/ytmusic-rs?rev=b2847291da1a5119a7e4e70c75ade80dd9ecb29e#b2847291da1a5119a7e4e70c75ade80dd9ecb29e"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ serde_json = "1.0"
 souvlaki = "0.8"
 sys-locale = "0.3"
 unic-langid = { version = "0.9", features = ["macros"] }
-ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "33268d6d8ad7fcfe19ae560d3fdc150608b84b92" }
+ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "b2847291da1a5119a7e4e70c75ade80dd9ecb29e" }
 
 librespot-core = { version = "0.8.0", default-features = false, features = [
   "rustls-tls-native-roots",

--- a/crates/music/src/youtube/client.rs
+++ b/crates/music/src/youtube/client.rs
@@ -18,11 +18,20 @@ const PORTRAIT_LIMIT: usize = 24;
 
 pub struct YouTubeClient {
     api: Arc<YtMusic>,
+    account: String,
 }
 
 impl YouTubeClient {
     pub fn new(api: Arc<YtMusic>) -> Self {
-        Self { api }
+        Self {
+            api,
+            account: String::new(),
+        }
+    }
+
+    pub fn owned_by(mut self, account: impl Into<String>) -> Self {
+        self.account = account.into();
+        self
     }
 
     async fn hydrate_durations(&self, tracks: &mut [ytmusic::Track]) {
@@ -172,7 +181,13 @@ impl MusicApi for YouTubeClient {
             .library_playlists()
             .await?
             .into_iter()
-            .map(|playlist| wire::playlist(playlist, false, false))
+            .map(|playlist| {
+                let mut playlist = wire::playlist(playlist, false, false);
+                if playlist.owned && playlist.owner.is_empty() {
+                    playlist.owner = self.account.clone();
+                }
+                playlist
+            })
             .collect();
         playlists.truncate(limit as usize);
         Ok(playlists)
@@ -207,15 +222,24 @@ impl MusicApi for YouTubeClient {
     }
 
     async fn remove_track_from_playlist(&self, playlist_id: &str, track_id: &str) -> Result<()> {
-        let detail = self.api.playlist(playlist_id).await?;
-        let set_video_id = detail
-            .tracks
-            .iter()
-            .find(|track| track.video_id.as_deref() == Some(track_id))
-            .and_then(|track| track.set_video_id.clone())
-            .context("track is not in the playlist")?;
+        let tracks = self.api.playlist(playlist_id).await?.tracks;
+        let seat = |list: &[ytmusic::Track]| {
+            list.iter()
+                .position(|track| track.video_id.as_deref() == Some(track_id))
+        };
+        let index = match seat(&tracks) {
+            Some(index) => index,
+            None => seat(&self.api.swap_playable(tracks.clone()).await)
+                .context("track is not in the playlist")?,
+        };
+        let track = tracks.get(index).context("track is not in the playlist")?;
+        let video_id = track.video_id.as_deref().context("track has no video id")?;
+        let set_video_id = track
+            .set_video_id
+            .as_deref()
+            .context("track cannot be removed from this playlist")?;
         self.api
-            .remove_playlist_track(playlist_id, track_id, &set_video_id)
+            .remove_playlist_track(playlist_id, video_id, set_video_id)
             .await
     }
 

--- a/crates/music/src/youtube/mod.rs
+++ b/crates/music/src/youtube/mod.rs
@@ -42,9 +42,10 @@ impl YouTubeProvider {
     }
 
     fn authenticated_session(&self, api: Arc<YtMusic>, profile: UserProfile) -> ProviderSession {
+        let client = YouTubeClient::new(api.clone()).owned_by(profile.display_name.clone());
         ProviderSession {
             profile,
-            api: Arc::new(YouTubeClient::new(api.clone())),
+            api: Arc::new(client),
             playback: Arc::new(Factory::new(api)),
             authenticated: true,
             playcounts: false,

--- a/crates/music/src/youtube/wire.rs
+++ b/crates/music/src/youtube/wire.rs
@@ -98,7 +98,7 @@ pub fn playlist(source: ytmusic::Playlist, owned: bool, public: bool) -> Playlis
         owner: source.author.unwrap_or_default(),
         owned: owned || source.owned,
         collaborative: false,
-        public,
+        public: source.public.unwrap_or(public),
         cover: cover(&source.thumbnails),
         track_count: source.track_count.unwrap_or(0),
     }

--- a/crates/state/src/library.rs
+++ b/crates/state/src/library.rs
@@ -244,7 +244,20 @@ impl Library {
                 if let Some(track) = track {
                     client.add_track_to_playlist(&id, &track).await?;
                 }
-                client.playlist(&id).await.map(|detail| detail.playlist)
+                let fetched = client.playlist(&id).await.map(|detail| detail.playlist);
+                Ok(fetched.unwrap_or_else(|error| {
+                    log::warn!("library: a new playlist is not readable yet: {error:#}");
+                    Playlist {
+                        id,
+                        name,
+                        owner: String::new(),
+                        owned: true,
+                        collaborative: false,
+                        public: false,
+                        cover: None,
+                        track_count: 0,
+                    }
+                }))
             },
             Self::insert_playlist,
             cx,

--- a/crates/ui/src/card.rs
+++ b/crates/ui/src/card.rs
@@ -279,6 +279,7 @@ impl RenderOnce for Card {
         let height = snapped(theme.metrics.list_row, window);
         let listed = art.is_none() && tile.is_none();
         let has_trailing = trailing.is_some();
+        let art_radius = art_radius.or_else(|| tile.map(|_| theme.radius));
         let art = art.or(tile).unwrap_or(snapped(height - inset * 2., window));
         let hovered = match (hovered, fill) {
             (Some(style), _) => Some(style),

--- a/crates/views/src/shared/album_grid.rs
+++ b/crates/views/src/shared/album_grid.rs
@@ -191,7 +191,6 @@ fn album_card(
 
     Card::new((id, index), SharedString::from(album.name))
         .tile(width)
-        .art_radius(theme.radius)
         .cover(cover)
         .weight(FontWeight::SEMIBOLD)
         .flat()


### PR DESCRIPTION
## Summary

- recognise the YouTube Music playlists you own, so rename, visibility and delete replace an unsupported remove-from-library that always failed
- report a created playlist as created and show it straight away, instead of failing on a fetch the service is not ready to answer yet
- remove a track from a YouTube Music playlist even when its music video was swapped for the album audio
- stop reading a playlist's privacy setting as its owner, and name the account as the owner of your own playlists
- round tile artwork the same way for playlists, albums, releases and tracks