### PR TITLE
fix(state): ready the restored track so play starts in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Sonora remembers what you were listening to. Reopen it and the track you left off on is waiting,
   paused where you stopped, with the rest of the queue and the tracks you already heard still in
-  place. Press play and it picks up from that second.
+  place. It is readied silently in the background, so press play and the music starts from that
+  second at once, without the progress bar sliding into place first.
 
 ### Fixed
 

--- a/crates/music/src/lib.rs
+++ b/crates/music/src/lib.rs
@@ -125,6 +125,14 @@ pub enum PlaybackEvent {
 
 pub trait Player: Send + Sync {
     fn load(&self, track_id: &str, seamless: bool) -> Result<()>;
+
+    fn arm(&self, track_id: &str, at: Duration) -> Result<()> {
+        self.load(track_id, false)?;
+        self.pause();
+        self.seek(at);
+        Ok(())
+    }
+
     fn preload(&self, track_id: &str) -> Result<()>;
     fn play(&self);
     fn pause(&self);

--- a/crates/music/src/local/playback.rs
+++ b/crates/music/src/local/playback.rs
@@ -11,7 +11,7 @@ use crate::{PlaybackConfig, PlaybackEvent, PlaybackEvents, PlaybackFactory, Play
 const POLL: Duration = Duration::from_millis(20);
 
 enum Command {
-    Load { id: String },
+    Load { id: String, at: Option<Duration> },
     Preload { id: String },
     Play,
     Pause,
@@ -45,6 +45,16 @@ impl Player for Engine {
         self.commands
             .send(Command::Load {
                 id: track_id.to_owned(),
+                at: None,
+            })
+            .context("cannot reach local playback engine")
+    }
+
+    fn arm(&self, track_id: &str, at: Duration) -> Result<()> {
+        self.commands
+            .send(Command::Load {
+                id: track_id.to_owned(),
+                at: Some(at),
             })
             .context("cannot reach local playback engine")
     }
@@ -137,22 +147,32 @@ async fn engine_loop(
             command = commands.recv() => {
                 let Some(command) = command else { break };
                 match command {
-                    Command::Load { id } => {
-                        events.send(PlaybackEvent::Loading(Duration::ZERO)).ok();
+                    Command::Load { id, at } => {
+                        events.send(PlaybackEvent::Loading(at.unwrap_or_default())).ok();
                         sink.clear();
                         current = None;
                         queued = None;
                         prev_len = 0;
                         match load(&sink, &id) {
                             Ok(slot) => {
-                                sink.play();
+                                place(&sink, &id, at);
+                                match at {
+                                    Some(_) => sink.pause(),
+                                    None => sink.play(),
+                                }
                                 if let Some(length) = slot.length {
                                     events.send(PlaybackEvent::Length(length)).ok();
                                 }
                                 prev_len = sink.len();
                                 current = Some(slot);
-                                playing = true;
-                                events.send(PlaybackEvent::Playing(Duration::ZERO)).ok();
+                                playing = at.is_none();
+                                let position = at.unwrap_or_default();
+                                events
+                                    .send(match playing {
+                                        true => PlaybackEvent::Playing(position),
+                                        false => PlaybackEvent::Paused(position),
+                                    })
+                                    .ok();
                             }
                             Err(error) => {
                                 log::warn!("playback: cannot load {id}: {error:#}");
@@ -219,6 +239,15 @@ async fn engine_loop(
                 prev_len = len;
             }
         }
+    }
+}
+
+fn place(sink: &rodio::Sink, id: &str, at: Option<Duration>) {
+    let Some(at) = at else {
+        return;
+    };
+    if let Err(error) = sink.try_seek(at) {
+        log::warn!("playback: cannot start {id} at {}s: {error}", at.as_secs());
     }
 }
 

--- a/crates/music/src/spotify/playback.rs
+++ b/crates/music/src/spotify/playback.rs
@@ -91,6 +91,14 @@ impl Engine {
         Ok(())
     }
 
+    fn arm(&self, track_id: &str, at: Duration) -> Result<()> {
+        let uri = track_uri(track_id)?;
+
+        self.flush.request();
+        self.player.load(uri, false, at.as_millis() as u32);
+        Ok(())
+    }
+
     fn preload(&self, track_id: &str) -> Result<()> {
         self.player.preload(track_uri(track_id)?);
         Ok(())
@@ -117,6 +125,10 @@ impl Engine {
 impl MusicPlayer for Engine {
     fn load(&self, track_id: &str, seamless: bool) -> Result<()> {
         self.load(track_id, seamless)
+    }
+
+    fn arm(&self, track_id: &str, at: Duration) -> Result<()> {
+        self.arm(track_id, at)
     }
 
     fn preload(&self, track_id: &str) -> Result<()> {

--- a/crates/music/src/youtube/playback.rs
+++ b/crates/music/src/youtube/playback.rs
@@ -14,7 +14,7 @@ const NORMAL_CAP: f32 = 1.0;
 const POLL: Duration = Duration::from_millis(20);
 
 enum Command {
-    Load { id: String },
+    Load { id: String, at: Option<Duration> },
     Preload { id: String },
     Play,
     Pause,
@@ -56,6 +56,16 @@ impl Player for Engine {
         self.commands
             .send(Command::Load {
                 id: track_id.to_string(),
+                at: None,
+            })
+            .context("cannot reach playback engine")
+    }
+
+    fn arm(&self, track_id: &str, at: Duration) -> Result<()> {
+        self.commands
+            .send(Command::Load {
+                id: track_id.to_string(),
+                at: Some(at),
             })
             .context("cannot reach playback engine")
     }
@@ -173,6 +183,7 @@ async fn engine_loop(
 
     let mut playing = false;
     let mut autostart = true;
+    let mut hold: Option<Duration> = None;
     let mut epoch = 0u64;
     let mut pending: Option<u64> = None;
     let mut inflight: Option<tokio::task::AbortHandle> = None;
@@ -186,8 +197,8 @@ async fn engine_loop(
             command = commands.recv() => {
                 let Some(command) = command else { break };
                 match command {
-                    Command::Load { id } => {
-                        if current.as_ref().is_some_and(|slot| slot.id == id) {
+                    Command::Load { id, at } => {
+                        if at.is_none() && current.as_ref().is_some_and(|slot| slot.id == id) {
                             playing = true;
                             autostart = true;
                             if let Some(slot) = &current {
@@ -214,17 +225,18 @@ async fn engine_loop(
                             inflight =
                                 Some(spawn(&api, id.clone(), epoch, Kind::Play, &fetched));
                         }
-                        events.send(PlaybackEvent::Loading(Duration::ZERO)).ok();
+                        events.send(PlaybackEvent::Loading(at.unwrap_or_default())).ok();
                         silence(&sink, current.as_ref()).await;
                         current = None;
                         queued = None;
                         playing = false;
-                        autostart = true;
+                        autostart = at.is_none();
+                        hold = at;
                         prev_len = 0;
                         let Some(loaded) = cached else { continue };
-                        match begin(&sink, &id, &loaded, &config, autostart) {
+                        match begin(&sink, &id, &loaded, &config, autostart, hold.take()) {
                             Ok(slot) => {
-                                announce(&events, &slot, autostart);
+                                announce(&events, &slot, autostart, at.unwrap_or_default());
                                 prev_len = sink.len();
                                 current = Some(slot);
                                 playing = autostart;
@@ -264,8 +276,10 @@ async fn engine_loop(
                         }
                         events.send(PlaybackEvent::Paused(position)).ok();
                     }
-                    Command::Seek(position) => {
-                        if let Some(slot) = &current {
+                    Command::Seek(position) => match &current {
+                        None if hold.is_some() => hold = Some(position),
+                        None => {}
+                        Some(slot) => {
                             slot.mute();
                             settle(&sink).await;
                             if let Err(error) = sink.try_seek(position) {
@@ -276,7 +290,7 @@ async fn engine_loop(
                             }
                             events.send(PlaybackEvent::Position(sink.get_pos())).ok();
                         }
-                    }
+                    },
                     Command::Gain(level) => output.set_volume(level),
                 }
             }
@@ -292,11 +306,12 @@ async fn engine_loop(
                         }
                         pending = None;
                         inflight = None;
+                        let at = hold.take();
                         match result
-                            .and_then(|loaded| begin(&sink, &id, &loaded, &config, autostart))
+                            .and_then(|loaded| begin(&sink, &id, &loaded, &config, autostart, at))
                         {
                             Ok(slot) => {
-                                announce(&events, &slot, autostart);
+                                announce(&events, &slot, autostart, at.unwrap_or_default());
                                 prev_len = sink.len();
                                 current = Some(slot);
                                 playing = autostart;
@@ -401,9 +416,15 @@ fn begin(
     loaded: &Loaded,
     config: &PlaybackConfig,
     start: bool,
+    at: Option<Duration>,
 ) -> Result<Slot> {
     sink.clear();
     let slot = append(sink, id, loaded, config, true)?;
+    if let Some(at) = at
+        && let Err(error) = sink.try_seek(at)
+    {
+        log::warn!("playback: cannot start {id} at {}s: {error}", at.as_secs());
+    }
     match start {
         true => sink.play(),
         false => sink.pause(),
@@ -434,13 +455,18 @@ fn append(
     })
 }
 
-fn announce(events: &UnboundedSender<PlaybackEvent>, slot: &Slot, playing: bool) {
+fn announce(
+    events: &UnboundedSender<PlaybackEvent>,
+    slot: &Slot,
+    playing: bool,
+    position: Duration,
+) {
     if let Some(length) = slot.length {
         events.send(PlaybackEvent::Length(length)).ok();
     }
     let event = match playing {
-        true => PlaybackEvent::Playing(Duration::ZERO),
-        false => PlaybackEvent::Paused(Duration::ZERO),
+        true => PlaybackEvent::Playing(position),
+        false => PlaybackEvent::Paused(position),
     };
     events.send(event).ok();
 }

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -122,6 +122,7 @@ pub struct Playback {
     refused: bool,
     armed: Option<Duration>,
     settle: Option<Duration>,
+    held: bool,
     stored: Duration,
 }
 
@@ -188,6 +189,7 @@ impl Playback {
             refused: false,
             armed: None,
             settle: None,
+            held: false,
             stored: Duration::ZERO,
         }
     }
@@ -263,6 +265,7 @@ impl Playback {
         self.preloaded = None;
         self.armed = None;
         self.settle = None;
+        self.held = false;
         cx.notify();
 
         let wait = self
@@ -766,7 +769,11 @@ impl Playback {
 
     pub fn resume(&mut self, cx: &mut Context<Self>) {
         if let Some(at) = self.armed {
-            return self.rearm(at, cx);
+            if !self.held {
+                return self.rearm(at, cx);
+            }
+            self.armed = None;
+            self.held = false;
         }
         if let Some(engine) = self.active_engine() {
             engine.play();
@@ -783,6 +790,31 @@ impl Playback {
         }
         self.load_after(&track, Start::Pick, cx);
         self.settle = Some(at);
+    }
+
+    fn hold(&mut self, cx: &mut Context<Self>) {
+        self.held = false;
+        let Some(at) = self.armed else {
+            return;
+        };
+        let Some(track) = self.track.clone() else {
+            return;
+        };
+        let Some(id) = track.id.as_deref().filter(|_| track.playable) else {
+            return;
+        };
+        let Some(engine) = self.engine_for(id) else {
+            return;
+        };
+        match engine.arm(id, at) {
+            Ok(()) => {
+                self.held = true;
+                self.state = PlaybackState::Paused;
+                self.position = at;
+            }
+            Err(error) => log::warn!("playback: cannot hold {}: {error:#}", track.name),
+        }
+        cx.notify();
     }
 
     fn adopt(&mut self, cx: &mut Context<Self>) {
@@ -811,7 +843,7 @@ impl Playback {
         self.position = at;
         self.stored = at;
         self.armed = Some(at);
-        cx.notify();
+        self.hold(cx);
     }
 
     fn remember(&mut self, force: bool, cx: &mut Context<Self>) {
@@ -856,6 +888,11 @@ impl Playback {
     pub fn seek(&mut self, position: Duration, cx: &mut Context<Self>) {
         if self.armed.is_some() {
             self.armed = Some(position);
+            if self.held
+                && let Some(engine) = self.active_engine()
+            {
+                engine.seek(position);
+            }
             self.position = position;
             self.remember(true, cx);
             cx.notify();
@@ -993,6 +1030,7 @@ impl Playback {
             self.state = PlaybackState::Idle;
             self.position = Duration::ZERO;
         }
+        self.hold(cx);
         cx.notify();
     }
 
@@ -1007,6 +1045,7 @@ impl Playback {
 
         self.listen(events, true, cx);
         self.local_engine = Some(engine);
+        self.hold(cx);
     }
 
     fn listen(&mut self, mut events: Box<dyn PlaybackEvents>, local: bool, cx: &mut Context<Self>) {
@@ -1036,6 +1075,11 @@ impl Playback {
             return;
         }
         match event {
+            BackendEvent::Unavailable | BackendEvent::Refused if self.held => {
+                self.held = false;
+                self.state = PlaybackState::Paused;
+                log::warn!("playback: cannot hold the restored track, waiting for play");
+            }
             BackendEvent::Loading(position) => {
                 self.state = PlaybackState::Loading;
                 self.position = position;
@@ -1122,6 +1166,7 @@ impl Playback {
             self.position = Duration::ZERO;
             self.armed = None;
             self.settle = None;
+            self.held = false;
             self.stored = Duration::ZERO;
         }
         cx.notify();


### PR DESCRIPTION
## Summary

- ready the restored track in the engine as soon as the session signs in, paused and silent at the position it was left at
- start playback in place when play is pressed, instead of loading from zero and seeking into position
- add `Player::arm`, so an engine can load a track paused at an offset, with a load-then-seek fallback for engines that cannot
- honour the offset in the spotify, youtube and imported-file engines
- keep scrubbing before the first press working, and fall back to the old load-on-press path when the track cannot be readied
