### PR TITLE
feat: mark tracks already in a playlist

### DIFF
--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -90,6 +90,9 @@ playlist-create-title = Create playlist
 playlist-rename-title = Rename playlist
 playlist-delete-title = Delete playlist
 playlist-delete-confirm = Delete “{ $name }”? This cannot be undone.
+playlist-again-title = Add it again?
+playlist-again-confirm = This track is already in “{ $name }”. Add another copy?
+playlist-again-add = Add again
 
 # queue panel
 queue-title = Queue

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -90,6 +90,9 @@ playlist-create-title = Utwórz playlistę
 playlist-rename-title = Zmień nazwę playlisty
 playlist-delete-title = Usuń playlistę
 playlist-delete-confirm = Usunąć „{ $name }”? Tej operacji nie można cofnąć.
+playlist-again-title = Dodać ponownie?
+playlist-again-confirm = Ten utwór jest już w „{ $name }”. Dodać kopię?
+playlist-again-add = Dodaj ponownie
 
 # queue panel
 queue-title = Kolejka

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -90,6 +90,9 @@ playlist-create-title = Создать плейлист
 playlist-rename-title = Переименовать плейлист
 playlist-delete-title = Удалить плейлист
 playlist-delete-confirm = Удалить «{ $name }»? Это действие нельзя отменить.
+playlist-again-title = Добавить ещё раз?
+playlist-again-confirm = Этот трек уже есть в «{ $name }». Добавить копию?
+playlist-again-add = Добавить ещё раз
 
 # queue panel
 queue-title = Очередь

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -90,6 +90,9 @@ playlist-create-title = Створити плейлист
 playlist-rename-title = Перейменувати плейлист
 playlist-delete-title = Видалити плейлист
 playlist-delete-confirm = Видалити «{ $name }»? Цю дію неможливо скасувати.
+playlist-again-title = Додати ще раз?
+playlist-again-confirm = Цей трек уже є в «{ $name }». Додати копію?
+playlist-again-add = Додати ще раз
 
 # queue panel
 queue-title = Черга

