### PR TITLE
fix(views): highlight only the playing song in search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - YouTube tracks that refused to play now do. When YouTube turns down the quick route, Sonora
   works out the stream signature itself and plays the track anyway, often at a higher bitrate.
+- Search results no longer all look like the track that is playing: only the song actually playing
+  is highlighted and shows a pause button.
 
 ## [0.12.1] - 2026-08-13
 

--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -159,14 +159,15 @@ impl SearchView {
 
         match hit {
             Hit::Song(track) => {
-                let tint = match track.id.is_some() && track.id == self.playback_status.0 {
+                let current = track.id.is_some() && track.id == self.playback_status.0;
+                let tint = match current {
                     true => theme.primary,
                     false => theme.foreground,
                 };
                 let track = track.clone();
                 let view = cx.entity().downgrade();
-                let playing = tint == theme.primary
-                    && self.playback.read(cx).state() == &state::PlaybackState::Playing;
+                let playing =
+                    current && matches!(self.playback_status.1, state::PlaybackState::Playing);
                 let played = track.clone();
                 Card::new(("song", place), track.name.clone())
                     .cover(track.cover.clone())


### PR DESCRIPTION
## Summary

- highlight and show a pause button only on the search result that is actually playing
- derive the search song tint and its play state from one identity check instead of comparing theme colours
