### PR TITLE
fix: keep repeated tracks in a playlist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9299,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "ytmusic"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/ytmusic-rs?rev=b2847291da1a5119a7e4e70c75ade80dd9ecb29e#b2847291da1a5119a7e4e70c75ade80dd9ecb29e"
+source = "git+https://github.com/nolight132/ytmusic-rs?rev=0d5957187649039b4939533a9c08477723683936#0d5957187649039b4939533a9c08477723683936"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde_json = "1.0"
 souvlaki = "0.8"
 sys-locale = "0.3"
 unic-langid = { version = "0.9", features = ["macros"] }
-ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "b2847291da1a5119a7e4e70c75ade80dd9ecb29e" }
+ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "0d5957187649039b4939533a9c08477723683936" }
 
 librespot-core = { version = "0.8.0", default-features = false, features = [
   "rustls-tls-native-roots",

--- a/crates/music/src/spotify/albums.rs
+++ b/crates/music/src/spotify/albums.rs
@@ -23,8 +23,11 @@ pub async fn saved_albums(session: &Session, limit: u32) -> Result<Vec<Album>> {
         return Ok(Vec::new());
     }
 
-    let mut known = metadata(session, &uris).await?;
-    Ok(uris.iter().filter_map(|uri| known.remove(uri)).collect())
+    let known = metadata(session, &uris).await?;
+    Ok(uris
+        .iter()
+        .filter_map(|uri| known.get(uri).cloned())
+        .collect())
 }
 
 pub async fn album(session: &Session, album_id: &str) -> Result<AlbumDetail> {
@@ -59,8 +62,10 @@ async fn legacy_album(session: &Session, album_id: &str) -> Result<AlbumDetail> 
     let tracks = match uris.is_empty() {
         true => Vec::new(),
         false => {
-            let mut known = collection::metadata(session, &uris).await?;
-            uris.iter().filter_map(|uri| known.remove(uri)).collect()
+            let known = collection::metadata(session, &uris).await?;
+            uris.iter()
+                .filter_map(|uri| known.get(uri).cloned())
+                .collect()
         }
     };
     Ok(AlbumDetail { album, tracks })

--- a/crates/music/src/spotify/artists.rs
+++ b/crates/music/src/spotify/artists.rs
@@ -78,15 +78,15 @@ async fn legacy_artist(session: &Session, artist_id: &str) -> Result<Artist> {
         }
     };
     let (tracks, releases) = tokio::join!(tracks, releases);
-    let mut known_tracks = tracks?;
-    let mut known_albums = releases?;
+    let known_tracks = tracks?;
+    let known_albums = releases?;
     let top_tracks = track_uris
         .iter()
-        .filter_map(|uri| known_tracks.remove(uri))
+        .filter_map(|uri| known_tracks.get(uri).cloned())
         .collect();
     let releases = release_uris
         .iter()
-        .filter_map(|uri| known_albums.remove(uri))
+        .filter_map(|uri| known_albums.get(uri).cloned())
         .collect();
 
     Ok(artist_from(&message, top_tracks, releases))

--- a/crates/music/src/spotify/playlists.rs
+++ b/crates/music/src/spotify/playlists.rs
@@ -149,8 +149,11 @@ async fn tracks_from(session: &Session, content: &SelectedListContent) -> Result
         return Ok(Vec::new());
     }
 
