### PR TITLE
docs: describe sonora as a music streaming client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # sonora
 
-A native Spotify client in Rust on [GPUI](https://github.com/zed-industries/zed) (Zed's UI
-framework), streaming through [librespot](https://github.com/librespot-org/librespot) and [ytmusic-rs](https://github.com/noligh132/ytmusic-rs). Cargo workspace, edition 2024, resolver 3.
+A native music streaming client, built with Rust and [GPUI](https://github.com/zed-industries/zed)
+(Zed's UI framework), streaming through [librespot](https://github.com/librespot-org/librespot) and [ytmusic-rs](https://github.com/noligh132/ytmusic-rs). Cargo workspace, edition 2024, resolver 3.
 
 ## Read this before writing code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 # Contributing to Sonora
 
-Sonora is a native Spotify client in Rust on [GPUI](https://github.com/zed-industries/zed),
-streaming through [librespot](https://github.com/librespot-org/librespot). Linux is the platform we mainly
+Sonora is a native music streaming client, built with Rust and
+[GPUI](https://github.com/zed-industries/zed), streaming through
+[librespot](https://github.com/librespot-org/librespot). Linux is the platform we mainly
 develop against. Windows and macOS are built by CI but usually not exercised locally except for
 platform-specific features.
 

--- a/assets/linux/sonora.desktop
+++ b/assets/linux/sonora.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Name=Sonora
 GenericName=Music Player
-Comment=An unofficial minimal native Spotify client
+Comment=A native music streaming client, built with Rust and GPUI
 Icon=sonora
 Exec=sonora %u
 Terminal=false

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Sonora - a minimal native Spotify client";
+  description = "Sonora - a native music streaming client";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -88,7 +88,7 @@
             '';
 
             meta = {
-              description = "A minimal native Spotify client built with GPUI";
+              description = "A native music streaming client, built with Rust and GPUI";
               mainProgram = "sonora";
               license = with pkgs.lib.licenses; [
                 gpl3Plus
@@ -143,7 +143,7 @@
             '';
 
             meta = sonora.meta // {
-              description = "A minimal native Spotify client built with GPUI (prebuilt release binary)";
+              description = "A native music streaming client, built with Rust and GPUI (prebuilt release binary)";
             };
           };
         in


### PR DESCRIPTION
## Summary

- describe sonora as a native music streaming client instead of a Spotify client, matching the readme