--- a/crates/music/src/spotify/collection2.rs
+++ b/crates/music/src/spotify/collection2.rs
@@ -178,7 +178,7 @@ fn kept(bytes: &[u8]) -> Result<Option<SavedItem>> {
     while let Some((field, value)) = reader.field()? {
         match (field, value) {
             (ITEM_URI, Value::Bytes(raw)) => uri = Some(text(raw)?),
-            (ITEM_ADDED_AT, Value::Varint(raw)) => {
+            (ITEM_ADDED_AT, Value::Varint(raw) | Value::Fixed(raw)) => {
                 added_at = Some(raw as u32 as i32 as i64);
             }
             (ITEM_REMOVED, Value::Varint(flag)) => removed = flag != 0,
@@ -186,9 +186,29 @@ fn kept(bytes: &[u8]) -> Result<Option<SavedItem>> {
         }
     }
 
+    if added_at.is_none() && uri.is_some() && !removed {
+        log::debug!(
+            "collection: saved item has no date, fields: {}",
+            fields(bytes)
+        );
+    }
+
     Ok(uri
         .filter(|_| !removed)
         .map(|uri| SavedItem { uri, added_at }))
+}
+
+fn fields(bytes: &[u8]) -> String {
+    let mut reader = Reader::new(bytes);
+    let mut seen = Vec::new();
+    while let Ok(Some((field, value))) = reader.field() {
+        seen.push(match value {
+            Value::Varint(raw) => format!("{field}=varint({raw})"),
+            Value::Fixed(raw) => format!("{field}=fixed({raw})"),
+            Value::Bytes(raw) => format!("{field}=bytes({})", raw.len()),
+        });
+    }
+    seen.join(", ")
 }
 
 #[cfg(test)]

--- a/crates/music/src/spotify/pb.rs
+++ b/crates/music/src/spotify/pb.rs
@@ -63,7 +63,7 @@ impl Writer {
 pub(crate) enum Value<'a> {
     Varint(u64),
     Bytes(&'a [u8]),
-    Fixed,
+    Fixed(u64),
 }
 
 pub(crate) struct Reader<'a> {
@@ -85,8 +85,8 @@ impl<'a> Reader<'a> {
         let value = match key & 7 {
             VARINT => Value::Varint(self.varint()?),
             LENGTH => Value::Bytes(self.slice()?),
-            FIXED64 => self.skip(8)?,
-            FIXED32 => self.skip(4)?,
+            FIXED64 => self.fixed(8)?,
+            FIXED32 => self.fixed(4)?,
             kind => bail!("unsupported wire type {kind}"),
         };
 
@@ -114,13 +114,15 @@ impl<'a> Reader<'a> {
         Ok(slice)
     }
 
-    fn skip(&mut self, width: usize) -> Result<Value<'a>> {
+    fn fixed(&mut self, width: usize) -> Result<Value<'a>> {
         let end = self.at.checked_add(width).context("length overflows")?;
-        if end > self.bytes.len() {
-            bail!("truncated field");
-        }
+        let bytes = self.bytes.get(self.at..end).context("truncated field")?;
         self.at = end;
-        Ok(Value::Fixed)
+        let mut value = 0u64;
+        for (shift, byte) in bytes.iter().enumerate() {
+            value |= u64::from(*byte) << (shift * 8);
+        }
+        Ok(Value::Fixed(value))
     }
 }
 

--- a/crates/state/src/library.rs
+++ b/crates/state/src/library.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -86,6 +86,8 @@ pub struct Library {
     playlist_task: Option<Task<()>>,
     pending: HashMap<String, Task<()>>,
     pending_albums: HashMap<String, Task<()>>,
+    contents: HashMap<String, HashSet<String>>,
+    reading: HashMap<String, Task<()>>,
 }
 
 impl Library {
@@ -103,6 +105,8 @@ impl Library {
                 }
             }
             SessionEvent::SignedOut => {
+                this.contents.clear();
+                this.reading.clear();
                 this.task = None;
                 this.playlist_task = None;
                 this.pending.clear();
@@ -131,6 +135,8 @@ impl Library {
             playlist_task: None,
             pending: HashMap::new(),
             pending_albums: HashMap::new(),
+            contents: HashMap::new(),
+            reading: HashMap::new(),
         };
         if let Some(client) = local_client {
             library.load_local(client, cx);
@@ -343,6 +349,7 @@ impl Library {
         cx: &mut Context<Self>,
     ) {
         let added = playlist_id.clone();
+        let held = track_id.clone();
         let name = self
             .playlist(&playlist_id)
             .map(|playlist| playlist.name.clone());
@@ -353,6 +360,9 @@ impl Library {
             move |client| async move { client.add_track_to_playlist(&playlist_id, &track_id).await },
             move |this, _, cx| {
                 this.amend_playlist(&added, |playlist| playlist.track_count += 1, cx);
+                if let Some(ids) = this.contents.get_mut(&added) {
+                    ids.insert(held);
+                }
             },
             cx,
         );
@@ -406,6 +416,52 @@ impl Library {
             return None;
         };
         albums.iter().find(|album| album.id == id)
+    }
+
+    pub fn holds(&self, playlist_id: &str, track_id: &str) -> Option<bool> {
+        Some(self.contents.get(playlist_id)?.contains(track_id))
+    }
+
+    pub fn read_playlists(&mut self, cx: &mut Context<Self>) {
+        let LibraryState::Ready { playlists, .. } = &self.state else {
+            return;
+        };
+        let wanted: Vec<String> = playlists
+            .iter()
+            .filter(|playlist| playlist.owned || playlist.collaborative)
+            .map(|playlist| playlist.id.clone())
+            .filter(|id| !self.contents.contains_key(id) && !self.reading.contains_key(id))
+            .collect();
+        let Some(client) = self.session.read(cx).client() else {
+            return;
+        };
+
+        for id in wanted {
+            let io = self.io.clone();
+            let client = client.clone();
+            let key = id.clone();
+            let asked = id.clone();
+            let task = cx.spawn(async move |this, cx| {
+                let listed =
+                    join(io.spawn(async move { client.playlist_tracks(&asked).await })).await;
+
+                this.update(cx, |this, cx| {
+                    this.reading.remove(&key);
+                    match listed {
+                        Ok(tracks) => {
+                            let ids = tracks.into_iter().filter_map(|track| track.id).collect();
+                            this.contents.insert(key, ids);
+                            cx.notify();
+                        }
+                        Err(error) => {
+                            log::warn!("library: cannot read a playlist: {error:#}")
+                        }
+                    }
+                })
+                .ok();
+            });
+            self.reading.insert(id.clone(), task);
+        }
     }
 
     pub fn playlist(&self, id: &str) -> Option<&Playlist> {
@@ -543,6 +599,7 @@ impl Library {
                     Ok(loaded) => partial(loaded),
                     Err(error) => LibraryState::Failed(format!("{error:#}")),
                 };
+                this.read_playlists(cx);
                 cx.notify();
             })
             .ok();

--- a/crates/ui/src/menu.rs
+++ b/crates/ui/src/menu.rs
@@ -24,6 +24,8 @@ const SUBMENU_TOP: Pixels = px(-14.);
 const SCROLLBAR_GUTTER: Pixels = px(8.);
 const WINDOW_MARGIN: Pixels = px(8.);
 const PANEL_SLACK: Pixels = px(6.);
+const PAD: f32 = 0.25;
+const BORDER: Pixels = px(1.);
 
 type Press = Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>;
 type Dismiss = Box<dyn Fn(&(), &mut Window, &mut App) + 'static>;
@@ -359,6 +361,7 @@ impl RenderOnce for Menu {
             .collect();
         let bounds_guards = dismiss_guards.clone();
         let viewport_width = window.viewport_size().width;
+        let tucked = (theme.radius - window.rem_size() * PAD - BORDER).max(Pixels::ZERO);
 
         let rows = items.into_iter().map(move |item| {
             let MenuItem {
@@ -406,7 +409,7 @@ impl RenderOnce for Menu {
                 .justify_between()
                 .px_3()
                 .py_1()
-                .rounded(theme.radius)
+                .rounded(tucked)
                 .when_else(
                     disabled,
                     |this| this.text_color(theme.muted_foreground).cursor_default(),

--- a/crates/ui/src/menu.rs
+++ b/crates/ui/src/menu.rs
@@ -156,6 +156,7 @@ pub struct MenuItem {
     id: ElementId,
     label: SharedString,
     selected: bool,
+    checked: bool,
     disabled: bool,
     separator: bool,
     content: Option<AnyElement>,
@@ -173,6 +174,7 @@ impl MenuItem {
             id: id.into(),
             label: label.into(),
             selected: false,
+            checked: false,
             disabled: false,
             separator: false,
             content: None,
@@ -181,6 +183,11 @@ impl MenuItem {
             press: None,
             submenu: None,
         }
+    }
+
+    pub fn checked(mut self, checked: bool) -> Self {
+        self.checked = checked;
+        self
     }
 
     pub fn selected(mut self, selected: bool) -> Self {
@@ -193,6 +200,7 @@ impl MenuItem {
             id: id.into(),
             label: SharedString::default(),
             selected: false,
+            checked: false,
             disabled: true,
             separator: true,
             content: None,
@@ -368,6 +376,7 @@ impl RenderOnce for Menu {
                 id,
                 label,
                 selected,
+                checked,
                 disabled,
                 separator,
                 content,
@@ -439,7 +448,7 @@ impl RenderOnce for Menu {
                         })
                         .child(div().truncate().child(label)),
                 )
-                .when(selected, |this| this.child("✓"))
+                .when(selected || checked, |this| this.child("✓"))
                 .when(submenu.is_some(), |this| this.child("›"))
                 .when_some(submenu_state, |this, state| {
                     this.on_hover(move |hovered, window, cx| {

--- a/crates/views/src/chrome/sidebar_right.rs
+++ b/crates/views/src/chrome/sidebar_right.rs
@@ -599,6 +599,7 @@ impl SidebarRight {
             .small()
             .icon(icon)
             .tooltip(tooltip)
+            .rounded_full()
             .selected(self.tab == tab)
             .tint(match self.tab == tab {
                 true => theme.foreground,

--- a/crates/views/src/shared/menu.rs
+++ b/crates/views/src/shared/menu.rs
@@ -129,7 +129,7 @@ impl ItemMenu {
                     let item =
                         MenuItem::new(format!("playlist-{}", playlist.id), playlist.name.clone())
                             .artwork(playlist.cover.clone())
-                            .selected(held);
+                            .checked(held);
                     match track.id.clone() {
                         Some(track_id) => {
                             let library = library.clone();

--- a/crates/views/src/shared/menu.rs
+++ b/crates/views/src/shared/menu.rs
@@ -121,20 +121,37 @@ impl ItemMenu {
                 .item(new_playlist)
                 .item(MenuItem::separator("playlist-separator"))
                 .items(playlists.into_iter().map(|playlist| {
-                    let item = MenuItem::new(format!("playlist-{}", playlist.id), playlist.name)
-                        .artwork(playlist.cover);
+                    let held = track
+                        .id
+                        .as_deref()
+                        .and_then(|id| library.read(cx).holds(&playlist.id, id))
+                        .unwrap_or(false);
+                    let item =
+                        MenuItem::new(format!("playlist-{}", playlist.id), playlist.name.clone())
+                            .artwork(playlist.cover.clone())
+                            .selected(held);
                     match track.id.clone() {
                         Some(track_id) => {
                             let library = library.clone();
-                            let playlist_id = playlist.id;
-                            item.on_click(move |_, _, cx| {
-                                library.update(cx, |library, cx| {
-                                    library.add_to_playlist(
-                                        playlist_id.clone(),
-                                        track_id.clone(),
-                                        cx,
-                                    )
-                                });
+                            let playlist_id = playlist.id.clone();
+                            item.on_click(move |_, window, cx| match held {
+                                true => PlaylistEditor::open(
+                                    Edit::Again {
+                                        playlist: playlist.clone(),
+                                        track: track_id.clone(),
+                                    },
+                                    window,
+                                    cx,
+                                ),
+                                false => {
+                                    library.update(cx, |library, cx| {
+                                        library.add_to_playlist(
+                                            playlist_id.clone(),
+                                            track_id.clone(),
+                                            cx,
+                                        )
+                                    });
+                                }
                             })
                         }
                         None => item.disabled(),

--- a/crates/views/src/shared/playlist_editor.rs
+++ b/crates/views/src/shared/playlist_editor.rs
@@ -13,6 +13,7 @@ pub(crate) enum Edit {
     Create(Option<String>),
     Rename(Playlist),
     Delete(Playlist),
+    Again { playlist: Playlist, track: String },
 }
 
 pub(crate) struct PlaylistEditor {
@@ -48,11 +49,11 @@ impl PlaylistEditor {
     fn show(&mut self, edit: Edit, window: &mut Window, cx: &mut Context<Self>) {
         let name = match &edit {
             Edit::Rename(playlist) => playlist.name.clone(),
-            Edit::Create(_) | Edit::Delete(_) => String::new(),
+            _ => String::new(),
         };
         self.restore = window.focused(cx);
         self.name.update(cx, |input, cx| input.set_text(name, cx));
-        match matches!(edit, Edit::Delete(_)) {
+        match plain(&edit) {
             true => window.focus(&self.focus, cx),
             false => self.name.update(cx, |input, cx| input.focus(window, cx)),
         }
@@ -90,10 +91,17 @@ impl PlaylistEditor {
             Edit::Delete(playlist) => library.update(cx, |library, cx| {
                 library.delete_playlist(playlist.id, cx);
             }),
+            Edit::Again { playlist, track } => library.update(cx, |library, cx| {
+                library.add_to_playlist(playlist.id, track, cx);
+            }),
             _ => {}
         }
         cx.notify();
     }
+}
+
+fn plain(edit: &Edit) -> bool {
+    matches!(edit, Edit::Delete(_) | Edit::Again { .. })
 }
 
 impl Render for PlaylistEditor {
@@ -103,13 +111,18 @@ impl Render for PlaylistEditor {
         };
         let theme = *cx.theme();
         let deleting = matches!(edit, Edit::Delete(_));
+        let asking = plain(&edit);
         let title = match &edit {
             Edit::Create(_) => t!("playlist-create-title"),
             Edit::Rename(_) => t!("playlist-rename-title"),
             Edit::Delete(_) => t!("playlist-delete-title"),
+            Edit::Again { .. } => t!("playlist-again-title"),
         };
         let detail = match &edit {
             Edit::Delete(playlist) => Some(t!("playlist-delete-confirm", name = &playlist.name)),
+            Edit::Again { playlist, .. } => {
+                Some(t!("playlist-again-confirm", name = &playlist.name))
+            }
             _ => None,
         };
 
@@ -130,7 +143,7 @@ impl Render for PlaylistEditor {
                 Modal::new("playlist-editor", title)
                     .width(theme.metrics.cover * 2.8)
                     .when_some(detail, Modal::detail)
-                    .when(!deleting, |modal| modal.child(self.name.clone()))
+                    .when(!asking, |modal| modal.child(self.name.clone()))
                     .action(
                         Button::new("cancel-playlist-edit")
                             .ghost()
@@ -144,9 +157,10 @@ impl Render for PlaylistEditor {
                                 |button| button.danger(),
                                 |button| button.primary(),
                             )
-                            .label(match deleting {
-                                true => t!("common-delete"),
-                                false => t!("common-save"),
+                            .label(match &edit {
+                                Edit::Delete(_) => t!("common-delete"),
+                                Edit::Again { .. } => t!("playlist-again-add"),
+                                _ => t!("common-save"),
                             })
                             .on_click(cx.listener(|this, _, window, cx| this.apply(window, cx))),
                     )


### PR DESCRIPTION
## Summary

- mark a playlist that already holds the track with a tick in the add-to-playlist menu, and confirm before adding a second copy
- read the saved date Spotify sends as a fixed-width field, so Date added stops coming through empty
- nest the rounded corners of a menu item and the sidebar pills inside their container instead of repeating its radius
- mark a menu item with a tick alone, leaving the highlighted background for a chosen value