-    let mut known = collection::metadata(session, &uris).await?;
-    Ok(uris.iter().filter_map(|uri| known.remove(uri)).collect())
+    let known = collection::metadata(session, &uris).await?;
+    Ok(uris
+        .iter()
+        .filter_map(|uri| known.get(uri).cloned())
+        .collect())
 }
 
 async fn snapshot(session: &Session, playlist_id: &str) -> Result<SelectedListContent> {

--- a/crates/music/src/spotify/search.rs
+++ b/crates/music/src/spotify/search.rs
@@ -32,8 +32,11 @@ pub async fn search(session: &Session, query: &str) -> Result<Vec<Track>> {
         return Ok(Vec::new());
     }
 
-    let mut known = collection::metadata(session, &uris).await?;
-    Ok(uris.iter().filter_map(|uri| known.remove(uri)).collect())
+    let known = collection::metadata(session, &uris).await?;
+    Ok(uris
+        .iter()
+        .filter_map(|uri| known.get(uri).cloned())
+        .collect())
 }
 
 fn escaped(query: &str) -> String {

--- a/crates/ui/src/scrollbar.rs
+++ b/crates/ui/src/scrollbar.rs
@@ -143,6 +143,10 @@ impl Scrollbar {
         self
     }
 
+    pub fn settle(&mut self, offset: Pixels) {
+        self.seen = offset;
+    }
+
     pub fn scroll(&self) -> &ScrollHandle {
         &self.scroll
     }

--- a/crates/views/src/chrome/player_bar.rs
+++ b/crates/views/src/chrome/player_bar.rs
@@ -76,7 +76,7 @@ impl PlayerBar {
         position: Point<Pixels>,
         cx: &mut Context<Self>,
     ) {
-        self.track_menu.reset();
+        self.track_menu.reset(cx);
         self.context_menu = Some((track, position));
         cx.notify();
     }

--- a/crates/views/src/chrome/sidebar_right.rs
+++ b/crates/views/src/chrome/sidebar_right.rs
@@ -241,7 +241,7 @@ impl SidebarRight {
                 .as_ref()
                 .is_some_and(|menu| menu.revision != revision)
             {
-                this.track_menu.reset();
+                this.track_menu.reset(cx);
                 this.context_menu = None;
             }
             cx.notify();
@@ -325,7 +325,7 @@ impl SidebarRight {
     }
 
     pub(crate) fn close(&mut self, cx: &mut Context<Self>) {
-        self.track_menu.reset();
+        self.track_menu.reset(cx);
         self.context_menu = None;
         self.open = false;
         self.remember(cx);
@@ -339,7 +339,7 @@ impl SidebarRight {
     }
 
     fn dismiss_menu(&mut self, cx: &mut Context<Self>) {
-        self.track_menu.reset();
+        self.track_menu.reset(cx);
         self.context_menu = None;
         cx.notify();
     }
@@ -390,7 +390,7 @@ impl SidebarRight {
             MouseButton::Right,
             cx.listener(move |this, event: &MouseDownEvent, window, cx| {
                 window.prevent_default();
-                this.track_menu.reset();
+                this.track_menu.reset(cx);
                 this.context_menu = Some(ContextMenuState {
                     track: menu_track.clone(),
                     revision: queue_revision,

--- a/crates/views/src/chrome/sidebar_right.rs
+++ b/crates/views/src/chrome/sidebar_right.rs
@@ -727,6 +727,10 @@ impl SidebarRight {
         if self.verse_of != following {
             self.verse_of = following;
             self.anchor_verse();
+            let scroll = self.verse_bar.read(cx).scroll().clone();
+            scroll.set_offset(gpui::point(scroll.offset().x, px(0.)));
+            self.verse_bar
+                .update(cx, |bar, _| bar.settle(scroll.offset().y));
         }
         if let Some(lines) = &lines {
             self.pin_verse(music::lyrics::active(lines, at), window, cx);
@@ -788,11 +792,13 @@ impl SidebarRight {
             scroll.set_offset(gpui::point(scroll.offset().x, goal));
             self.placed = Some(goal);
             self.goal = None;
+            self.verse_bar.update(cx, |bar, _| bar.settle(goal));
             return;
         }
         let next = current + step * GLIDE;
         scroll.set_offset(gpui::point(scroll.offset().x, next));
         self.placed = Some(next);
+        self.verse_bar.update(cx, |bar, _| bar.settle(next));
         window.request_animation_frame();
     }
 

--- a/crates/views/src/screens/home/mod.rs
+++ b/crates/views/src/screens/home/mod.rs
@@ -39,7 +39,7 @@ impl HomeView {
 
         cx.observe(&home, |this, _, cx| {
             this.quick_picks_page = 0;
-            this.track_menu.reset();
+            this.track_menu.reset(cx);
             this.context_menu = None;
             cx.notify();
         })
@@ -125,7 +125,7 @@ impl Render for HomeView {
                             return;
                         };
                         home.update(cx, |this, cx| {
-                            this.track_menu.reset();
+                            this.track_menu.reset(cx);
                             this.context_menu = Some((place, event.position));
                             cx.notify();
                         });

--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -55,7 +55,7 @@ impl SearchView {
         .detach();
 
         cx.observe(&search, |this, _, cx| {
-            this.track_menu.reset();
+            this.track_menu.reset(cx);
             this.context_menu = None;
             cx.notify();
         })
@@ -169,7 +169,7 @@ impl SearchView {
                             return;
                         };
                         view.update(cx, |this, cx| {
-                            this.track_menu.reset();
+                            this.track_menu.reset(cx);
                             this.context_menu = Some((track.clone(), event.position));
                             cx.notify();
                         });
@@ -255,7 +255,7 @@ impl SearchView {
                         return;
                     };
                     view.update(cx, |this, cx| {
-                        this.track_menu.reset();
+                        this.track_menu.reset(cx);
                         this.context_menu = Some((track.clone(), event.position));
                         cx.notify();
                     });

--- a/crates/views/src/shared/menu.rs
+++ b/crates/views/src/shared/menu.rs
@@ -31,9 +31,13 @@ impl ItemMenu {
         }
     }
 
-    pub fn reset(&self) {
+    pub fn reset(&self, cx: &App) {
         self.playlist_submenu.reset();
         self.artist_submenu.reset();
+        self.playlist_scrollbar
+            .read(cx)
+            .scroll()
+            .set_offset(gpui::Point::default());
     }
 
     pub fn for_track(&self, track: &Track, cx: &App) -> Menu {

--- a/crates/views/src/shared/menu.rs
+++ b/crates/views/src/shared/menu.rs
@@ -41,11 +41,11 @@ impl ItemMenu {
     }
 
     pub fn for_track(&self, track: &Track, cx: &App) -> Menu {
-        self.build(track, None, None, None, TrackColumns::default(), cx)
+        self.build(track, None, None, TrackColumns::default(), cx)
     }
 
     pub fn for_table_track(&self, track: &Track, columns: TrackColumns, cx: &App) -> Menu {
-        self.build(track, None, None, None, columns, cx)
+        self.build(track, None, None, columns, cx)
     }
 
     pub fn for_album_track(
@@ -55,7 +55,7 @@ impl ItemMenu {
         columns: TrackColumns,
         cx: &App,
     ) -> Menu {
-        self.build(track, None, None, Some(album_id), columns, cx)
+        self.build(track, None, Some(album_id), columns, cx)
     }
 
     pub fn for_playlist_track(
@@ -65,7 +65,6 @@ impl ItemMenu {
         columns: TrackColumns,
         cx: &App,
     ) -> Menu {
-        let playlist_id = detail.read(cx).id().map(str::to_owned);
         let remove = match track.id.clone() {
             Some(id) => MenuItem::new("remove-from-playlist", t!("menu-remove-from-playlist"))
                 .icon("icons/x.svg")
@@ -76,21 +75,13 @@ impl ItemMenu {
                 .icon("icons/x.svg")
                 .disabled(),
         };
-        self.build(
-            track,
-            Some(remove),
-            playlist_id.as_deref(),
-            None,
-            columns,
-            cx,
-        )
+        self.build(track, Some(remove), None, columns, cx)
     }
 
     fn build(
         &self,
         track: &Track,
         library_action: Option<MenuItem>,
-        current_playlist: Option<&str>,
         current_album: Option<&str>,
         columns: TrackColumns,
         cx: &App,
@@ -100,7 +91,6 @@ impl ItemMenu {
             LibraryState::Ready { playlists, .. } => playlists
                 .iter()
                 .filter(|playlist| playlist.owned || playlist.collaborative)
-                .filter(|playlist| Some(playlist.id.as_str()) != current_playlist)
                 .cloned()
                 .collect(),
             _ => Vec::new(),

--- a/crates/views/src/shared/tracks/mod.rs
+++ b/crates/views/src/shared/tracks/mod.rs
@@ -364,8 +364,8 @@ impl GridSource for TrackSource {
         })
     }
 
-    fn context_menu_will_open(&self, _row: usize, _cx: &App) {
-        self.menu.reset();
+    fn context_menu_will_open(&self, _row: usize, cx: &App) {
+        self.menu.reset(cx);
     }
 
     fn compare(&self, field: TrackField, a: usize, b: usize, cx: &App) -> Ordering {


### PR DESCRIPTION
## Summary

- keep every occurrence of a track when resolving a Spotify playlist, album, artist or search result, so a track added twice actually shows up twice
- allow a duplicate on YouTube Music, which silently collapses a repeat unless the add action opts out of its dedupe
- offer the playlist you are already viewing in the add-to-playlist menu instead of hiding it
- reset the lyrics scroll on a new track, and leave the scrollbar asleep while the lyrics follow the song on their own
- forget the scroll position of the add-to-playlist submenu between openings