### PR TITLE
perf(views): share the shelf feed instead of cloning it each frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   paused where you stopped, with the rest of the queue and the tracks you already heard still in
   place. Press play and it picks up from that second.
 
+### Changed
+
+- The home feed, genre pages and the genre grid in search scroll and resize without stuttering,
+  however many shelves the feed carries.
+
 ### Fixed
 
 - Switching music service, or signing out, now clears the queue, the history and the current track,

--- a/crates/state/src/genre.rs
+++ b/crates/state/src/genre.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use gpui::{Context, Entity, Task};
 use music::{Genre, GenreDetail, GenreItem, GenreSection};
 use tokio::task::AbortHandle;
@@ -5,7 +7,7 @@ use tokio::task::AbortHandle;
 use crate::{Io, Session, SessionEvent, join};
 
 pub struct Genres {
-    genres: Vec<Genre>,
+    genres: Rc<Vec<Genre>>,
     loading: bool,
     error: Option<String>,
     session: Entity<Session>,
@@ -19,7 +21,7 @@ impl Genres {
             SessionEvent::SignedIn => this.load(cx),
             SessionEvent::SignedOut => {
                 this.task = None;
-                this.genres.clear();
+                this.genres = Rc::new(Vec::new());
                 this.loading = false;
                 this.error = None;
                 cx.notify();
@@ -29,7 +31,7 @@ impl Genres {
         .detach();
 
         Self {
-            genres: Vec::new(),
+            genres: Rc::new(Vec::new()),
             loading: false,
             error: None,
             session,
@@ -38,16 +40,15 @@ impl Genres {
         }
     }
 
-    pub fn genres(&self) -> &[Genre] {
-        &self.genres
+    pub fn genres(&self) -> Rc<Vec<Genre>> {
+        self.genres.clone()
     }
 
     pub fn adopt(&mut self, id: &str, cover: Option<String>, cx: &mut Context<Self>) {
         let Some(cover) = cover else {
             return;
         };
-        let Some(genre) = self
-            .genres
+        let Some(genre) = Rc::make_mut(&mut self.genres)
             .iter_mut()
             .find(|genre| genre.id == id && genre.cover.is_none())
         else {
@@ -60,7 +61,7 @@ impl Genres {
 
     pub fn forget(&mut self, id: &str, cx: &mut Context<Self>) {
         let kept = self.genres.len();
-        self.genres.retain(|genre| genre.id != id);
+        Rc::make_mut(&mut self.genres).retain(|genre| genre.id != id);
         if self.genres.len() != kept {
             cx.notify();
         }
@@ -93,7 +94,7 @@ impl Genres {
             this.update(cx, |this, cx| {
                 this.loading = false;
                 match loaded {
-                    Ok(genres) => this.genres = genres,
+                    Ok(genres) => this.genres = Rc::new(genres),
                     Err(error) => this.error = Some(format!("{error:#}")),
                 }
                 cx.notify();
@@ -105,7 +106,8 @@ impl Genres {
 
 pub struct GenreDetails {
     id: Option<String>,
-    detail: Option<GenreDetail>,
+    name: Option<String>,
+    sections: Rc<Vec<GenreSection>>,
     loading: bool,
     error: Option<String>,
     session: Entity<Session>,
@@ -138,7 +140,8 @@ impl GenreDetails {
 
         Self {
             id: None,
-            detail: None,
+            name: None,
+            sections: Rc::new(Vec::new()),
             loading: false,
             error: None,
             session,
@@ -150,14 +153,11 @@ impl GenreDetails {
     }
 
     pub fn name(&self) -> Option<&str> {
-        self.detail.as_ref().map(|detail| detail.name.as_str())
+        self.name.as_deref()
     }
 
-    pub fn sections(&self) -> &[GenreSection] {
-        self.detail
-            .as_ref()
-            .map(|detail| detail.sections.as_slice())
-            .unwrap_or_default()
+    pub fn sections(&self) -> Rc<Vec<GenreSection>> {
+        self.sections.clone()
     }
 
     pub fn is_loading(&self) -> bool {
@@ -169,7 +169,7 @@ impl GenreDetails {
     }
 
     pub fn open(&mut self, id: &str, cx: &mut Context<Self>) {
-        if self.id.as_deref() == Some(id) && (self.loading || self.detail.is_some()) {
+        if self.id.as_deref() == Some(id) && (self.loading || self.name.is_some()) {
             return;
         }
 
@@ -209,7 +209,8 @@ impl GenreDetails {
                                 true => genres.forget(&known, cx),
                                 false => genres.adopt(&known, cover, cx),
                             });
-                        this.detail = Some(detail);
+                        this.name = Some(detail.name);
+                        this.sections = Rc::new(detail.sections);
                     }
                     Err(error) => this.error = Some(format!("{error:#}")),
                 }
@@ -225,7 +226,8 @@ impl GenreDetails {
             request.abort();
         }
         self.id = None;
-        self.detail = None;
+        self.name = None;
+        self.sections = Rc::new(Vec::new());
         self.loading = false;
         self.error = None;
     }

--- a/crates/state/src/home.rs
+++ b/crates/state/src/home.rs
@@ -15,7 +15,7 @@ pub struct Home {
     io: Io,
     quick_picks: Rc<Vec<Track>>,
     quick_picks_seed: u64,
-    sections: Vec<GenreSection>,
+    sections: Rc<Vec<GenreSection>>,
     feeding: bool,
     task: Option<Task<()>>,
 }
@@ -34,7 +34,7 @@ impl Home {
             SessionEvent::SignedIn => this.feed(cx),
             SessionEvent::SignedOut => {
                 this.task = None;
-                this.sections.clear();
+                this.sections = Rc::new(Vec::new());
                 this.feeding = false;
                 cx.notify();
             }
@@ -62,7 +62,7 @@ impl Home {
             io,
             quick_picks,
             quick_picks_seed,
-            sections: Vec::new(),
+            sections: Rc::new(Vec::new()),
             feeding: false,
             task: None,
         };
@@ -70,8 +70,8 @@ impl Home {
         home
     }
 
-    pub fn sections(&self) -> &[GenreSection] {
-        &self.sections
+    pub fn sections(&self) -> Rc<Vec<GenreSection>> {
+        self.sections.clone()
     }
 
     pub fn is_feeding(&self) -> bool {
@@ -94,7 +94,7 @@ impl Home {
             this.update(cx, |this, cx| {
                 this.feeding = false;
                 match loaded {
-                    Ok(sections) => this.sections = sections,
+                    Ok(sections) => this.sections = Rc::new(sections),
                     Err(error) => log::warn!("home: cannot load the feed: {error:#}"),
                 }
                 cx.notify();

--- a/crates/views/src/screens/genre.rs
+++ b/crates/views/src/screens/genre.rs
@@ -102,13 +102,13 @@ impl Render for GenreView {
         let loading = detail.is_loading();
         let title = detail.name().unwrap_or_default().to_owned();
         let error = detail.error().map(str::to_owned);
-        let sections = detail.sections().to_vec();
+        let sections = detail.sections();
         let empty = !loading && sections.is_empty();
         let (mode, width) = (self.mode, self.width);
         let scroll = self.scrollbar.read(cx).scroll().clone();
         let viewport = self.shelves.read(cx).viewport(&scroll, window);
         let shelves = self.shelves.update(cx, |shelves, cx| {
-            shelves.render(&sections, mode, width, viewport, window, cx)
+            shelves.render(sections, mode, width, viewport, window, cx)
         });
 
         div().flex().flex_col().size_full().child(

--- a/crates/views/src/screens/home/mod.rs
+++ b/crates/views/src/screens/home/mod.rs
@@ -106,7 +106,7 @@ impl Render for HomeView {
             ))
         });
 
-        let sections = self.home.read(cx).sections().to_vec();
+        let sections = self.home.read(cx).sections();
         let feeding = self.home.read(cx).is_feeding();
         let width = self.width;
         let scroll = self.scrollbar.read(cx).scroll().clone();
@@ -115,7 +115,7 @@ impl Render for HomeView {
             .shelves
             .update(cx, |shelves, cx| match sections.is_empty() && feeding {
                 true => shelves.pending(width, cx),
-                false => vec![shelves.render(&sections, Mode::Cards, width, viewport, window, cx)],
+                false => vec![shelves.render(sections, Mode::Cards, width, viewport, window, cx)],
             });
 
         Scroller::new("home-page", &self.scrollbar)

--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -413,7 +413,7 @@ impl SearchView {
 
     fn browse(&self, gutter: Pixels, window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
         let error = self.genres.read(cx).error().map(str::to_owned);
-        let found = self.genres.read(cx).genres().to_vec();
+        let found = self.genres.read(cx).genres();
         let theme = *cx.theme();
         let pad = theme.metrics.inset;
         let width = cells::content_width(window, pad * 2., cx);

--- a/crates/views/src/shared/shelves.rs
+++ b/crates/views/src/shared/shelves.rs
@@ -86,7 +86,7 @@ impl Shelves {
 
     pub(crate) fn render(
         &mut self,
-        sections: &[GenreSection],
+        sections: Rc<Vec<GenreSection>>,
         mode: Mode,
         width: Pixels,
         viewport: Viewport,
@@ -104,7 +104,6 @@ impl Shelves {
             .iter()
             .map(|section| self.height(section, mode, width, window, cx))
             .collect();
-        let sections = sections.to_vec();
         let me = cx.entity().downgrade();
         let above = self.above.clone();
 
@@ -124,7 +123,7 @@ impl Shelves {
 
                 match mode {
                     Mode::Cards => {
-                        shelves.rail(place, section, width, &view.downgrade(), window, cx)
+                        shelves.rail(place, &sections, width, &view.downgrade(), window, cx)
                     }
                     Mode::List => shelves.lane(place, section, width, window, cx),
                 }
@@ -205,12 +204,15 @@ impl Shelves {
     fn rail(
         &self,
         place: usize,
-        section: &GenreSection,
+        sections: &Rc<Vec<GenreSection>>,
         width: Pixels,
         me: &WeakEntity<Self>,
         window: &Window,
         cx: &App,
     ) -> AnyElement {
+        let Some(section) = sections.get(place) else {
+            return div().into_any_element();
+        };
         let layout = CardGrid::layout(width);
         let (handle, glide) = self.rails[place].clone();
         let crowded = section.items.len() > layout.columns;
@@ -222,7 +224,7 @@ impl Shelves {
             top: -handle.offset().x.min(Pixels::ZERO),
             height: seen,
         };
-        let items = section.items.clone();
+        let feed = sections.clone();
         let drawn = me.clone();
         let card = layout.card;
         let tall = Card::tile_height(card, window, cx);
@@ -265,13 +267,15 @@ impl Shelves {
                         Deck::new(self.tag("rail", place))
                             .across()
                             .viewport(viewport)
-                            .rows(items.iter().map(|_| card))
+                            .rows(section.items.iter().map(|_| card))
                             .gap(RAIL_GAP)
                             .draw(move |index, _, cx| {
                                 let Some(view) = drawn.upgrade() else {
                                     return div().into_any_element();
                                 };
-                                let Some(item) = items.get(index) else {
+                                let Some(item) =
+                                    feed.get(place).and_then(|section| section.items.get(index))
+                                else {
                                     return div().into_any_element();
                                 };
 
@@ -435,7 +439,7 @@ pub(crate) fn plate(
 
 pub(crate) fn grid(
     id: &'static str,
-    genres: Vec<music::Genre>,
+    genres: Rc<Vec<music::Genre>>,
     width: Pixels,
     viewport: Viewport,
     window: &Window,


### PR DESCRIPTION
## Summary

- share the home and genre shelf feed through a reference-counted handle so a repaint no longer deep-clones every section and item
- pass the browse genre list to the search screen by handle rather than by copy
- keep paging, row heights and column packing exactly as they were