### PR TITLE
feat(ui): glide the scroll instead of jumping

### DIFF
--- a/crates/ui/src/deck.rs
+++ b/crates/ui/src/deck.rs
@@ -17,6 +17,7 @@ pub struct Deck {
     viewport: Viewport,
     rows: Vec<Pixels>,
     gap: Pixels,
+    across: bool,
     draw: Option<Draw>,
     measure: Option<Measure>,
 }
@@ -30,9 +31,15 @@ impl Deck {
             viewport: Viewport::default(),
             rows: Vec::new(),
             gap: Pixels::ZERO,
+            across: false,
             draw: None,
             measure: None,
         }
+    }
+
+    pub fn across(mut self) -> Self {
+        self.across = true;
+        self
     }
 
     pub fn viewport(mut self, viewport: Viewport) -> Self {
@@ -92,6 +99,7 @@ impl RenderOnce for Deck {
             viewport,
             rows,
             gap,
+            across,
             draw,
             measure,
         } = self;
@@ -106,11 +114,20 @@ impl RenderOnce for Deck {
                 let Some(head) = bounds.first() else {
                     return;
                 };
-                measure(head.origin.y - first, window, cx);
+                let start = match across {
+                    true => head.origin.x,
+                    false => head.origin.y,
+                };
+                measure(start - first, window, cx);
             })
         });
+        let reach = extent(&rows, gap);
 
-        let mut deck = base.id(id).relative().w_full().h(extent(&rows, gap));
+        let mut deck = base.id(id).relative().when_else(
+            across,
+            |this| this.h_full().w(reach),
+            |this| this.w_full().h(reach),
+        );
         deck.style().refine(&overrides);
 
         match draw {
@@ -118,10 +135,11 @@ impl RenderOnce for Deck {
             Some(draw) => deck.children(shown.map(|index| {
                 div()
                     .absolute()
-                    .top(tops[index])
-                    .left_0()
-                    .w_full()
-                    .h(rows[index])
+                    .when_else(
+                        across,
+                        |this| this.left(tops[index]).top_0().h_full().w(rows[index]),
+                        |this| this.top(tops[index]).left_0().w_full().h(rows[index]),
+                    )
                     .overflow_hidden()
                     .child(draw(index, window, cx))
             })),

--- a/crates/ui/src/glide.rs
+++ b/crates/ui/src/glide.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use gpui::{Pixels, Point, ScrollHandle, Window, point, px};
 
-const EASE: f32 = 0.22;
+const EASE: f32 = 0.12;
 const REST: Pixels = px(0.5);
 
 #[derive(Default)]

--- a/crates/ui/src/glide.rs
+++ b/crates/ui/src/glide.rs
@@ -1,0 +1,67 @@
+use gpui::{Pixels, Point, ScrollHandle, Window, point, px};
+
+const EASE: f32 = 0.22;
+const REST: Pixels = px(0.5);
+
+#[derive(Default)]
+pub struct Glide {
+    shown: Point<Pixels>,
+    target: Point<Pixels>,
+    gliding: bool,
+}
+
+impl Glide {
+    pub fn nudge(&mut self, scroll: &ScrollHandle) {
+        let landed = scroll.offset();
+        let step = landed - self.shown;
+        let from = match self.gliding {
+            true => self.target,
+            false => self.shown,
+        };
+
+        self.target = held(from + step, scroll);
+        self.gliding = true;
+        scroll.set_offset(self.shown);
+    }
+
+    pub fn aim(&mut self, scroll: &ScrollHandle, to: Point<Pixels>) {
+        self.target = held(to, scroll);
+        self.gliding = true;
+    }
+
+    pub fn goal(&self, scroll: &ScrollHandle) -> Point<Pixels> {
+        match self.gliding {
+            true => self.target,
+            false => scroll.offset(),
+        }
+    }
+
+    pub fn step(&mut self, scroll: &ScrollHandle, window: &mut Window) {
+        if !self.gliding {
+            self.shown = scroll.offset();
+            return;
+        }
+
+        let target = held(self.target, scroll);
+        let step = target - self.shown;
+        if step.x.abs() < REST && step.y.abs() < REST {
+            self.shown = target;
+            self.gliding = false;
+            scroll.set_offset(target);
+            return;
+        }
+
+        self.shown += point(step.x * EASE, step.y * EASE);
+        scroll.set_offset(self.shown);
+        window.request_animation_frame();
+    }
+}
+
+fn held(at: Point<Pixels>, scroll: &ScrollHandle) -> Point<Pixels> {
+    let reach = scroll.max_offset();
+
+    point(
+        at.x.clamp(-reach.x.max(Pixels::ZERO), Pixels::ZERO),
+        at.y.clamp(-reach.y.max(Pixels::ZERO), Pixels::ZERO),
+    )
+}

--- a/crates/ui/src/glide.rs
+++ b/crates/ui/src/glide.rs
@@ -98,7 +98,7 @@ impl Glide {
         };
 
         scroll.set_offset(landed);
-        window.request_animation_frame();
+        window.refresh();
         self.arm(scroll, window);
     }
 }

--- a/crates/ui/src/glide.rs
+++ b/crates/ui/src/glide.rs
@@ -1,9 +1,12 @@
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::time::{Duration, Instant};
 
 use gpui::{Pixels, Point, ScrollHandle, Window, point, px};
 
 const EASE: f32 = 0.12;
+const HERTZ: f32 = 180.;
+const STALL: Duration = Duration::from_millis(64);
 const REST: Pixels = px(0.5);
 
 #[derive(Default)]
@@ -12,6 +15,7 @@ struct Drift {
     target: Point<Pixels>,
     gliding: bool,
     armed: bool,
+    beat: Option<Instant>,
 }
 
 #[derive(Clone, Default)]
@@ -82,16 +86,25 @@ impl Glide {
                 return;
             }
 
+            let now = Instant::now();
+            let elapsed = drift
+                .beat
+                .replace(now)
+                .map(|beat| now.duration_since(beat).min(STALL))
+                .unwrap_or(Duration::from_secs_f32(1. / HERTZ));
+            let ease = 1. - (1. - EASE).powf(elapsed.as_secs_f32() * HERTZ);
+
             let target = held(drift.target, scroll);
             let step = target - drift.shown;
             match step.x.abs() < REST && step.y.abs() < REST {
                 true => {
                     drift.shown = target;
                     drift.gliding = false;
+                    drift.beat = None;
                     target
                 }
                 false => {
-                    drift.shown += point(step.x * EASE, step.y * EASE);
+                    drift.shown += point(step.x * ease, step.y * ease);
                     drift.shown
                 }
             }

