### PR TITLE
merge: playlist marks, duplicates and lyrics polish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9299,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "ytmusic"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/ytmusic-rs?rev=b2847291da1a5119a7e4e70c75ade80dd9ecb29e#b2847291da1a5119a7e4e70c75ade80dd9ecb29e"
+source = "git+https://github.com/nolight132/ytmusic-rs?rev=0d5957187649039b4939533a9c08477723683936#0d5957187649039b4939533a9c08477723683936"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde_json = "1.0"
 souvlaki = "0.8"
 sys-locale = "0.3"
 unic-langid = { version = "0.9", features = ["macros"] }
-ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "b2847291da1a5119a7e4e70c75ade80dd9ecb29e" }
+ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "0d5957187649039b4939533a9c08477723683936" }
 
 librespot-core = { version = "0.8.0", default-features = false, features = [
   "rustls-tls-native-roots",

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -90,6 +90,9 @@ playlist-create-title = Create playlist
 playlist-rename-title = Rename playlist
 playlist-delete-title = Delete playlist
 playlist-delete-confirm = Delete “{ $name }”? This cannot be undone.
+playlist-again-title = Add it again?
+playlist-again-confirm = This track is already in “{ $name }”. Add another copy?
+playlist-again-add = Add again
 
 # queue panel
 queue-title = Queue

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -90,6 +90,9 @@ playlist-create-title = Utwórz playlistę
 playlist-rename-title = Zmień nazwę playlisty
 playlist-delete-title = Usuń playlistę
 playlist-delete-confirm = Usunąć „{ $name }”? Tej operacji nie można cofnąć.
+playlist-again-title = Dodać ponownie?
+playlist-again-confirm = Ten utwór jest już w „{ $name }”. Dodać kopię?
+playlist-again-add = Dodaj ponownie
 
 # queue panel
 queue-title = Kolejka

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -90,6 +90,9 @@ playlist-create-title = Создать плейлист
 playlist-rename-title = Переименовать плейлист
 playlist-delete-title = Удалить плейлист
 playlist-delete-confirm = Удалить «{ $name }»? Это действие нельзя отменить.
+playlist-again-title = Добавить ещё раз?
+playlist-again-confirm = Этот трек уже есть в «{ $name }». Добавить копию?
+playlist-again-add = Добавить ещё раз
 
 # queue panel
 queue-title = Очередь

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -90,6 +90,9 @@ playlist-create-title = Створити плейлист
 playlist-rename-title = Перейменувати плейлист
 playlist-delete-title = Видалити плейлист
 playlist-delete-confirm = Видалити «{ $name }»? Цю дію неможливо скасувати.
+playlist-again-title = Додати ще раз?
+playlist-again-confirm = Цей трек уже є в «{ $name }». Додати копію?
+playlist-again-add = Додати ще раз
 
 # queue panel
 queue-title = Черга

--- a/crates/music/src/spotify/albums.rs
+++ b/crates/music/src/spotify/albums.rs
@@ -23,8 +23,11 @@ pub async fn saved_albums(session: &Session, limit: u32) -> Result<Vec<Album>> {
         return Ok(Vec::new());
     }
 
-    let mut known = metadata(session, &uris).await?;
-    Ok(uris.iter().filter_map(|uri| known.remove(uri)).collect())
+    let known = metadata(session, &uris).await?;
+    Ok(uris
+        .iter()
+        .filter_map(|uri| known.get(uri).cloned())
+        .collect())
 }
 
 pub async fn album(session: &Session, album_id: &str) -> Result<AlbumDetail> {
@@ -59,8 +62,10 @@ async fn legacy_album(session: &Session, album_id: &str) -> Result<AlbumDetail> 
     let tracks = match uris.is_empty() {
         true => Vec::new(),
         false => {
-            let mut known = collection::metadata(session, &uris).await?;
-            uris.iter().filter_map(|uri| known.remove(uri)).collect()
+            let known = collection::metadata(session, &uris).await?;
+            uris.iter()
+                .filter_map(|uri| known.get(uri).cloned())
+                .collect()
         }
     };
     Ok(AlbumDetail { album, tracks })

--- a/crates/music/src/spotify/artists.rs
+++ b/crates/music/src/spotify/artists.rs
@@ -78,15 +78,15 @@ async fn legacy_artist(session: &Session, artist_id: &str) -> Result<Artist> {
         }
     };
     let (tracks, releases) = tokio::join!(tracks, releases);
-    let mut known_tracks = tracks?;
-    let mut known_albums = releases?;
+    let known_tracks = tracks?;
+    let known_albums = releases?;
     let top_tracks = track_uris
         .iter()
-        .filter_map(|uri| known_tracks.remove(uri))
+        .filter_map(|uri| known_tracks.get(uri).cloned())
         .collect();
     let releases = release_uris
         .iter()
-        .filter_map(|uri| known_albums.remove(uri))
+        .filter_map(|uri| known_albums.get(uri).cloned())
         .collect();
 
     Ok(artist_from(&message, top_tracks, releases))

--- a/crates/music/src/spotify/collection2.rs
+++ b/crates/music/src/spotify/collection2.rs
@@ -178,7 +178,7 @@ fn kept(bytes: &[u8]) -> Result<Option<SavedItem>> {
     while let Some((field, value)) = reader.field()? {
         match (field, value) {
             (ITEM_URI, Value::Bytes(raw)) => uri = Some(text(raw)?),
-            (ITEM_ADDED_AT, Value::Varint(raw)) => {
+            (ITEM_ADDED_AT, Value::Varint(raw) | Value::Fixed(raw)) => {
                 added_at = Some(raw as u32 as i32 as i64);
             }
             (ITEM_REMOVED, Value::Varint(flag)) => removed = flag != 0,
@@ -186,9 +186,29 @@ fn kept(bytes: &[u8]) -> Result<Option<SavedItem>> {
         }
     }
 
+    if added_at.is_none() && uri.is_some() && !removed {
+        log::debug!(
+            "collection: saved item has no date, fields: {}",
+            fields(bytes)
+        );
+    }
+
     Ok(uri
         .filter(|_| !removed)
         .map(|uri| SavedItem { uri, added_at }))
+}
+
+fn fields(bytes: &[u8]) -> String {
+    let mut reader = Reader::new(bytes);
+    let mut seen = Vec::new();
+    while let Ok(Some((field, value))) = reader.field() {
+        seen.push(match value {
+            Value::Varint(raw) => format!("{field}=varint({raw})"),
+            Value::Fixed(raw) => format!("{field}=fixed({raw})"),
+            Value::Bytes(raw) => format!("{field}=bytes({})", raw.len()),
+        });
+    }
+    seen.join(", ")
 }
 
 #[cfg(test)]

--- a/crates/music/src/spotify/pb.rs
+++ b/crates/music/src/spotify/pb.rs
@@ -63,7 +63,7 @@ impl Writer {
 pub(crate) enum Value<'a> {
     Varint(u64),
     Bytes(&'a [u8]),
-    Fixed,
+    Fixed(u64),
 }
 
 pub(crate) struct Reader<'a> {
@@ -85,8 +85,8 @@ impl<'a> Reader<'a> {
         let value = match key & 7 {
             VARINT => Value::Varint(self.varint()?),
             LENGTH => Value::Bytes(self.slice()?),
-            FIXED64 => self.skip(8)?,
-            FIXED32 => self.skip(4)?,
+            FIXED64 => self.fixed(8)?,
+            FIXED32 => self.fixed(4)?,
             kind => bail!("unsupported wire type {kind}"),
         };
 
@@ -114,13 +114,15 @@ impl<'a> Reader<'a> {
         Ok(slice)
     }
 
-    fn skip(&mut self, width: usize) -> Result<Value<'a>> {
+    fn fixed(&mut self, width: usize) -> Result<Value<'a>> {
         let end = self.at.checked_add(width).context("length overflows")?;
-        if end > self.bytes.len() {
-            bail!("truncated field");
-        }
+        let bytes = self.bytes.get(self.at..end).context("truncated field")?;
         self.at = end;
-        Ok(Value::Fixed)
+        let mut value = 0u64;
+        for (shift, byte) in bytes.iter().enumerate() {
+            value |= u64::from(*byte) << (shift * 8);
+        }
+        Ok(Value::Fixed(value))
     }
 }
 

--- a/crates/music/src/spotify/playlists.rs
+++ b/crates/music/src/spotify/playlists.rs
@@ -149,8 +149,11 @@ async fn tracks_from(session: &Session, content: &SelectedListContent) -> Result
         return Ok(Vec::new());
     }
 
-    let mut known = collection::metadata(session, &uris).await?;
-    Ok(uris.iter().filter_map(|uri| known.remove(uri)).collect())
+    let known = collection::metadata(session, &uris).await?;
+    Ok(uris
+        .iter()
+        .filter_map(|uri| known.get(uri).cloned())
+        .collect())
 }
 
 async fn snapshot(session: &Session, playlist_id: &str) -> Result<SelectedListContent> {

--- a/crates/music/src/spotify/search.rs
+++ b/crates/music/src/spotify/search.rs
@@ -32,8 +32,11 @@ pub async fn search(session: &Session, query: &str) -> Result<Vec<Track>> {
         return Ok(Vec::new());
     }
 
-    let mut known = collection::metadata(session, &uris).await?;
-    Ok(uris.iter().filter_map(|uri| known.remove(uri)).collect())
+    let known = collection::metadata(session, &uris).await?;
+    Ok(uris
+        .iter()
+        .filter_map(|uri| known.get(uri).cloned())
+        .collect())
 }
 
 fn escaped(query: &str) -> String {

--- a/crates/state/src/library.rs
+++ b/crates/state/src/library.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -86,6 +86,8 @@ pub struct Library {
     playlist_task: Option<Task<()>>,
     pending: HashMap<String, Task<()>>,
     pending_albums: HashMap<String, Task<()>>,
+    contents: HashMap<String, HashSet<String>>,
+    reading: HashMap<String, Task<()>>,
 }
 
 impl Library {
@@ -103,6 +105,8 @@ impl Library {
                 }
             }
             SessionEvent::SignedOut => {
+                this.contents.clear();
+                this.reading.clear();
                 this.task = None;
                 this.playlist_task = None;
                 this.pending.clear();
@@ -131,6 +135,8 @@ impl Library {
             playlist_task: None,
             pending: HashMap::new(),
             pending_albums: HashMap::new(),
+            contents: HashMap::new(),
+            reading: HashMap::new(),
         };
         if let Some(client) = local_client {
             library.load_local(client, cx);
@@ -343,6 +349,7 @@ impl Library {
         cx: &mut Context<Self>,
     ) {
         let added = playlist_id.clone();
+        let held = track_id.clone();
         let name = self
             .playlist(&playlist_id)
             .map(|playlist| playlist.name.clone());
@@ -353,6 +360,9 @@ impl Library {
             move |client| async move { client.add_track_to_playlist(&playlist_id, &track_id).await },
             move |this, _, cx| {
                 this.amend_playlist(&added, |playlist| playlist.track_count += 1, cx);
+                if let Some(ids) = this.contents.get_mut(&added) {
+                    ids.insert(held);
+                }
             },
             cx,
         );
@@ -406,6 +416,52 @@ impl Library {
             return None;
         };
         albums.iter().find(|album| album.id == id)
+    }
+
+    pub fn holds(&self, playlist_id: &str, track_id: &str) -> Option<bool> {
+        Some(self.contents.get(playlist_id)?.contains(track_id))
+    }
+
+    pub fn read_playlists(&mut self, cx: &mut Context<Self>) {
+        let LibraryState::Ready { playlists, .. } = &self.state else {
+            return;
+        };
+        let wanted: Vec<String> = playlists
+            .iter()
+            .filter(|playlist| playlist.owned || playlist.collaborative)
+            .map(|playlist| playlist.id.clone())
+            .filter(|id| !self.contents.contains_key(id) && !self.reading.contains_key(id))
+            .collect();
+        let Some(client) = self.session.read(cx).client() else {
+            return;
+        };
+
+        for id in wanted {
+            let io = self.io.clone();
+            let client = client.clone();
+            let key = id.clone();
+            let asked = id.clone();
+            let task = cx.spawn(async move |this, cx| {
+                let listed =
+                    join(io.spawn(async move { client.playlist_tracks(&asked).await })).await;
+
+                this.update(cx, |this, cx| {
+                    this.reading.remove(&key);
+                    match listed {
+                        Ok(tracks) => {
+                            let ids = tracks.into_iter().filter_map(|track| track.id).collect();
+                            this.contents.insert(key, ids);
+                            cx.notify();
+                        }
+                        Err(error) => {
+                            log::warn!("library: cannot read a playlist: {error:#}")
+                        }
+                    }
+                })
+                .ok();
+            });
+            self.reading.insert(id.clone(), task);
+        }
     }
 
     pub fn playlist(&self, id: &str) -> Option<&Playlist> {
@@ -543,6 +599,7 @@ impl Library {
                     Ok(loaded) => partial(loaded),
                     Err(error) => LibraryState::Failed(format!("{error:#}")),
                 };
+                this.read_playlists(cx);
                 cx.notify();
             })
             .ok();

--- a/crates/ui/src/menu.rs
+++ b/crates/ui/src/menu.rs
@@ -24,6 +24,8 @@ const SUBMENU_TOP: Pixels = px(-14.);
 const SCROLLBAR_GUTTER: Pixels = px(8.);
 const WINDOW_MARGIN: Pixels = px(8.);
 const PANEL_SLACK: Pixels = px(6.);
+const PAD: f32 = 0.25;
+const BORDER: Pixels = px(1.);
 
 type Press = Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>;
 type Dismiss = Box<dyn Fn(&(), &mut Window, &mut App) + 'static>;
@@ -359,6 +361,7 @@ impl RenderOnce for Menu {
             .collect();
         let bounds_guards = dismiss_guards.clone();
         let viewport_width = window.viewport_size().width;
+        let tucked = (theme.radius - window.rem_size() * PAD - BORDER).max(Pixels::ZERO);
 
         let rows = items.into_iter().map(move |item| {
             let MenuItem {
@@ -406,7 +409,7 @@ impl RenderOnce for Menu {
                 .justify_between()
                 .px_3()
                 .py_1()
-                .rounded(theme.radius)
+                .rounded(tucked)
                 .when_else(
                     disabled,
                     |this| this.text_color(theme.muted_foreground).cursor_default(),

--- a/crates/ui/src/menu.rs
+++ b/crates/ui/src/menu.rs
@@ -156,6 +156,7 @@ pub struct MenuItem {
     id: ElementId,
     label: SharedString,
     selected: bool,
+    checked: bool,
     disabled: bool,
     separator: bool,
     content: Option<AnyElement>,
@@ -173,6 +174,7 @@ impl MenuItem {
             id: id.into(),
             label: label.into(),
             selected: false,
+            checked: false,
             disabled: false,
             separator: false,
             content: None,
@@ -181,6 +183,11 @@ impl MenuItem {
             press: None,
             submenu: None,
         }
+    }
+
+    pub fn checked(mut self, checked: bool) -> Self {
+        self.checked = checked;
+        self
     }
 
     pub fn selected(mut self, selected: bool) -> Self {
@@ -193,6 +200,7 @@ impl MenuItem {
             id: id.into(),
             label: SharedString::default(),
             selected: false,
+            checked: false,
             disabled: true,
             separator: true,
             content: None,
@@ -368,6 +376,7 @@ impl RenderOnce for Menu {
                 id,
                 label,
                 selected,
+                checked,
                 disabled,
                 separator,
                 content,
@@ -439,7 +448,7 @@ impl RenderOnce for Menu {
                         })
                         .child(div().truncate().child(label)),
                 )
-                .when(selected, |this| this.child("✓"))
+                .when(selected || checked, |this| this.child("✓"))
                 .when(submenu.is_some(), |this| this.child("›"))
                 .when_some(submenu_state, |this, state| {
                     this.on_hover(move |hovered, window, cx| {

--- a/crates/ui/src/scrollbar.rs
+++ b/crates/ui/src/scrollbar.rs
@@ -143,6 +143,10 @@ impl Scrollbar {
         self
     }
 
+    pub fn settle(&mut self, offset: Pixels) {
+        self.seen = offset;
+    }
+
     pub fn scroll(&self) -> &ScrollHandle {
         &self.scroll
     }

--- a/crates/views/src/chrome/player_bar.rs
+++ b/crates/views/src/chrome/player_bar.rs
@@ -76,7 +76,7 @@ impl PlayerBar {
         position: Point<Pixels>,
         cx: &mut Context<Self>,
     ) {
-        self.track_menu.reset();
+        self.track_menu.reset(cx);
         self.context_menu = Some((track, position));
         cx.notify();
     }

--- a/crates/views/src/chrome/sidebar_right.rs
+++ b/crates/views/src/chrome/sidebar_right.rs
@@ -599,6 +599,7 @@ impl SidebarRight {
             .small()
             .icon(icon)
             .tooltip(tooltip)
+            .rounded_full()
             .selected(self.tab == tab)
             .tint(match self.tab == tab {
                 true => theme.foreground,

--- a/crates/views/src/chrome/sidebar_right.rs
+++ b/crates/views/src/chrome/sidebar_right.rs
@@ -241,7 +241,7 @@ impl SidebarRight {
                 .as_ref()
                 .is_some_and(|menu| menu.revision != revision)
             {
-                this.track_menu.reset();
+                this.track_menu.reset(cx);
                 this.context_menu = None;
             }
             cx.notify();
@@ -325,7 +325,7 @@ impl SidebarRight {
     }
 
     pub(crate) fn close(&mut self, cx: &mut Context<Self>) {
-        self.track_menu.reset();
+        self.track_menu.reset(cx);
         self.context_menu = None;
         self.open = false;
         self.remember(cx);
@@ -339,7 +339,7 @@ impl SidebarRight {
     }
 
     fn dismiss_menu(&mut self, cx: &mut Context<Self>) {
-        self.track_menu.reset();
+        self.track_menu.reset(cx);
         self.context_menu = None;
         cx.notify();
     }
@@ -390,7 +390,7 @@ impl SidebarRight {
             MouseButton::Right,
             cx.listener(move |this, event: &MouseDownEvent, window, cx| {
                 window.prevent_default();
-                this.track_menu.reset();
+                this.track_menu.reset(cx);
                 this.context_menu = Some(ContextMenuState {
                     track: menu_track.clone(),
                     revision: queue_revision,

--- a/crates/views/src/chrome/sidebar_right.rs
+++ b/crates/views/src/chrome/sidebar_right.rs
@@ -727,6 +727,10 @@ impl SidebarRight {
         if self.verse_of != following {
             self.verse_of = following;
             self.anchor_verse();
+            let scroll = self.verse_bar.read(cx).scroll().clone();
+            scroll.set_offset(gpui::point(scroll.offset().x, px(0.)));
+            self.verse_bar
+                .update(cx, |bar, _| bar.settle(scroll.offset().y));
         }
         if let Some(lines) = &lines {
             self.pin_verse(music::lyrics::active(lines, at), window, cx);
@@ -788,11 +792,13 @@ impl SidebarRight {
             scroll.set_offset(gpui::point(scroll.offset().x, goal));
             self.placed = Some(goal);
             self.goal = None;
+            self.verse_bar.update(cx, |bar, _| bar.settle(goal));
             return;
         }
         let next = current + step * GLIDE;
         scroll.set_offset(gpui::point(scroll.offset().x, next));
         self.placed = Some(next);
+        self.verse_bar.update(cx, |bar, _| bar.settle(next));
         window.request_animation_frame();
     }
 

--- a/crates/views/src/screens/home/mod.rs
+++ b/crates/views/src/screens/home/mod.rs
@@ -39,7 +39,7 @@ impl HomeView {
 
         cx.observe(&home, |this, _, cx| {
             this.quick_picks_page = 0;
-            this.track_menu.reset();
+            this.track_menu.reset(cx);
             this.context_menu = None;
             cx.notify();
         })
@@ -125,7 +125,7 @@ impl Render for HomeView {
                             return;
                         };
                         home.update(cx, |this, cx| {
-                            this.track_menu.reset();
+                            this.track_menu.reset(cx);
                             this.context_menu = Some((place, event.position));
                             cx.notify();
                         });

--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -55,7 +55,7 @@ impl SearchView {
         .detach();
 
         cx.observe(&search, |this, _, cx| {
-            this.track_menu.reset();
+            this.track_menu.reset(cx);
             this.context_menu = None;
             cx.notify();
         })
@@ -169,7 +169,7 @@ impl SearchView {
                             return;
                         };
                         view.update(cx, |this, cx| {
-                            this.track_menu.reset();
+                            this.track_menu.reset(cx);
                             this.context_menu = Some((track.clone(), event.position));
                             cx.notify();
                         });
@@ -255,7 +255,7 @@ impl SearchView {
                         return;
                     };
                     view.update(cx, |this, cx| {
-                        this.track_menu.reset();
+                        this.track_menu.reset(cx);
                         this.context_menu = Some((track.clone(), event.position));
                         cx.notify();
                     });

--- a/crates/views/src/screens/settings.rs
+++ b/crates/views/src/screens/settings.rs
@@ -136,13 +136,13 @@ impl SettingsView {
             ],
             SettingsTab::Appearance => vec![
                 self.theme_row(cx).into_any_element(),
-                self.font_row(cx).into_any_element(),
+                self.opacity_row(cx).into_any_element(),
+                self.adaptive_row(cx).into_any_element(),
             ]
             .into_iter()
             .chain([
-                self.adaptive_row(cx).into_any_element(),
                 self.corners_row(cx).into_any_element(),
-                self.opacity_row(cx).into_any_element(),
+                self.font_row(cx).into_any_element(),
             ])
             .chain(decorated().then(|| self.decorations_row(cx).into_any_element()))
             .chain(decorated().then(|| self.side_row(cx).into_any_element()))

--- a/crates/views/src/shared/menu.rs
+++ b/crates/views/src/shared/menu.rs
@@ -31,9 +31,13 @@ impl ItemMenu {
         }
     }
 
-    pub fn reset(&self) {
+    pub fn reset(&self, cx: &App) {
         self.playlist_submenu.reset();
         self.artist_submenu.reset();
+        self.playlist_scrollbar
+            .read(cx)
+            .scroll()
+            .set_offset(gpui::Point::default());
     }
 
     pub fn for_track(&self, track: &Track, cx: &App) -> Menu {

--- a/crates/views/src/shared/menu.rs
+++ b/crates/views/src/shared/menu.rs
@@ -41,11 +41,11 @@ impl ItemMenu {
     }
 
     pub fn for_track(&self, track: &Track, cx: &App) -> Menu {
-        self.build(track, None, None, None, TrackColumns::default(), cx)
+        self.build(track, None, None, TrackColumns::default(), cx)
     }
 
     pub fn for_table_track(&self, track: &Track, columns: TrackColumns, cx: &App) -> Menu {
-        self.build(track, None, None, None, columns, cx)
+        self.build(track, None, None, columns, cx)
     }
 
     pub fn for_album_track(
@@ -55,7 +55,7 @@ impl ItemMenu {
         columns: TrackColumns,
         cx: &App,
     ) -> Menu {
-        self.build(track, None, None, Some(album_id), columns, cx)
+        self.build(track, None, Some(album_id), columns, cx)
     }
 
     pub fn for_playlist_track(
@@ -65,7 +65,6 @@ impl ItemMenu {
         columns: TrackColumns,
         cx: &App,
     ) -> Menu {
-        let playlist_id = detail.read(cx).id().map(str::to_owned);
         let remove = match track.id.clone() {
             Some(id) => MenuItem::new("remove-from-playlist", t!("menu-remove-from-playlist"))
                 .icon("icons/x.svg")
@@ -76,21 +75,13 @@ impl ItemMenu {
                 .icon("icons/x.svg")
                 .disabled(),
         };
-        self.build(
-            track,
-            Some(remove),
-            playlist_id.as_deref(),
-            None,
-            columns,
-            cx,
-        )
+        self.build(track, Some(remove), None, columns, cx)
     }
 
     fn build(
         &self,
         track: &Track,
         library_action: Option<MenuItem>,
-        current_playlist: Option<&str>,
         current_album: Option<&str>,
         columns: TrackColumns,
         cx: &App,
@@ -100,7 +91,6 @@ impl ItemMenu {
             LibraryState::Ready { playlists, .. } => playlists
                 .iter()
                 .filter(|playlist| playlist.owned || playlist.collaborative)
-                .filter(|playlist| Some(playlist.id.as_str()) != current_playlist)
                 .cloned()
                 .collect(),
             _ => Vec::new(),

--- a/crates/views/src/shared/menu.rs
+++ b/crates/views/src/shared/menu.rs
@@ -129,7 +129,7 @@ impl ItemMenu {
                     let item =
                         MenuItem::new(format!("playlist-{}", playlist.id), playlist.name.clone())
                             .artwork(playlist.cover.clone())
-                            .selected(held);
+                            .checked(held);
                     match track.id.clone() {
                         Some(track_id) => {
                             let library = library.clone();

--- a/crates/views/src/shared/menu.rs
+++ b/crates/views/src/shared/menu.rs
@@ -121,20 +121,37 @@ impl ItemMenu {
                 .item(new_playlist)
                 .item(MenuItem::separator("playlist-separator"))
                 .items(playlists.into_iter().map(|playlist| {
-                    let item = MenuItem::new(format!("playlist-{}", playlist.id), playlist.name)
-                        .artwork(playlist.cover);
+                    let held = track
+                        .id
+                        .as_deref()
+                        .and_then(|id| library.read(cx).holds(&playlist.id, id))
+                        .unwrap_or(false);
+                    let item =
+                        MenuItem::new(format!("playlist-{}", playlist.id), playlist.name.clone())
+                            .artwork(playlist.cover.clone())
+                            .selected(held);
                     match track.id.clone() {
                         Some(track_id) => {
                             let library = library.clone();
-                            let playlist_id = playlist.id;
-                            item.on_click(move |_, _, cx| {
-                                library.update(cx, |library, cx| {
-                                    library.add_to_playlist(
-                                        playlist_id.clone(),
-                                        track_id.clone(),
-                                        cx,
-                                    )
-                                });
+                            let playlist_id = playlist.id.clone();
+                            item.on_click(move |_, window, cx| match held {
+                                true => PlaylistEditor::open(
+                                    Edit::Again {
+                                        playlist: playlist.clone(),
+                                        track: track_id.clone(),
+                                    },
+                                    window,
+                                    cx,
+                                ),
+                                false => {
+                                    library.update(cx, |library, cx| {
+                                        library.add_to_playlist(
+                                            playlist_id.clone(),
+                                            track_id.clone(),
+                                            cx,
+                                        )
+                                    });
+                                }
                             })
                         }
                         None => item.disabled(),

--- a/crates/views/src/shared/playlist_editor.rs
+++ b/crates/views/src/shared/playlist_editor.rs
@@ -13,6 +13,7 @@ pub(crate) enum Edit {
     Create(Option<String>),
     Rename(Playlist),
     Delete(Playlist),
+    Again { playlist: Playlist, track: String },
 }
 
 pub(crate) struct PlaylistEditor {
@@ -48,11 +49,11 @@ impl PlaylistEditor {
     fn show(&mut self, edit: Edit, window: &mut Window, cx: &mut Context<Self>) {
         let name = match &edit {
             Edit::Rename(playlist) => playlist.name.clone(),
-            Edit::Create(_) | Edit::Delete(_) => String::new(),
+            _ => String::new(),
         };
         self.restore = window.focused(cx);
         self.name.update(cx, |input, cx| input.set_text(name, cx));
-        match matches!(edit, Edit::Delete(_)) {
+        match plain(&edit) {
             true => window.focus(&self.focus, cx),
             false => self.name.update(cx, |input, cx| input.focus(window, cx)),
         }
@@ -90,10 +91,17 @@ impl PlaylistEditor {
             Edit::Delete(playlist) => library.update(cx, |library, cx| {
                 library.delete_playlist(playlist.id, cx);
             }),
+            Edit::Again { playlist, track } => library.update(cx, |library, cx| {
+                library.add_to_playlist(playlist.id, track, cx);
+            }),
             _ => {}
         }
         cx.notify();
     }
+}
+
+fn plain(edit: &Edit) -> bool {
+    matches!(edit, Edit::Delete(_) | Edit::Again { .. })
 }
 
 impl Render for PlaylistEditor {
@@ -103,13 +111,18 @@ impl Render for PlaylistEditor {
         };
         let theme = *cx.theme();
         let deleting = matches!(edit, Edit::Delete(_));
+        let asking = plain(&edit);
         let title = match &edit {
             Edit::Create(_) => t!("playlist-create-title"),
             Edit::Rename(_) => t!("playlist-rename-title"),
             Edit::Delete(_) => t!("playlist-delete-title"),
+            Edit::Again { .. } => t!("playlist-again-title"),
         };
         let detail = match &edit {
             Edit::Delete(playlist) => Some(t!("playlist-delete-confirm", name = &playlist.name)),
+            Edit::Again { playlist, .. } => {
+                Some(t!("playlist-again-confirm", name = &playlist.name))
+            }
             _ => None,
         };
 
@@ -130,7 +143,7 @@ impl Render for PlaylistEditor {
                 Modal::new("playlist-editor", title)
                     .width(theme.metrics.cover * 2.8)
                     .when_some(detail, Modal::detail)
-                    .when(!deleting, |modal| modal.child(self.name.clone()))
+                    .when(!asking, |modal| modal.child(self.name.clone()))
                     .action(
                         Button::new("cancel-playlist-edit")
                             .ghost()
@@ -144,9 +157,10 @@ impl Render for PlaylistEditor {
                                 |button| button.danger(),
                                 |button| button.primary(),
                             )
-                            .label(match deleting {
-                                true => t!("common-delete"),
-                                false => t!("common-save"),
+                            .label(match &edit {
+                                Edit::Delete(_) => t!("common-delete"),
+                                Edit::Again { .. } => t!("playlist-again-add"),
+                                _ => t!("common-save"),
                             })
                             .on_click(cx.listener(|this, _, window, cx| this.apply(window, cx))),
                     )

--- a/crates/views/src/shared/tracks/mod.rs
+++ b/crates/views/src/shared/tracks/mod.rs
@@ -364,8 +364,8 @@ impl GridSource for TrackSource {
         })
     }
 
-    fn context_menu_will_open(&self, _row: usize, _cx: &App) {
-        self.menu.reset();
+    fn context_menu_will_open(&self, _row: usize, cx: &App) {
+        self.menu.reset(cx);
     }
 
     fn compare(&self, field: TrackField, a: usize, b: usize, cx: &App) -> Ordering {


### PR DESCRIPTION
## Summary

- mark a playlist that already holds the track with a tick, and confirm before adding a second copy
- keep every occurrence of a track when resolving a Spotify playlist, album, artist or search result, and let YouTube Music accept a duplicate
- offer the playlist you are already viewing in the add-to-playlist menu, and forget that submenu's scroll between openings
- reset the lyrics scroll on a new track and leave the scrollbar asleep while the lyrics follow the song
- nest rounded corners inside their container, and mark a menu item with a tick alone
- read the saved date Spotify sends as a fixed-width field, so Date added stops coming through empty
- reorder the appearance settings