### PR TITLE
fix(music): recover youtube playback when the direct stream is refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- YouTube tracks that refused to play now do. When YouTube turns down the quick route, Sonora
+  works out the stream signature itself and plays the track anyway, often at a higher bitrate.
+
 ## [0.12.0] - 2026-08-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2909,6 +2909,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -5894,6 +5899,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "relative-path"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca40a312222d8ba74837cb474edef44b37f561da5f773981007a10bbaa992b0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6013,6 +6027,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "rquickjs"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e04e4eedfb060b503b5f0a2644abb890b0b3620d3fb674f9455f230014964e4"
+dependencies = [
+ "rquickjs-core",
+]
+
+[[package]]
+name = "rquickjs-core"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e4f499ac5b943d97ee6dbc44f23c2c10426f420f7d2f1793d6318911b6608c"
+dependencies = [
+ "hashbrown 0.17.1",
+ "relative-path",
+ "rquickjs-sys",
+]
+
+[[package]]
+name = "rquickjs-sys"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13ac243b86a74120814ef7e9e30ad5a2c1199b7b9963b1cf7c84e4cdc1cad99"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -9313,7 +9356,7 @@ dependencies = [
 [[package]]
 name = "ytmusic"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/ytmusic-rs?rev=ef40d9421c01c7ad675d3006fb3dfbfdb21c1aac#ef40d9421c01c7ad675d3006fb3dfbfdb21c1aac"
+source = "git+https://github.com/nolight132/ytmusic-rs?rev=af7d2caddf1a0f681efd35c3385ce4e3456a9ed8#af7d2caddf1a0f681efd35c3385ce4e3456a9ed8"
 dependencies = [
  "aes",
  "anyhow",
@@ -9325,6 +9368,7 @@ dependencies = [
  "rand 0.9.5",
  "regex-lite",
  "reqwest",
+ "rquickjs",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ serde_json = "1.0"
 souvlaki = "0.8"
 sys-locale = "0.3"
 unic-langid = { version = "0.9", features = ["macros"] }
-ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "ef40d9421c01c7ad675d3006fb3dfbfdb21c1aac" }
+ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "af7d2caddf1a0f681efd35c3385ce4e3456a9ed8" }
 
 librespot-core = { version = "0.8.0", default-features = false, features = [
   "rustls-tls-native-roots",

--- a/crates/music/src/youtube/mod.rs
+++ b/crates/music/src/youtube/mod.rs
@@ -27,6 +27,7 @@ pub struct YouTubeProvider {
     authuser: PathBuf,
     guest: PathBuf,
     resolved: PathBuf,
+    player: PathBuf,
 }
 
 impl YouTubeProvider {
@@ -40,6 +41,7 @@ impl YouTubeProvider {
             authuser: cache.join("authuser.txt"),
             guest: cache.join("guest"),
             resolved: cache.join("resolved.json"),
+            player: cache.join("player.json"),
         }
     }
 
@@ -47,8 +49,13 @@ impl YouTubeProvider {
         Arc::new(
             YtMusic::with_cookies(cookies)
                 .as_user(authuser)
-                .cache_resolutions(self.resolved.clone()),
+                .cache_resolutions(self.resolved.clone())
+                .cache_player(self.player.clone()),
         )
+    }
+
+    fn guest_client(&self) -> Arc<YtMusic> {
+        Arc::new(YtMusic::anonymous().cache_player(self.player.clone()))
     }
 
     fn authenticated_session(&self, api: Arc<YtMusic>, profile: UserProfile) -> ProviderSession {
@@ -240,7 +247,7 @@ impl MusicProvider for YouTubeProvider {
         }
         if self.guest.exists() {
             log::debug!("youtube: restoring guest session");
-            return Ok(Some(self.guest_session(Arc::new(YtMusic::anonymous()))));
+            return Ok(Some(self.guest_session(self.guest_client())));
         }
         Ok(None)
     }
@@ -254,7 +261,7 @@ impl MusicProvider for YouTubeProvider {
         match method {
             SignIn::Anonymous | SignIn::Default => {
                 self.store_guest();
-                Ok(self.guest_session(Arc::new(YtMusic::anonymous())))
+                Ok(self.guest_session(self.guest_client()))
             }
             SignIn::Browser(name) => {
                 let browser = self

--- a/crates/music/src/youtube/playback.rs
+++ b/crates/music/src/youtube/playback.rs
@@ -446,13 +446,11 @@ fn announce(events: &UnboundedSender<PlaybackEvent>, slot: &Slot, playing: bool)
 }
 
 async fn fetch(api: &YtMusic, id: &str) -> Result<Loaded> {
-    let format = api.best_audio(id).await?;
-    let duration = format.duration;
-    let data = api.download(&format).await?;
+    let (format, data) = api.load_audio(id).await?;
     Ok(Loaded {
         data: Arc::new(data),
         loudness_db: format.loudness_db,
-        duration,
+        duration: format.duration,
     })
 }
 


### PR DESCRIPTION
## Summary

- bump ytmusic-rs to the revision that deciphers stream signatures in an embedded quickjs runtime
- load youtube audio through `load_audio`, so a refused resolve or a refused download both fall back
- cache the preprocessed solver under the youtube cache dir for both the cookie and the guest client