### PR TITLE
feat(state): remember playback across restarts and clear it on a provider switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Sonora remembers what you were listening to. Reopen it and the track you left off on is waiting,
+  paused where you stopped, with the rest of the queue and the tracks you already heard still in
+  place. Press play and it picks up from that second.
+
 ### Fixed
 
 - Switching music service, or signing out, now clears the queue, the history and the current track,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Switching music service, or signing out, now clears the queue, the history and the current track,
+  so nothing from one service is left sitting in the player when you move to another. Music from
+  your imported folder keeps playing.
 - YouTube tracks that refused to play now do. When YouTube turns down the quick route, Sonora
   works out the stream signature itself and plays the track anyway, often at a higher bitrate.
 

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -99,7 +99,7 @@ pub fn init(
     let session =
         cx.new(|cx| Session::new(providers, local_provider, settings.clone(), io.clone(), cx));
     let library = cx.new(|cx| Library::new(session.clone(), io.clone(), cx));
-    let queue = cx.new(|cx| Queue::new(settings.clone(), cx));
+    let queue = cx.new(|cx| Queue::new(session.clone(), settings.clone(), cx));
     let playback = cx.new(|cx| Playback::new(session.clone(), queue.clone(), settings.clone(), cx));
     let lyrics = cx.new(|cx| Lyrics::new(playback.clone(), lyrics_providers, io, cx));
 

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -21,7 +21,7 @@ pub use home::Home;
 pub use library::{Library, LibraryEvent, LibraryState};
 pub use lyrics::{Lyrics, LyricsState};
 pub use playback::{Origin, Playback, PlaybackState, Repeat};
-pub use queue::Queue;
+pub use queue::{Named, Queue, Resume, Stub};
 pub use remote::{Remote, attach as attach_remote};
 pub use search::{AlbumHit, ArtistHit, Hit, Kind, Search};
 pub use session::{ProviderInfo, Session, SessionEvent, SessionState};

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -44,6 +44,7 @@ const POSITION_INTERVAL: Duration = Duration::from_millis(500);
 const PRELOAD_BEFORE_END: Duration = Duration::from_secs(10);
 const SKIP_DEBOUNCE: Duration = Duration::from_millis(250);
 const KEY_COOLDOWN: Duration = Duration::from_secs(6);
+const RESUME_STEP: Duration = Duration::from_secs(5);
 const TAPER_DB: f32 = 50.;
 const SIMILAR_LIMIT: usize = 20;
 
@@ -119,6 +120,9 @@ pub struct Playback {
     skipped: Option<Instant>,
     blocked_until: Option<Instant>,
     refused: bool,
+    armed: Option<Duration>,
+    settle: Option<Duration>,
+    stored: Duration,
 }
 
 impl EventEmitter<PlaybackEvent> for Playback {}
@@ -136,6 +140,7 @@ impl Playback {
                     return;
                 };
                 this.start_engine(playback, cx);
+                this.adopt(cx);
             }
             SessionEvent::SignedOut => this.teardown(cx),
             SessionEvent::LocalChanged => {
@@ -181,6 +186,9 @@ impl Playback {
             skipped: None,
             blocked_until: None,
             refused: false,
+            armed: None,
+            settle: None,
+            stored: Duration::ZERO,
         }
     }
 
