### PR TITLE
feat: local music provider

### DIFF
--- a/crates/music/src/lib.rs
+++ b/crates/music/src/lib.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pub mod local;
 mod audio;
+pub mod local;
 pub mod lrclib;
 pub mod lyrics;
 mod models;

--- a/crates/sonora/src/main.rs
+++ b/crates/sonora/src/main.rs
@@ -66,9 +66,8 @@ fn main() {
                     .unwrap_or_else(std::env::temp_dir)
                     .join("sonora"),
             ));
-        state::init(cx, io, providers, local_provider);
         let lyrics: Vec<Arc<dyn LyricsProvider>> = vec![Arc::new(music::lrclib::LrcLib::new())];
-        state::init(cx, io, providers, lyrics);
+        state::init(cx, io, providers, local_provider, lyrics);
         router::init(start, cx);
         let (look, overrides, language) = {
             let settings = Sonora::global(cx).settings.read(cx);
@@ -150,7 +149,7 @@ fn open_window(
             window.set_rem_size(cx.theme().font_size);
             state::attach_remote(window_handle(window), cx);
             cx.new(|cx| Root::new(session, library, playback, queue, window, cx))
-        },ing
+        },
     )
     .expect("failed to open window");
 }

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -68,7 +68,7 @@ pub(crate) async fn join<T>(handle: JoinHandle<Result<T>>) -> Result<T> {
     handle.await?
 }
 
-ingpub struct Sonora {
+pub struct Sonora {
     pub session: Entity<Session>,
     pub library: Entity<Library>,
     pub lyrics: Entity<Lyrics>,
@@ -97,7 +97,7 @@ pub fn init(
     let settings = cx.new(|_| AppSettings::load());
     let session =
         cx.new(|cx| Session::new(providers, local_provider, settings.clone(), io.clone(), cx));
-    let library = cx.new(|cx| Library::new(session.clone(), io, cx));
+    let library = cx.new(|cx| Library::new(session.clone(), io.clone(), cx));
     let queue = cx.new(|cx| Queue::new(settings.clone(), cx));
     let playback = cx.new(|cx| Playback::new(session.clone(), queue.clone(), settings.clone(), cx));
     let lyrics = cx.new(|cx| Lyrics::new(playback.clone(), lyrics_providers, io, cx));


### PR DESCRIPTION
## Summary

- add a local music provider that scans a folder for audio files and plays them alongside the streaming services
- read tags, artwork and duration from the files, and surface them as tracks, albums and artists
- add a local library screen and a folder setting for it
- repair the leftovers of the dev merge that stopped the branch from compiling