--- a/crates/ui/src/glide.rs
+++ b/crates/ui/src/glide.rs
@@ -1,59 +1,105 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use gpui::{Pixels, Point, ScrollHandle, Window, point, px};
 
 const EASE: f32 = 0.22;
 const REST: Pixels = px(0.5);
 
 #[derive(Default)]
-pub struct Glide {
+struct Drift {
     shown: Point<Pixels>,
     target: Point<Pixels>,
     gliding: bool,
+    armed: bool,
 }
 
-impl Glide {
-    pub fn nudge(&mut self, scroll: &ScrollHandle) {
-        let landed = scroll.offset();
-        let step = landed - self.shown;
-        let from = match self.gliding {
-            true => self.target,
-            false => self.shown,
-        };
+#[derive(Clone, Default)]
+pub struct Glide(Rc<RefCell<Drift>>);
 
-        self.target = held(from + step, scroll);
-        self.gliding = true;
-        scroll.set_offset(self.shown);
+impl Glide {
+    pub fn sync(&self, scroll: &ScrollHandle) {
+        let mut drift = self.0.borrow_mut();
+        if !drift.gliding {
+            drift.shown = scroll.offset();
+        }
     }
 
-    pub fn aim(&mut self, scroll: &ScrollHandle, to: Point<Pixels>) {
-        self.target = held(to, scroll);
-        self.gliding = true;
+    pub fn nudge(&self, scroll: &ScrollHandle, window: &mut Window) {
+        {
+            let mut drift = self.0.borrow_mut();
+            let landed = scroll.offset();
+            let step = landed - drift.shown;
+            let from = match drift.gliding {
+                true => drift.target,
+                false => drift.shown,
+            };
+
+            drift.target = held(from + step, scroll);
+            drift.gliding = true;
+            scroll.set_offset(drift.shown);
+        }
+        self.arm(scroll, window);
+    }
+
+    pub fn aim(&self, scroll: &ScrollHandle, to: Point<Pixels>, window: &mut Window) {
+        {
+            let mut drift = self.0.borrow_mut();
+            drift.target = held(to, scroll);
+            drift.gliding = true;
+        }
+        self.arm(scroll, window);
     }
 
     pub fn goal(&self, scroll: &ScrollHandle) -> Point<Pixels> {
-        match self.gliding {
-            true => self.target,
+        let drift = self.0.borrow();
+
+        match drift.gliding {
+            true => drift.target,
             false => scroll.offset(),
         }
     }
 
-    pub fn step(&mut self, scroll: &ScrollHandle, window: &mut Window) {
-        if !self.gliding {
-            self.shown = scroll.offset();
-            return;
+    fn arm(&self, scroll: &ScrollHandle, window: &mut Window) {
+        {
+            let mut drift = self.0.borrow_mut();
+            if drift.armed {
+                return;
+            }
+            drift.armed = true;
         }
 
-        let target = held(self.target, scroll);
-        let step = target - self.shown;
-        if step.x.abs() < REST && step.y.abs() < REST {
-            self.shown = target;
-            self.gliding = false;
-            scroll.set_offset(target);
-            return;
-        }
+        let glide = self.clone();
+        let scroll = scroll.clone();
+        window.on_next_frame(move |window, _| glide.step(&scroll, window));
+    }
 
-        self.shown += point(step.x * EASE, step.y * EASE);
-        scroll.set_offset(self.shown);
+    fn step(&self, scroll: &ScrollHandle, window: &mut Window) {
+        let landed = {
+            let mut drift = self.0.borrow_mut();
+            drift.armed = false;
+            if !drift.gliding {
+                return;
+            }
+
+            let target = held(drift.target, scroll);
+            let step = target - drift.shown;
+            match step.x.abs() < REST && step.y.abs() < REST {
+                true => {
+                    drift.shown = target;
+                    drift.gliding = false;
+                    target
+                }
+                false => {
+                    drift.shown += point(step.x * EASE, step.y * EASE);
+                    drift.shown
+                }
+            }
+        };
+
+        scroll.set_offset(landed);
         window.request_animation_frame();
+        self.arm(scroll, window);
     }
 }
 

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -7,6 +7,7 @@ mod drag;
 mod explicit;
 mod filters;
 mod form;
+mod glide;
 mod grid;
 mod info_card;
 mod inline_links;
@@ -45,6 +46,7 @@ pub use drag::{Edge, drop_gap, drop_marker};
 pub use explicit::ExplicitBadge;
 pub use filters::{FlagAxis, RangeAxis, RangeScrubber, RangeState, SortAxis, Unit};
 pub use form::{FORM_CONTEXT, Submit};
+pub use glide::Glide;
 pub use grid::{
     Cell, ColumnSpec, Deselect, GRID_CONTEXT, Grid, GridDelegate, GridEvent, GridSource, GridState,
     Layout, ROW_GROUP, SelectNext, SelectPrevious, Sort, Sorting, Table, Toggle, Viewport, Width,

--- a/crates/ui/src/scrollbar.rs
+++ b/crates/ui/src/scrollbar.rs
@@ -156,12 +156,12 @@ impl Scrollbar {
         self.seen = offset;
     }
 
-    pub fn nudge(&mut self) {
-        self.glide.nudge(&self.scroll.clone());
+    pub fn nudge(&mut self, window: &mut Window) {
+        self.glide.nudge(&self.scroll, window);
     }
 
-    pub fn glide(&mut self, window: &mut Window) {
-        self.glide.step(&self.scroll.clone(), window);
+    pub fn sync(&self) {
+        self.glide.sync(&self.scroll);
     }
 
     pub fn scroll(&self) -> &ScrollHandle {

--- a/crates/ui/src/scrollbar.rs
+++ b/crates/ui/src/scrollbar.rs
@@ -8,6 +8,7 @@ use gpui::{
     MouseDownEvent, Pixels, Render, ScrollHandle, Task, Window, div, point, px,
 };
 
+use crate::glide::Glide;
 use crate::theme::ActiveTheme as _;
 
 const BAR: Pixels = px(6.);
@@ -114,6 +115,7 @@ pub struct Scrollbar {
     hover_guard: Option<HoverGuard>,
     scroll_guard: Option<ScrollGuard>,
     linger: Option<Task<()>>,
+    glide: Glide,
 }
 
 impl Scrollbar {
@@ -130,6 +132,7 @@ impl Scrollbar {
             hover_guard: None,
             scroll_guard: None,
             linger: None,
+            glide: Glide::default(),
         }
     }
 
@@ -151,6 +154,14 @@ impl Scrollbar {
 
     pub fn settle(&mut self, offset: Pixels) {
         self.seen = offset;
+    }
+
+    pub fn nudge(&mut self) {
+        self.glide.nudge(&self.scroll.clone());
+    }
+
+    pub fn glide(&mut self, window: &mut Window) {
+        self.glide.step(&self.scroll.clone(), window);
     }
 
     pub fn scroll(&self) -> &ScrollHandle {

--- a/crates/ui/src/scroller.rs
+++ b/crates/ui/src/scroller.rs
@@ -45,7 +45,7 @@ impl ParentElement for Scroller {
 }
 
 impl RenderOnce for Scroller {
-    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
         let Self {
             mut base,
             id,
@@ -55,7 +55,7 @@ impl RenderOnce for Scroller {
 
         let scroll = bar.read(cx).scroll().clone();
         let overrides = std::mem::take(base.style());
-        bar.update(cx, |bar, _| bar.glide(window));
+        bar.read(cx).sync();
         let gliding = bar.clone();
 
         let mut surface = base
@@ -64,11 +64,11 @@ impl RenderOnce for Scroller {
             .overflow_y_scroll()
             .restrict_scroll_to_axis()
             .track_scroll(&scroll)
-            .on_scroll_wheel(move |event: &ScrollWheelEvent, _, cx| {
+            .on_scroll_wheel(move |event: &ScrollWheelEvent, window, cx| {
                 if event.delta.precise() {
                     return;
                 }
-                gliding.update(cx, |bar, _| bar.nudge());
+                gliding.update(cx, |bar, _| bar.nudge(window));
             })
             .children(children);
 

--- a/crates/ui/src/scroller.rs
+++ b/crates/ui/src/scroller.rs
@@ -1,5 +1,8 @@
 use gpui::prelude::*;
-use gpui::{AnyElement, App, Div, ElementId, Entity, Interactivity, StyleRefinement, Window, div};
+use gpui::{
+    AnyElement, App, Div, ElementId, Entity, Interactivity, ScrollWheelEvent, StyleRefinement,
+    Window, div,
+};
 
 use crate::scrollbar::Scrollbar;
 
@@ -42,7 +45,7 @@ impl ParentElement for Scroller {
 }
 
 impl RenderOnce for Scroller {
-    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let Self {
             mut base,
             id,
@@ -52,6 +55,8 @@ impl RenderOnce for Scroller {
 
         let scroll = bar.read(cx).scroll().clone();
         let overrides = std::mem::take(base.style());
+        bar.update(cx, |bar, _| bar.glide(window));
+        let gliding = bar.clone();
 
         let mut surface = base
             .id(id)
@@ -59,6 +64,12 @@ impl RenderOnce for Scroller {
             .overflow_y_scroll()
             .restrict_scroll_to_axis()
             .track_scroll(&scroll)
+            .on_scroll_wheel(move |event: &ScrollWheelEvent, _, cx| {
+                if event.delta.precise() {
+                    return;
+                }
+                gliding.update(cx, |bar, _| bar.nudge());
+            })
             .children(children);
 
         surface.style().refine(&overrides);

--- a/crates/views/src/screens/genre.rs
+++ b/crates/views/src/screens/genre.rs
@@ -5,10 +5,7 @@ use gpui::{
 };
 use i18n::t;
 use state::{AppSettings, GenreDetails, Playback, Sonora};
-use ui::{
-    ActiveTheme as _, Mode, Popovers, Scrollbar, Scroller, Skeleton, Text, Viewport, scrolled,
-    vacant,
-};
+use ui::{ActiveTheme as _, Mode, Popovers, Scrollbar, Scroller, Skeleton, Text, vacant};
 
 use crate::chrome::{Chrome, Toolbar, Tooled, tools};
 use crate::shared::cells;
@@ -109,15 +106,7 @@ impl Render for GenreView {
         let empty = !loading && sections.is_empty();
         let (mode, width) = (self.mode, self.width);
         let scroll = self.scrollbar.read(cx).scroll().clone();
-        let above = self.shelves.read(cx).above();
-        let seen = scroll.bounds().size.height;
-        let viewport = Viewport {
-            top: (scrolled(&scroll) - above).max(Pixels::ZERO),
-            height: match seen > Pixels::ZERO {
-                true => seen,
-                false => window.viewport_size().height,
-            },
-        };
+        let viewport = self.shelves.read(cx).viewport(&scroll, window);
         let shelves = self.shelves.update(cx, |shelves, cx| {
             shelves.render(&sections, mode, width, viewport, window, cx)
         });

--- a/crates/views/src/screens/genre.rs
+++ b/crates/views/src/screens/genre.rs
@@ -5,7 +5,10 @@ use gpui::{
 };
 use i18n::t;
 use state::{AppSettings, GenreDetails, Playback, Sonora};
-use ui::{ActiveTheme as _, Mode, Popovers, Scrollbar, Scroller, Skeleton, Text, vacant};
+use ui::{
+    ActiveTheme as _, Mode, Popovers, Scrollbar, Scroller, Skeleton, Text, Viewport, scrolled,
+    vacant,
+};
 
 use crate::chrome::{Chrome, Toolbar, Tooled, tools};
 use crate::shared::cells;
@@ -105,9 +108,19 @@ impl Render for GenreView {
         let sections = detail.sections().to_vec();
         let empty = !loading && sections.is_empty();
         let (mode, width) = (self.mode, self.width);
-        let shelves = self
-            .shelves
-            .update(cx, |shelves, cx| shelves.render(&sections, mode, width, cx));
+        let scroll = self.scrollbar.read(cx).scroll().clone();
+        let above = self.shelves.read(cx).above();
+        let seen = scroll.bounds().size.height;
+        let viewport = Viewport {
+            top: (scrolled(&scroll) - above).max(Pixels::ZERO),
+            height: match seen > Pixels::ZERO {
+                true => seen,
+                false => window.viewport_size().height,
+            },
+        };
+        let shelves = self.shelves.update(cx, |shelves, cx| {
+            shelves.render(&sections, mode, width, viewport, window, cx)
+        });
 
         div().flex().flex_col().size_full().child(
             Scroller::new("genre", &self.scrollbar).p(pad).child(
@@ -128,7 +141,7 @@ impl Render for GenreView {
                             .child(SharedString::from(error))
                     }))
                     .when(empty, |this| this.child(vacant(t!("genre-empty"), cx)))
-                    .children(shelves),
+                    .child(shelves),
             ),
         )
     }

--- a/crates/views/src/screens/genre.rs
+++ b/crates/views/src/screens/genre.rs
@@ -105,9 +105,9 @@ impl Render for GenreView {
         let sections = detail.sections().to_vec();
         let empty = !loading && sections.is_empty();
         let (mode, width) = (self.mode, self.width);
-        let shelves = self.shelves.update(cx, |shelves, cx| {
-            shelves.render(&sections, mode, width, window, cx)
-        });
+        let shelves = self
+            .shelves
+            .update(cx, |shelves, cx| shelves.render(&sections, mode, width, cx));
 
         div().flex().flex_col().size_full().child(
             Scroller::new("genre", &self.scrollbar).p(pad).child(

--- a/crates/views/src/screens/genre.rs
+++ b/crates/views/src/screens/genre.rs
@@ -105,9 +105,9 @@ impl Render for GenreView {
         let sections = detail.sections().to_vec();
         let empty = !loading && sections.is_empty();
         let (mode, width) = (self.mode, self.width);
-        let shelves = self
-            .shelves
-            .update(cx, |shelves, cx| shelves.render(&sections, mode, width, cx));
+        let shelves = self.shelves.update(cx, |shelves, cx| {
+            shelves.render(&sections, mode, width, window, cx)
+        });
 
         div().flex().flex_col().size_full().child(
             Scroller::new("genre", &self.scrollbar).p(pad).child(

--- a/crates/views/src/screens/home/mod.rs
+++ b/crates/views/src/screens/home/mod.rs
@@ -3,7 +3,7 @@ use crate::shared::menu::ItemMenu;
 use gpui::prelude::*;
 use gpui::{Context, Entity, Pixels, Point, Render, ScrollHandle, Window, div, px};
 use state::{Home, Playback};
-use ui::{ActiveTheme as _, Mode, Popup, Scrollbar, Scroller};
+use ui::{ActiveTheme as _, Mode, Popup, Scrollbar, Scroller, Viewport, scrolled};
 
 use crate::shared::cells;
 use crate::shared::picks::{Picks, Shape};
@@ -109,11 +109,21 @@ impl Render for HomeView {
         let sections = self.home.read(cx).sections().to_vec();
         let feeding = self.home.read(cx).is_feeding();
         let width = self.width;
+        let scroll = self.scrollbar.read(cx).scroll().clone();
+        let above = self.shelves.read(cx).above();
+        let seen = scroll.bounds().size.height;
+        let viewport = Viewport {
+            top: (scrolled(&scroll) - above).max(Pixels::ZERO),
+            height: match seen > Pixels::ZERO {
+                true => seen,
+                false => window.viewport_size().height,
+            },
+        };
         let shelves = self
             .shelves
             .update(cx, |shelves, cx| match sections.is_empty() && feeding {
                 true => shelves.pending(width, cx),
-                false => shelves.render(&sections, Mode::Cards, width, cx),
+                false => vec![shelves.render(&sections, Mode::Cards, width, viewport, window, cx)],
             });
 
         Scroller::new("home-page", &self.scrollbar)

--- a/crates/views/src/screens/home/mod.rs
+++ b/crates/views/src/screens/home/mod.rs
@@ -3,7 +3,7 @@ use crate::shared::menu::ItemMenu;
 use gpui::prelude::*;
 use gpui::{Context, Entity, Pixels, Point, Render, ScrollHandle, Window, div, px};
 use state::{Home, Playback};
-use ui::{ActiveTheme as _, Mode, Popup, Scrollbar, Scroller, Viewport, scrolled};
+use ui::{ActiveTheme as _, Mode, Popup, Scrollbar, Scroller};
 
 use crate::shared::cells;
 use crate::shared::picks::{Picks, Shape};
@@ -110,15 +110,7 @@ impl Render for HomeView {
         let feeding = self.home.read(cx).is_feeding();
         let width = self.width;
         let scroll = self.scrollbar.read(cx).scroll().clone();
-        let above = self.shelves.read(cx).above();
-        let seen = scroll.bounds().size.height;
-        let viewport = Viewport {
-            top: (scrolled(&scroll) - above).max(Pixels::ZERO),
-            height: match seen > Pixels::ZERO {
-                true => seen,
-                false => window.viewport_size().height,
-            },
-        };
+        let viewport = self.shelves.read(cx).viewport(&scroll, window);
         let shelves = self
             .shelves
             .update(cx, |shelves, cx| match sections.is_empty() && feeding {

--- a/crates/views/src/screens/home/mod.rs
+++ b/crates/views/src/screens/home/mod.rs
@@ -113,7 +113,7 @@ impl Render for HomeView {
             .shelves
             .update(cx, |shelves, cx| match sections.is_empty() && feeding {
                 true => shelves.pending(width, cx),
-                false => shelves.render(&sections, Mode::Cards, width, cx),
+                false => shelves.render(&sections, Mode::Cards, width, window, cx),
             });
 
         Scroller::new("home-page", &self.scrollbar)

--- a/crates/views/src/screens/home/mod.rs
+++ b/crates/views/src/screens/home/mod.rs
@@ -113,7 +113,7 @@ impl Render for HomeView {
             .shelves
             .update(cx, |shelves, cx| match sections.is_empty() && feeding {
                 true => shelves.pending(width, cx),
-                false => shelves.render(&sections, Mode::Cards, width, window, cx),
+                false => shelves.render(&sections, Mode::Cards, width, cx),
             });
 
         Scroller::new("home-page", &self.scrollbar)

--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -14,7 +14,7 @@ use state::{Genres, Hit, Kind, Playback, Search};
 use ui::ActiveTheme as _;
 use ui::{
     Card, Pin, PinKind, Pinnable, Popup, Room, Scrollbar, Scroller, Separator, Text, Theme, VAST,
-    clock, eyebrow, vacant,
+    Viewport, clock, eyebrow, scrolled, vacant,
 };
 
 use crate::shared::cells;
@@ -416,11 +416,16 @@ impl SearchView {
         let theme = *cx.theme();
         let pad = theme.metrics.inset;
         let width = cells::content_width(window, pad * 2., cx);
-        let plates: Vec<AnyElement> = found
-            .into_iter()
-            .enumerate()
-            .map(|(place, genre)| shelves::plate(("genre", place), genre, None, cx))
-            .collect();
+        let scroll = self.browsing.read(cx).scroll().clone();
+        let seen = scroll.bounds().size.height;
+        let viewport = Viewport {
+            top: scrolled(&scroll),
+            height: match seen > Pixels::ZERO {
+                true => seen,
+                false => window.viewport_size().height,
+            },
+        };
+        let plates = shelves::grid("genre", found, width, viewport, window, cx);
 
         div()
             .flex()
@@ -440,7 +445,7 @@ impl SearchView {
                 Scroller::new("search-browse", &self.browsing)
                     .px(gutter)
                     .pb(pad)
-                    .child(shelves::spread(plates, shelves::lanes(width))),
+                    .child(plates),
             )
             .into_any_element()
     }

--- a/crates/views/src/shared/shelves.rs
+++ b/crates/views/src/shared/shelves.rs
@@ -1,7 +1,4 @@
 use gpui::prelude::*;
-use std::cell::RefCell;
-use std::rc::Rc;
-
 use gpui::{
     AnyElement, App, Context, Div, ElementId, Entity, FontWeight, Pixels, ScrollHandle,
     ScrollWheelEvent, SharedString, Window, div, point, px,
@@ -24,7 +21,7 @@ const STEADY: Pixels = px(0.5);
 const PENDING: usize = 3;
 const HEADING: Pixels = px(140.);
 
-type Rail = (ScrollHandle, Rc<RefCell<Glide>>);
+type Rail = (ScrollHandle, Glide);
 
 pub(crate) struct Shelves {
     id: &'static str,
@@ -82,15 +79,13 @@ impl Shelves {
         sections: &[GenreSection],
         mode: Mode,
         width: Pixels,
-        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Vec<AnyElement> {
         while self.rails.len() < sections.len() {
-            self.rails
-                .push((ScrollHandle::new(), Rc::new(RefCell::new(Glide::default()))));
+            self.rails.push((ScrollHandle::new(), Glide::default()));
         }
         for (scroll, glide) in &self.rails {
-            glide.borrow_mut().step(scroll, window);
+            glide.sync(scroll);
         }
 
         sections
@@ -172,11 +167,11 @@ impl Shelves {
                     .on_scroll_wheel({
                         let scroll = handle.clone();
                         let glide = glide.clone();
-                        move |event: &ScrollWheelEvent, _, _| {
+                        move |event: &ScrollWheelEvent, window, _| {
                             if event.delta.precise() {
                                 return;
                             }
-                            glide.borrow_mut().nudge(&scroll);
+                            glide.nudge(&scroll, window);
                         }
                     })
                     .children(cards),
@@ -188,10 +183,10 @@ impl Shelves {
         &self,
         place: usize,
         handle: &ScrollHandle,
-        glide: &Rc<RefCell<Glide>>,
+        glide: &Glide,
         cx: &Context<Self>,
     ) -> AnyElement {
-        let at = glide.borrow().goal(handle).x;
+        let at = glide.goal(handle).x;
         let reach = handle.max_offset().x;
 
         div()
@@ -215,7 +210,7 @@ impl Shelves {
         id: impl Into<ElementId>,
         forward: bool,
         handle: &ScrollHandle,
-        glide: &Rc<RefCell<Glide>>,
+        glide: &Glide,
         cx: &Context<Self>,
     ) -> Button {
         let handle = handle.clone();
@@ -233,8 +228,8 @@ impl Shelves {
                 true => "common-next",
                 false => "common-previous",
             })
-            .on_click(move |_, _, cx| {
-                slide(&handle, &glide, forward);
+            .on_click(move |_, window, cx| {
+                slide(&handle, &glide, forward, window);
                 me.update(cx, |_, cx| cx.notify()).ok();
             })
     }
@@ -366,14 +361,13 @@ fn dressed(card: Card, tile: Option<Pixels>, cx: &App) -> Card {
     }
 }
 
-fn slide(handle: &ScrollHandle, glide: &Rc<RefCell<Glide>>, forward: bool) {
+fn slide(handle: &ScrollHandle, glide: &Glide, forward: bool, window: &mut Window) {
     let page = handle.bounds().size.width;
-    let mut glide = glide.borrow_mut();
     let at = glide.goal(handle);
     let next = match forward {
         true => at.x - page,
         false => at.x + page,
     };
 
-    glide.aim(handle, point(next, at.y));
+    glide.aim(handle, point(next, at.y), window);
 }

--- a/crates/views/src/shared/shelves.rs
+++ b/crates/views/src/shared/shelves.rs
@@ -113,7 +113,7 @@ impl Shelves {
             .rows(heights)
             .gap(STACK_GAP)
             .on_measure(move |top, _, _| above.set(top))
-            .draw(move |place, _, cx| {
+            .draw(move |place, window, cx| {
                 let Some(view) = me.upgrade() else {
                     return div().into_any_element();
                 };
@@ -123,8 +123,10 @@ impl Shelves {
                 let shelves = view.read(cx);
 
                 match mode {
-                    Mode::Cards => shelves.rail(place, section, width, &view.downgrade(), cx),
-                    Mode::List => shelves.lane(place, section, width, cx),
+                    Mode::Cards => {
+                        shelves.rail(place, section, width, &view.downgrade(), window, cx)
+                    }
+                    Mode::List => shelves.lane(place, section, width, window, cx),
                 }
             })
             .into_any_element()
@@ -143,7 +145,7 @@ impl Shelves {
         cx: &App,
     ) -> Pixels {
         let theme = *cx.theme();
-        let head = snapped(theme.text(Text::Large) * LEADING, window) + HEADING_GAP;
+        let head = head(window, cx) + HEADING_GAP;
         let body = match mode {
             Mode::Cards => Card::tile_height(CardGrid::layout(width).card, window, cx),
             Mode::List => {
@@ -157,7 +159,14 @@ impl Shelves {
         head + body
     }
 
-    fn lane(&self, place: usize, section: &GenreSection, width: Pixels, cx: &App) -> AnyElement {
+    fn lane(
+        &self,
+        place: usize,
+        section: &GenreSection,
+        width: Pixels,
+        window: &Window,
+        cx: &App,
+    ) -> AnyElement {
         let lanes = lanes(width);
         let cards = section
             .items
@@ -171,7 +180,13 @@ impl Shelves {
             .flex()
             .flex_col()
             .gap_3()
-            .child(heading(SharedString::from(section.title.clone()), cx))
+            .child(
+                div()
+                    .flex()
+                    .items_end()
+                    .h(head(window, cx))
+                    .child(heading(SharedString::from(section.title.clone()), cx)),
+            )
             .child(spread(cards, lanes))
             .into_any_element()
     }
@@ -182,6 +197,7 @@ impl Shelves {
         section: &GenreSection,
         width: Pixels,
         me: &WeakEntity<Self>,
+        window: &Window,
         cx: &App,
     ) -> AnyElement {
         let layout = CardGrid::layout(width);
@@ -198,6 +214,7 @@ impl Shelves {
         let items = section.items.clone();
         let drawn = me.clone();
         let card = layout.card;
+        let tall = Card::tile_height(card, window, cx);
 
         div()
             .flex()
@@ -209,6 +226,7 @@ impl Shelves {
                     .items_end()
                     .justify_between()
                     .gap_4()
+                    .h(head(window, cx))
                     .child(heading(SharedString::from(section.title.clone()), cx))
                     .when(crowded, |this| {
                         this.child(self.arrows(place, &handle, &glide, me))
@@ -218,6 +236,7 @@ impl Shelves {
                 div()
                     .id((self.id, place))
                     .w_full()
+                    .h(tall)
                     .overflow_x_scroll()
                     .restrict_scroll_to_axis()
                     .track_scroll(&handle)
@@ -457,6 +476,12 @@ fn spread(cards: Vec<AnyElement>, lanes: usize) -> Div {
                 .gap_2()
                 .children(column)
         }))
+}
+
+fn head(window: &Window, cx: &App) -> Pixels {
+    let theme = *cx.theme();
+
+    snapped(theme.text(Text::Title) * LEADING, window).max(theme.metrics.control_small)
 }
 
 fn dressed(card: Card, tile: Option<Pixels>, cx: &App) -> Card {

--- a/crates/views/src/shared/shelves.rs
+++ b/crates/views/src/shared/shelves.rs
@@ -458,7 +458,7 @@ pub(crate) fn grid(
                 .flex()
                 .w_full()
                 .gap_2()
-                .children(cells.map(|cell| div().flex().flex_1().min_w_0().child(cell)))
+                .children(cells.map(|cell| div().flex().flex_col().flex_1().min_w_0().child(cell)))
                 .into_any_element()
         })
         .into_any_element()

--- a/crates/views/src/shared/shelves.rs
+++ b/crates/views/src/shared/shelves.rs
@@ -35,7 +35,7 @@ pub(crate) struct Shelves {
     id: &'static str,
     playback: Entity<Playback>,
     rails: Vec<Rail>,
-    above: Rc<Cell<Pixels>>,
+    above: Rc<Cell<Option<Pixels>>>,
 }
 
 impl Shelves {
@@ -44,7 +44,7 @@ impl Shelves {
             id,
             playback,
             rails: Vec::new(),
-            above: Rc::new(Cell::new(Pixels::ZERO)),
+            above: Rc::new(Cell::new(None)),
         }
     }
 
@@ -112,7 +112,7 @@ impl Shelves {
             .viewport(viewport)
             .rows(heights)
             .gap(STACK_GAP)
-            .on_measure(move |top, _, _| above.set(top))
+            .on_measure(move |top, _, _| above.set(Some(top)))
             .draw(move |place, window, cx| {
                 let Some(view) = me.upgrade() else {
                     return div().into_any_element();
@@ -132,8 +132,19 @@ impl Shelves {
             .into_any_element()
     }
 
-    pub(crate) fn above(&self) -> Pixels {
-        self.above.get()
+    pub(crate) fn viewport(&self, scroll: &ScrollHandle, window: &Window) -> Viewport {
+        let seen = scroll.bounds().size.height;
+
+        Viewport {
+            top: match self.above.get() {
+                Some(above) => (scroll.bounds().origin.y - above).max(Pixels::ZERO),
+                None => Pixels::ZERO,
+            },
+            height: match seen > Pixels::ZERO {
+                true => seen,
+                false => window.viewport_size().height,
+            },
+        }
     }
 
     fn height(

--- a/crates/views/src/shared/shelves.rs
+++ b/crates/views/src/shared/shelves.rs
@@ -1,14 +1,17 @@
 use gpui::prelude::*;
 use gpui::{
     AnyElement, App, Context, Div, ElementId, Entity, FontWeight, Pixels, ScrollHandle,
-    ScrollWheelEvent, SharedString, Window, div, point, px,
+    ScrollWheelEvent, SharedString, WeakEntity, Window, div, point, px,
 };
+use std::cell::Cell;
+use std::rc::Rc;
+
 use music::{Album, GenreItem, GenreSection, Playlist};
 use router::{Destination, navigate};
 use state::{Origin, Playback, PlaybackState};
 use ui::{
-    ActiveTheme as _, Button, Card, Glide, Mode, Pin, PinKind, Pinnable as _, Skeleton, Text,
-    heading,
+    ActiveTheme as _, Button, Card, Deck, Glide, Mode, Pin, PinKind, Pinnable as _, Skeleton, Text,
+    Viewport, heading, snapped,
 };
 
 use crate::shared::album_grid::CardGrid;
@@ -19,6 +22,11 @@ const LANES: usize = 5;
 const ROWS: usize = 3;
 const STEADY: Pixels = px(0.5);
 const PENDING: usize = 3;
+const RAIL_GAP: Pixels = px(16.);
+const STACK_GAP: Pixels = px(32.);
+const LANE_GAP: Pixels = px(8.);
+const HEADING_GAP: Pixels = px(12.);
+const LEADING: f32 = 1.4;
 const HEADING: Pixels = px(140.);
 
 type Rail = (ScrollHandle, Glide);
@@ -27,6 +35,7 @@ pub(crate) struct Shelves {
     id: &'static str,
     playback: Entity<Playback>,
     rails: Vec<Rail>,
+    above: Rc<Cell<Pixels>>,
 }
 
 impl Shelves {
@@ -35,6 +44,7 @@ impl Shelves {
             id,
             playback,
             rails: Vec::new(),
+            above: Rc::new(Cell::new(Pixels::ZERO)),
         }
     }
 
@@ -79,8 +89,10 @@ impl Shelves {
         sections: &[GenreSection],
         mode: Mode,
         width: Pixels,
+        viewport: Viewport,
+        window: &Window,
         cx: &mut Context<Self>,
-    ) -> Vec<AnyElement> {
+    ) -> AnyElement {
         while self.rails.len() < sections.len() {
             self.rails.push((ScrollHandle::new(), Glide::default()));
         }
@@ -88,23 +100,64 @@ impl Shelves {
             glide.sync(scroll);
         }
 
-        sections
+        let heights: Vec<Pixels> = sections
             .iter()
-            .enumerate()
-            .map(|(place, section)| match mode {
-                Mode::Cards => self.rail(place, section, width, cx),
-                Mode::List => self.lane(place, section, width, cx),
+            .map(|section| self.height(section, mode, width, window, cx))
+            .collect();
+        let sections = sections.to_vec();
+        let me = cx.entity().downgrade();
+        let above = self.above.clone();
+
+        Deck::new(self.tag("stack", 0))
+            .viewport(viewport)
+            .rows(heights)
+            .gap(STACK_GAP)
+            .on_measure(move |top, _, _| above.set(top))
+            .draw(move |place, _, cx| {
+                let Some(view) = me.upgrade() else {
+                    return div().into_any_element();
+                };
+                let Some(section) = sections.get(place) else {
+                    return div().into_any_element();
+                };
+                let shelves = view.read(cx);
+
+                match mode {
+                    Mode::Cards => shelves.rail(place, section, width, &view.downgrade(), cx),
+                    Mode::List => shelves.lane(place, section, width, cx),
+                }
             })
-            .collect()
+            .into_any_element()
     }
 
-    fn lane(
+    pub(crate) fn above(&self) -> Pixels {
+        self.above.get()
+    }
+
+    fn height(
         &self,
-        place: usize,
         section: &GenreSection,
+        mode: Mode,
         width: Pixels,
-        cx: &Context<Self>,
-    ) -> AnyElement {
+        window: &Window,
+        cx: &App,
+    ) -> Pixels {
+        let theme = *cx.theme();
+        let head = snapped(theme.text(Text::Large) * LEADING, window) + HEADING_GAP;
+        let body = match mode {
+            Mode::Cards => Card::tile_height(CardGrid::layout(width).card, window, cx),
+            Mode::List => {
+                let lanes = lanes(width);
+                let rows = section.items.len().min(lanes * ROWS).div_ceil(lanes);
+                let row = snapped(theme.metrics.list_row, window);
+                row * rows as f32 + LANE_GAP * rows.saturating_sub(1) as f32
+            }
+        };
+
+        head + body
+    }
+
+    fn lane(&self, place: usize, section: &GenreSection, width: Pixels, cx: &App) -> AnyElement {
         let lanes = lanes(width);
         let cards = section
             .items
@@ -128,17 +181,23 @@ impl Shelves {
         place: usize,
         section: &GenreSection,
         width: Pixels,
-        cx: &Context<Self>,
+        me: &WeakEntity<Self>,
+        cx: &App,
     ) -> AnyElement {
         let layout = CardGrid::layout(width);
         let (handle, glide) = self.rails[place].clone();
         let crowded = section.items.len() > layout.columns;
-        let cards: Vec<AnyElement> = section
-            .items
-            .iter()
-            .enumerate()
-            .map(|(index, item)| self.card(place * 100 + index, item, Some(layout.card), cx))
-            .collect();
+        let seen = match handle.bounds().size.width {
+            reach if reach > Pixels::ZERO => reach,
+            _ => width,
+        };
+        let viewport = Viewport {
+            top: -handle.offset().x.min(Pixels::ZERO),
+            height: seen,
+        };
+        let items = section.items.clone();
+        let drawn = me.clone();
+        let card = layout.card;
 
         div()
             .flex()
@@ -152,15 +211,13 @@ impl Shelves {
                     .gap_4()
                     .child(heading(SharedString::from(section.title.clone()), cx))
                     .when(crowded, |this| {
-                        this.child(self.arrows(place, &handle, &glide, cx))
+                        this.child(self.arrows(place, &handle, &glide, me))
                     }),
             )
             .child(
                 div()
                     .id((self.id, place))
-                    .flex()
                     .w_full()
-                    .gap_4()
                     .overflow_x_scroll()
                     .restrict_scroll_to_axis()
                     .track_scroll(&handle)
@@ -174,7 +231,24 @@ impl Shelves {
                             glide.nudge(&scroll, window);
                         }
                     })
-                    .children(cards),
+                    .child(
+                        Deck::new(self.tag("rail", place))
+                            .across()
+                            .viewport(viewport)
+                            .rows(items.iter().map(|_| card))
+                            .gap(RAIL_GAP)
+                            .draw(move |index, _, cx| {
+                                let Some(view) = drawn.upgrade() else {
+                                    return div().into_any_element();
+                                };
+                                let Some(item) = items.get(index) else {
+                                    return div().into_any_element();
+                                };
+
+                                view.read(cx)
+                                    .card(place * 100 + index, item, Some(card), cx)
+                            }),
+                    ),
             )
             .into_any_element()
     }
@@ -184,7 +258,7 @@ impl Shelves {
         place: usize,
         handle: &ScrollHandle,
         glide: &Glide,
-        cx: &Context<Self>,
+        me: &WeakEntity<Self>,
     ) -> AnyElement {
         let at = glide.goal(handle).x;
         let reach = handle.max_offset().x;
@@ -195,11 +269,11 @@ impl Shelves {
             .items_center()
             .gap_1()
             .child(
-                self.arrow(self.tag("previous", place), false, handle, glide, cx)
+                self.arrow(self.tag("previous", place), false, handle, glide, me)
                     .disabled(at >= -STEADY),
             )
             .child(
-                self.arrow(self.tag("next", place), true, handle, glide, cx)
+                self.arrow(self.tag("next", place), true, handle, glide, me)
                     .disabled(reach > Pixels::ZERO && at <= STEADY - reach),
             )
             .into_any_element()
@@ -211,11 +285,11 @@ impl Shelves {
         forward: bool,
         handle: &ScrollHandle,
         glide: &Glide,
-        cx: &Context<Self>,
+        me: &WeakEntity<Self>,
     ) -> Button {
         let handle = handle.clone();
         let glide = glide.clone();
-        let me = cx.entity().downgrade();
+        let me = me.clone();
 
         Button::new(id)
             .small()
@@ -329,11 +403,42 @@ pub(crate) fn plate(
         .into_any_element()
 }
 
-pub(crate) fn lanes(width: Pixels) -> usize {
+pub(crate) fn grid(
+    id: &'static str,
+    genres: Vec<music::Genre>,
+    width: Pixels,
+    viewport: Viewport,
+    window: &Window,
+    cx: &App,
+) -> AnyElement {
+    let lanes = lanes(width);
+    let row = snapped(cx.theme().metrics.list_row, window);
+    let rows = genres.len().div_ceil(lanes);
+
+    Deck::new(id)
+        .viewport(viewport)
+        .rows((0..rows).map(|_| row))
+        .gap(LANE_GAP)
+        .draw(move |place, _, cx| {
+            let first = place * lanes;
+            let cells = (first..(first + lanes).min(genres.len()))
+                .map(|index| plate((id, index), genres[index].clone(), None, cx));
+
+            div()
+                .flex()
+                .w_full()
+                .gap_2()
+                .children(cells.map(|cell| div().flex().flex_1().min_w_0().child(cell)))
+                .into_any_element()
+        })
+        .into_any_element()
+}
+
+fn lanes(width: Pixels) -> usize {
     ((width / PLATE).floor().max(1.) as usize).min(LANES)
 }
 
-pub(crate) fn spread(cards: Vec<AnyElement>, lanes: usize) -> Div {
+fn spread(cards: Vec<AnyElement>, lanes: usize) -> Div {
     let mut columns: Vec<Vec<AnyElement>> = (0..lanes).map(|_| Vec::new()).collect();
     for (place, card) in cards.into_iter().enumerate() {
         columns[place % lanes].push(card);

--- a/crates/views/src/shared/shelves.rs
+++ b/crates/views/src/shared/shelves.rs
@@ -1,13 +1,17 @@
 use gpui::prelude::*;
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use gpui::{
     AnyElement, App, Context, Div, ElementId, Entity, FontWeight, Pixels, ScrollHandle,
-    SharedString, div, point, px,
+    ScrollWheelEvent, SharedString, Window, div, point, px,
 };
 use music::{Album, GenreItem, GenreSection, Playlist};
 use router::{Destination, navigate};
 use state::{Origin, Playback, PlaybackState};
 use ui::{
-    ActiveTheme as _, Button, Card, Mode, Pin, PinKind, Pinnable as _, Skeleton, Text, heading,
+    ActiveTheme as _, Button, Card, Glide, Mode, Pin, PinKind, Pinnable as _, Skeleton, Text,
+    heading,
 };
 
 use crate::shared::album_grid::CardGrid;
@@ -20,10 +24,12 @@ const STEADY: Pixels = px(0.5);
 const PENDING: usize = 3;
 const HEADING: Pixels = px(140.);
 
+type Rail = (ScrollHandle, Rc<RefCell<Glide>>);
+
 pub(crate) struct Shelves {
     id: &'static str,
     playback: Entity<Playback>,
-    rails: Vec<ScrollHandle>,
+    rails: Vec<Rail>,
 }
 
 impl Shelves {
@@ -76,10 +82,15 @@ impl Shelves {
         sections: &[GenreSection],
         mode: Mode,
         width: Pixels,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Vec<AnyElement> {
         while self.rails.len() < sections.len() {
-            self.rails.push(ScrollHandle::new());
+            self.rails
+                .push((ScrollHandle::new(), Rc::new(RefCell::new(Glide::default()))));
+        }
+        for (scroll, glide) in &self.rails {
+            glide.borrow_mut().step(scroll, window);
         }
 
         sections
@@ -125,7 +136,7 @@ impl Shelves {
         cx: &Context<Self>,
     ) -> AnyElement {
         let layout = CardGrid::layout(width);
-        let handle = self.rails[place].clone();
+        let (handle, glide) = self.rails[place].clone();
         let crowded = section.items.len() > layout.columns;
         let cards: Vec<AnyElement> = section
             .items
@@ -145,7 +156,9 @@ impl Shelves {
                     .justify_between()
                     .gap_4()
                     .child(heading(SharedString::from(section.title.clone()), cx))
-                    .when(crowded, |this| this.child(self.arrows(place, &handle, cx))),
+                    .when(crowded, |this| {
+                        this.child(self.arrows(place, &handle, &glide, cx))
+                    }),
             )
             .child(
                 div()
@@ -156,13 +169,29 @@ impl Shelves {
                     .overflow_x_scroll()
                     .restrict_scroll_to_axis()
                     .track_scroll(&handle)
+                    .on_scroll_wheel({
+                        let scroll = handle.clone();
+                        let glide = glide.clone();
+                        move |event: &ScrollWheelEvent, _, _| {
+                            if event.delta.precise() {
+                                return;
+                            }
+                            glide.borrow_mut().nudge(&scroll);
+                        }
+                    })
                     .children(cards),
             )
             .into_any_element()
     }
 
-    fn arrows(&self, place: usize, handle: &ScrollHandle, cx: &Context<Self>) -> AnyElement {
-        let at = handle.offset().x;
+    fn arrows(
+        &self,
+        place: usize,
+        handle: &ScrollHandle,
+        glide: &Rc<RefCell<Glide>>,
+        cx: &Context<Self>,
+    ) -> AnyElement {
+        let at = glide.borrow().goal(handle).x;
         let reach = handle.max_offset().x;
 
         div()
@@ -171,11 +200,11 @@ impl Shelves {
             .items_center()
             .gap_1()
             .child(
-                self.arrow(self.tag("previous", place), false, handle, cx)
+                self.arrow(self.tag("previous", place), false, handle, glide, cx)
                     .disabled(at >= -STEADY),
             )
             .child(
-                self.arrow(self.tag("next", place), true, handle, cx)
+                self.arrow(self.tag("next", place), true, handle, glide, cx)
                     .disabled(reach > Pixels::ZERO && at <= STEADY - reach),
             )
             .into_any_element()
@@ -186,9 +215,11 @@ impl Shelves {
         id: impl Into<ElementId>,
         forward: bool,
         handle: &ScrollHandle,
+        glide: &Rc<RefCell<Glide>>,
         cx: &Context<Self>,
     ) -> Button {
         let handle = handle.clone();
+        let glide = glide.clone();
         let me = cx.entity().downgrade();
 
         Button::new(id)
@@ -203,7 +234,7 @@ impl Shelves {
                 false => "common-previous",
             })
             .on_click(move |_, _, cx| {
-                slide(&handle, forward);
+                slide(&handle, &glide, forward);
                 me.update(cx, |_, cx| cx.notify()).ok();
             })
     }
@@ -335,14 +366,14 @@ fn dressed(card: Card, tile: Option<Pixels>, cx: &App) -> Card {
     }
 }
 
-fn slide(handle: &ScrollHandle, forward: bool) {
+fn slide(handle: &ScrollHandle, glide: &Rc<RefCell<Glide>>, forward: bool) {
     let page = handle.bounds().size.width;
-    let reach = handle.max_offset().x.max(Pixels::ZERO);
-    let at = handle.offset().x;
+    let mut glide = glide.borrow_mut();
+    let at = glide.goal(handle);
     let next = match forward {
-        true => (at - page).max(-reach),
-        false => (at + page).min(Pixels::ZERO),
+        true => at.x - page,
+        false => at.x + page,
     };
 
-    handle.set_offset(point(next, handle.offset().y));
+    glide.aim(handle, point(next, at.y));
 }


### PR DESCRIPTION
## Summary

- ease every wheel scroll toward its target instead of jumping, vertically through Scroller and horizontally in the shelf rails
- glide the shelf arrows to the next page rather than snapping
- leave trackpad and touch gestures untouched, they are already pixel-precise

closes #59