@@ -253,6 +261,8 @@ impl Playback {
         self.state = PlaybackState::Loading;
         self.position = Duration::ZERO;
         self.preloaded = None;
+        self.armed = None;
+        self.settle = None;
         cx.notify();
 
         let wait = self
@@ -755,10 +765,64 @@ impl Playback {
     }
 
     pub fn resume(&mut self, cx: &mut Context<Self>) {
+        if let Some(at) = self.armed {
+            return self.rearm(at, cx);
+        }
         if let Some(engine) = self.active_engine() {
             engine.play();
             cx.notify();
         }
+    }
+
+    fn rearm(&mut self, at: Duration, cx: &mut Context<Self>) {
+        let Some(track) = self.track.clone() else {
+            return;
+        };
+        if self.active_engine().is_none() {
+            return;
+        }
+        self.load_after(&track, Start::Pick, cx);
+        self.settle = Some(at);
+    }
+
+    fn adopt(&mut self, cx: &mut Context<Self>) {
+        if self.track.is_some() || !self.queue.read(cx).is_empty() {
+            return;
+        }
+        let Some(slug) = self.session.read(cx).provider_slug() else {
+            return;
+        };
+        let Some(resume) = self
+            .settings
+            .read(cx)
+            .resume()
+            .filter(|resume| resume.provider == slug)
+            .cloned()
+        else {
+            return;
+        };
+
+        let at = Duration::from_secs_f32(resume.position.max(0.));
+        let Some(track) = self.queue.update(cx, |queue, cx| queue.revive(resume, cx)) else {
+            return;
+        };
+        self.track = Some(track);
+        self.state = PlaybackState::Paused;
+        self.position = at;
+        self.stored = at;
+        self.armed = Some(at);
+        cx.notify();
+    }
+
+    fn remember(&mut self, force: bool, cx: &mut Context<Self>) {
+        let position = self.position;
+        if !force && position.abs_diff(self.stored) < RESUME_STEP {
+            return;
+        }
+        self.stored = position;
+        let seconds = position.as_secs_f32();
+        self.settings
+            .update(cx, |settings, cx| settings.set_resume_position(seconds, cx));
     }
 
     pub fn pause(&mut self, cx: &mut Context<Self>) {
@@ -790,6 +854,13 @@ impl Playback {
     }
 
     pub fn seek(&mut self, position: Duration, cx: &mut Context<Self>) {
+        if self.armed.is_some() {
+            self.armed = Some(position);
+            self.position = position;
+            self.remember(true, cx);
+            cx.notify();
+            return;
+        }
         if let Some(engine) = self.active_engine() {
             engine.seek(position);
             self.position = position;
@@ -973,6 +1044,9 @@ impl Playback {
                 let started = self.state != PlaybackState::Playing;
                 self.state = PlaybackState::Playing;
                 self.position = position;
+                if let Some(at) = self.settle.take() {
+                    self.seek(at, cx);
+                }
                 if started {
                     cx.emit(PlaybackEvent::StartedPlayback);
                 }
@@ -980,9 +1054,11 @@ impl Playback {
             BackendEvent::Paused(position) => {
                 self.state = PlaybackState::Paused;
                 self.position = position;
+                self.remember(true, cx);
             }
             BackendEvent::Position(position) => {
                 self.position = position;
+                self.remember(false, cx);
                 self.preload_next(position, cx);
             }
             BackendEvent::Length(duration) => {
@@ -1044,6 +1120,9 @@ impl Playback {
             self.origin = None;
             self.state = PlaybackState::Idle;
             self.position = Duration::ZERO;
+            self.armed = None;
+            self.settle = None;
+            self.stored = Duration::ZERO;
         }
         cx.notify();
     }

--- a/crates/state/src/queue.rs
+++ b/crates/state/src/queue.rs
@@ -3,9 +3,34 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use gpui::{Context, Entity};
 use music::Track;
 
-use crate::AppSettings;
+use crate::{AppSettings, Session, SessionEvent};
 
 const PAST_LIMIT: usize = 500;
+
+fn local(track: &Track) -> bool {
+    track.id.as_deref().is_some_and(music::is_local_id)
+}
+
+fn sift<T>(
+    past: &mut Vec<T>,
+    current: &mut Option<T>,
+    upcoming: &mut VecDeque<T>,
+    source: &mut Vec<T>,
+    keep: impl Fn(&T) -> bool,
+) -> bool {
+    let tally = |past: &Vec<T>, current: &Option<T>, upcoming: &VecDeque<T>, source: &Vec<T>| {
+        past.len() + usize::from(current.is_some()) + upcoming.len() + source.len()
+    };
+
+    let before = tally(past, current, upcoming, source);
+    past.retain(&keep);
+    if current.as_ref().is_some_and(|item| !keep(item)) {
+        *current = None;
+    }
+    upcoming.retain(&keep);
+    source.retain(&keep);
+    before != tally(past, current, upcoming, source)
+}
 
 fn scramble(upcoming: &mut VecDeque<Track>) {
     let mut tracks: Vec<Track> = upcoming.drain(..).collect();
@@ -112,7 +137,17 @@ pub struct Queue {
 }
 
 impl Queue {
-    pub fn new(settings: Entity<AppSettings>, cx: &mut Context<Self>) -> Self {
+    pub fn new(
+        session: Entity<Session>,
+        settings: Entity<AppSettings>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        cx.subscribe(&session, |this, _, event, cx| match event {
+            SessionEvent::SignedOut => this.purge(cx),
+            SessionEvent::SignedIn | SessionEvent::LocalChanged => {}
+        })
+        .detach();
+
         let shuffle = settings.read(cx).shuffle();
 
         Self {
@@ -155,6 +190,22 @@ impl Queue {
         trim(&mut self.past, PAST_LIMIT);
         self.revision = self.revision.wrapping_add(1);
         cx.notify();
+    }
+
+    fn purge(&mut self, cx: &mut Context<Self>) {
+        let suggested = self.similar > 0;
+        self.upcoming.truncate(self.queued());
+        self.similar = 0;
+        let sifted = sift(
+            &mut self.past,
+            &mut self.current,
+            &mut self.upcoming,
+            &mut self.source,
+            local,
+        );
+        if suggested || sifted {
+            self.changed(cx);
+        }
     }
 
     pub fn revision(&self) -> u64 {
@@ -409,7 +460,8 @@ mod tests {
     use music::Track;
 
     use super::{
-        gap_target, in_order, move_item, restore, scramble, select_past, select_upcoming, trim,
+        gap_target, in_order, local, move_item, restore, scramble, select_past, select_upcoming,
+        sift, trim,
     };
 
     fn track(id: &str) -> Track {
@@ -600,6 +652,85 @@ mod tests {
         let to = gap_target(1, 2, items.len());
         assert!(!move_item(&mut items, 1, to));
         assert_eq!(items, [4, 2, 3, 1]);
+    }
+
+    #[test]
+    fn sifting_keeps_only_what_is_wanted() {
+        let mut past = vec![1, 2, 3];
+        let mut current = Some(4);
+        let mut upcoming = VecDeque::from([5, 6]);
+        let mut source = vec![1, 2, 3, 4, 5, 6];
+
+        assert!(sift(
+            &mut past,
+            &mut current,
+            &mut upcoming,
+            &mut source,
+            |item| item % 2 == 0
+        ));
+        assert_eq!(past, [2]);
+        assert_eq!(current, Some(4));
+        assert_eq!(upcoming, [6]);
+        assert_eq!(source, [2, 4, 6]);
+    }
+
+    #[test]
+    fn sifting_reports_an_untouched_queue() {
+        let mut past = vec![1];
+        let mut current = Some(2);
+        let mut upcoming = VecDeque::from([3]);
+        let mut source = vec![1, 2, 3];
+
+        assert!(!sift(
+            &mut past,
+            &mut current,
+            &mut upcoming,
+            &mut source,
+            |_| true
+        ));
+        assert_eq!(past, [1]);
+        assert_eq!(current, Some(2));
+        assert_eq!(upcoming, [3]);
+    }
+
+    #[test]
+    fn signing_out_leaves_only_imported_tracks() {
+        let imported = format!("{}song.flac", music::LOCAL_TRACK_PREFIX);
+        let mut past = vec![track("streamed"), track(&imported)];
+        let mut current = Some(track("playing"));
+        let mut upcoming = VecDeque::from([track("next"), track(&imported)]);
+        let mut source = vec![track("streamed"), track(&imported)];
+
+        assert!(sift(
+            &mut past,
+            &mut current,
+            &mut upcoming,
+            &mut source,
+            local
+        ));
+        assert_eq!(past.len(), 1);
+        assert!(current.is_none());
+        assert_eq!(upcoming.len(), 1);
+        assert_eq!(source.len(), 1);
+        assert!(past.iter().chain(&source).all(local));
+    }
+
+    #[test]
+    fn an_imported_track_outlives_the_session() {
+        let imported = format!("{}song.flac", music::LOCAL_TRACK_PREFIX);
+        let mut past = Vec::new();
+        let mut current = Some(track(&imported));
+        let mut upcoming = VecDeque::new();
+        let mut source = Vec::new();
+
+        assert!(!sift(
+            &mut past,
+            &mut current,
+            &mut upcoming,
+            &mut source,
+            local
+        ));
+        assert!(current.is_some());
     }
 
     #[test]

--- a/crates/state/src/queue.rs
+++ b/crates/state/src/queue.rs
@@ -1,11 +1,122 @@
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::time::Duration;
 
 use gpui::{Context, Entity};
-use music::Track;
+use music::{ArtistRef, Track};
+use serde::{Deserialize, Serialize};
 
 use crate::{AppSettings, Session, SessionEvent};
 
 const PAST_LIMIT: usize = 500;
+const KEPT_PAST: usize = 20;
+const KEPT_UPCOMING: usize = 200;
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Resume {
+    pub(crate) provider: String,
+    pub(crate) position: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) current: Option<Stub>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) past: Vec<Stub>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) upcoming: Vec<Stub>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Stub {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) artists: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) credited: Vec<Named>,
+    pub(crate) album: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) album_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) cover: Option<String>,
+    pub(crate) seconds: f32,
+    pub(crate) explicit: bool,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Named {
+    pub(crate) name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) id: Option<String>,
+}
+
+fn stub(track: &Track) -> Option<Stub> {
+    Some(Stub {
+        id: track.id.clone()?,
+        name: track.name.clone(),
+        artists: track.artists.clone(),
+        credited: track
+            .artist_refs
+            .iter()
+            .map(|artist| Named {
+                name: artist.name.clone(),
+                id: artist.id.clone(),
+            })
+            .collect(),
+        album: track.album.clone(),
+        album_id: track.album_id.clone(),
+        cover: track.cover.clone(),
+        seconds: track.duration.as_secs_f32(),
+        explicit: track.explicit,
+    })
+}
+
+fn hydrate(stub: Stub) -> Track {
+    Track {
+        id: Some(stub.id),
+        name: stub.name,
+        playable: true,
+        artists: stub.artists,
+        artist_refs: stub
+            .credited
+            .into_iter()
+            .map(|named| ArtistRef {
+                name: named.name,
+                id: named.id,
+            })
+            .collect(),
+        album: stub.album,
+        album_id: stub.album_id,
+        cover: stub.cover,
+        duration: Duration::from_secs_f32(stub.seconds.max(0.)),
+        added_at: None,
+        playcount: None,
+        popularity: 0,
+        explicit: stub.explicit,
+        track_number: 0,
+        disc_number: 0,
+        tags: Vec::new(),
+        languages: Vec::new(),
+        credits: Vec::new(),
+    }
+}
+
+fn record<'a>(
+    provider: &str,
+    past: &[Track],
+    current: Option<&Track>,
+    upcoming: impl Iterator<Item = &'a Track>,
+) -> Resume {
+    Resume {
+        provider: provider.to_owned(),
+        position: 0.,
+        current: current.and_then(stub),
+        past: past[past.len().saturating_sub(KEPT_PAST)..]
+            .iter()
+            .filter_map(stub)
+            .collect(),
+        upcoming: upcoming.take(KEPT_UPCOMING).filter_map(stub).collect(),
+    }
+}
 
 fn local(track: &Track) -> bool {
     track.id.as_deref().is_some_and(music::is_local_id)
@@ -133,6 +244,7 @@ pub struct Queue {
     similar: usize,
     shuffle: bool,
     revision: u64,
+    session: Entity<Session>,
     settings: Entity<AppSettings>,
 }
 
@@ -158,6 +270,7 @@ impl Queue {
             similar: 0,
             shuffle,
             revision: 0,
+            session,
             settings,
         }
     }
@@ -189,7 +302,46 @@ impl Queue {
     fn changed(&mut self, cx: &mut Context<Self>) {
         trim(&mut self.past, PAST_LIMIT);
         self.revision = self.revision.wrapping_add(1);
+        self.remember(cx);
         cx.notify();
+    }
+
+    fn blank(&self) -> bool {
+        self.past.is_empty() && self.current.is_none() && self.upcoming.is_empty()
+    }
+
+    fn remember(&mut self, cx: &mut Context<Self>) {
+        let resume = self
+            .session
+            .read(cx)
+            .provider_slug()
+            .filter(|_| !self.blank())
+            .map(|slug| {
+                record(
+                    slug,
+                    &self.past,
+                    self.current.as_ref(),
+                    self.upcoming.range(..self.queued()),
+                )
+            });
+        self.settings
+            .update(cx, |settings, cx| settings.set_resume(resume, cx));
+    }
+
+    pub(crate) fn revive(&mut self, resume: Resume, cx: &mut Context<Self>) -> Option<Track> {
+        self.past = resume.past.into_iter().map(hydrate).collect();
+        self.current = resume.current.map(hydrate);
+        self.upcoming = resume.upcoming.into_iter().map(hydrate).collect();
+        self.similar = 0;
+        self.source = self
+            .past
+            .iter()
+            .chain(self.current.as_ref())
+            .chain(self.upcoming.iter())
+            .cloned()
+            .collect();
+        self.changed(cx);
+        self.current.clone()
     }
 
     fn purge(&mut self, cx: &mut Context<Self>) {
@@ -457,11 +609,11 @@ mod tests {
     use std::collections::VecDeque;
     use std::time::Duration;
 
-    use music::Track;
+    use music::{ArtistRef, Track};
 
     use super::{
-        gap_target, in_order, local, move_item, restore, scramble, select_past, select_upcoming,
-        sift, trim,
+        gap_target, hydrate, in_order, local, move_item, record, restore, scramble, select_past,
+        select_upcoming, sift, stub, trim,
     };
 
     fn track(id: &str) -> Track {
@@ -652,6 +804,69 @@ mod tests {
         let to = gap_target(1, 2, items.len());
         assert!(!move_item(&mut items, 1, to));
         assert_eq!(items, [4, 2, 3, 1]);
+    }
+
+    #[test]
+    fn a_saved_track_keeps_what_the_player_bar_shows() {
+        let mut source = track("abc");
+        source.artists = "One, Two".to_owned();
+        source.artist_refs = vec![
+            ArtistRef {
+                name: "One".to_owned(),
+                id: Some("a1".to_owned()),
+            },
+            ArtistRef {
+                name: "Two".to_owned(),
+                id: None,
+            },
+        ];
+        source.album = "Album".to_owned();
+        source.album_id = Some("al".to_owned());
+        source.cover = Some("https://cover".to_owned());
+        source.explicit = true;
+
+        let saved = stub(&source).expect("a track with an id");
+        let json = serde_json::to_string(&saved).expect("a serializable stub");
+        let restored = hydrate(serde_json::from_str(&json).expect("a readable stub"));
+
+        assert_eq!(restored.id, source.id);
+        assert_eq!(restored.name, source.name);
+        assert_eq!(restored.artists, source.artists);
+        assert_eq!(restored.artist_refs, source.artist_refs);
+        assert_eq!(restored.album, source.album);
+        assert_eq!(restored.album_id, source.album_id);
+        assert_eq!(restored.cover, source.cover);
+        assert_eq!(restored.duration, source.duration);
+        assert!(restored.explicit);
+        assert!(restored.playable);
+    }
+
+    #[test]
+    fn a_track_without_an_id_is_never_saved() {
+        let mut orphan = track("abc");
+        orphan.id = None;
+
+        assert!(stub(&orphan).is_none());
+    }
+
+    #[test]
+    fn a_record_caps_the_history_and_the_queue() {
+        let past = listing(60);
+        let upcoming = listing(300);
+        let current = track("now");
+
+        let resume = record("spotify", &past, Some(&current), upcoming.iter());
+
+        assert_eq!(resume.provider, "spotify");
+        assert_eq!(resume.position, 0.);
+        assert_eq!(resume.current.map(|stub| stub.id), Some("now".to_owned()));
+        assert_eq!(resume.past.len(), 20);
+        assert_eq!(resume.past.first().map(|stub| stub.id.as_str()), Some("40"));
+        assert_eq!(resume.upcoming.len(), 200);
+        assert_eq!(
+            resume.upcoming.first().map(|stub| stub.id.as_str()),
+            Some("0")
+        );
     }
 
     #[test]

--- a/crates/state/src/settings.rs
+++ b/crates/state/src/settings.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use ui::{Layout, Look, Mode, Pin, Rounding, Sorting, ThemeKind, ThemeOverrides};
 
 use crate::Repeat;
-use crate::queue::gap_target;
+use crate::queue::{Resume, gap_target};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -48,6 +48,8 @@ struct Values {
     sorting: HashMap<String, Option<Sorting>>,
     views: HashMap<String, Mode>,
     pinned: Vec<Pin>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resume: Option<Resume>,
     appearance: Appearance,
 }
 
@@ -87,6 +89,7 @@ impl Default for Values {
             sorting: HashMap::new(),
             views: HashMap::new(),
             pinned: Vec::new(),
+            resume: None,
             appearance: Appearance::default(),
         }
     }
@@ -315,6 +318,33 @@ impl AppSettings {
         self.schedule_save(cx);
     }
 
+    pub fn resume(&self) -> Option<&Resume> {
+        self.values.resume.as_ref()
+    }
+
+    pub fn set_resume(&mut self, resume: Option<Resume>, cx: &mut Context<Self>) {
+        let mut resume = resume;
+        if let Some(next) = resume.as_mut() {
+            carry(self.values.resume.as_ref(), next);
+        }
+        if self.values.resume == resume {
+            return;
+        }
+        self.values.resume = resume;
+        self.schedule_save(cx);
+    }
+
+    pub fn set_resume_position(&mut self, position: f32, cx: &mut Context<Self>) {
+        let Some(resume) = self.values.resume.as_mut() else {
+            return;
+        };
+        if resume.position == position {
+            return;
+        }
+        resume.position = position;
+        self.schedule_save(cx);
+    }
+
     pub fn pinned(&self) -> &[Pin] {
         &self.values.pinned
     }
@@ -470,6 +500,13 @@ fn settings_path() -> PathBuf {
         .join("settings.json")
 }
 
+fn carry(previous: Option<&Resume>, next: &mut Resume) {
+    let playing = |resume: &Resume| resume.current.as_ref().map(|stub| stub.id.clone());
+    next.position = previous
+        .filter(|old| old.provider == next.provider && playing(old) == playing(next))
+        .map_or(0., |old| old.position);
+}
+
 fn place(pinned: &mut Vec<Pin>, pin: Pin, gap: Option<usize>) -> bool {
     let gap = gap.unwrap_or(pinned.len()).min(pinned.len());
     let Some(from) = pinned.iter().position(|it| it.same(&pin)) else {
@@ -490,7 +527,59 @@ fn place(pinned: &mut Vec<Pin>, pin: Pin, gap: Option<usize>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::queue::Stub;
     use ui::PinKind;
+
+    fn resume(provider: &str, playing: &str, position: f32) -> Resume {
+        Resume {
+            provider: provider.to_owned(),
+            position,
+            current: Some(Stub {
+                id: playing.to_owned(),
+                ..Stub::default()
+            }),
+            ..Resume::default()
+        }
+    }
+
+    #[test]
+    fn the_saved_position_follows_the_same_track() {
+        let previous = resume("spotify", "abc", 42.);
+        let mut next = resume("spotify", "abc", 0.);
+
+        carry(Some(&previous), &mut next);
+
+        assert_eq!(next.position, 42.);
+    }
+
+    #[test]
+    fn a_new_track_starts_from_the_beginning() {
+        let previous = resume("spotify", "abc", 42.);
+        let mut next = resume("spotify", "def", 0.);
+
+        carry(Some(&previous), &mut next);
+
+        assert_eq!(next.position, 0.);
+    }
+
+    #[test]
+    fn another_provider_never_inherits_a_position() {
+        let previous = resume("spotify", "abc", 42.);
+        let mut next = resume("youtube", "abc", 0.);
+
+        carry(Some(&previous), &mut next);
+
+        assert_eq!(next.position, 0.);
+    }
+
+    #[test]
+    fn a_first_record_starts_from_the_beginning() {
+        let mut next = resume("spotify", "abc", 42.);
+
+        carry(None, &mut next);
+
+        assert_eq!(next.position, 0.);
+    }
 
     fn pin(id: &str) -> Pin {
         Pin::new(PinKind::Album, id, id)


### PR DESCRIPTION
## Summary

- clear the current track, the queue and the play history when the music service changes or you sign out, keeping imported music playing
- remember the queue, the history, the current track and the position inside it, scoped to the service that was signed in
- restore that state paused at the saved second on the next launch, loading and seeking only when play is pressed
