### PR TITLE
feat(ui): word selection and a clear button in text fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   second at once, without the progress bar sliding into place first.
 - Double-clicking a word in any text field selects it, and a third click selects everything in the
   field.
+- The search field carries a clear button while it holds text, so one click empties it and brings
+  the full list back.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   paused where you stopped, with the rest of the queue and the tracks you already heard still in
   place. It is readied silently in the background, so press play and the music starts from that
   second at once, without the progress bar sliding into place first.
+- Double-clicking a word in any text field selects it, and a third click selects everything in the
+  field.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ partial translation is welcome — pick a language below and fill in what it lac
 
 | Language | Translated | Coverage |
 | --- | --- | --- |
-| English (`en-US`) | 343/343 | 100% |
-| Deutsch (`de`) | 343/343 | 100% |
-| Français (`fr`) | 343/343 | 100% |
-| Русский (`ru`) | 343/343 | 100% |
-| Українська (`uk`) | 343/343 | 100% |
-| Polski (`pl`) | 343/343 | 100% |
+| English (`en-US`) | 344/344 | 100% |
+| Deutsch (`de`) | 344/344 | 100% |
+| Français (`fr`) | 344/344 | 100% |
+| Русский (`ru`) | 344/344 | 100% |
+| Українська (`uk`) | 344/344 | 100% |
+| Polski (`pl`) | 344/344 | 100% |
 
 <!-- i18n:end -->
 

--- a/assets/i18n/de/main.ftl
+++ b/assets/i18n/de/main.ftl
@@ -15,6 +15,7 @@ common-more = Mehr
 common-previous = Zurück
 common-next = Weiter
 common-dismiss = Schließen
+common-clear = Leeren
 number-group = { "." }
 
 # navigation

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -15,6 +15,7 @@ common-more = More
 common-previous = Previous
 common-next = Next
 common-dismiss = Dismiss
+common-clear = Clear
 number-group = { "," }
 
 # navigation

--- a/assets/i18n/fr/main.ftl
+++ b/assets/i18n/fr/main.ftl
@@ -15,6 +15,7 @@ common-more = Plus
 common-previous = Précédent
 common-next = Suivant
 common-dismiss = Fermer
+common-clear = Effacer
 number-group = { " " }
 
 # navigation

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -15,6 +15,7 @@ common-more = Więcej
 common-previous = Wstecz
 common-next = Dalej
 common-dismiss = Zamknij
+common-clear = Wyczyść
 number-group = { "\u00A0" }
 
 # navigation

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -15,6 +15,7 @@ common-more = Ещё
 common-previous = Назад
 common-next = Вперёд
 common-dismiss = Закрыть
+common-clear = Очистить
 number-group = { "\u00A0" }
 
 # navigation

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -15,6 +15,7 @@ common-more = Ще
 common-previous = Назад
 common-next = Вперед
 common-dismiss = Закрити
+common-clear = Очистити
 number-group = { "\u00A0" }
 
 # navigation

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -5,6 +5,9 @@ use gpui::{
     UnderlineStyle, Window, div, fill, point, px, relative, size, svg,
 };
 
+use i18n::t;
+
+use crate::button::Button;
 use crate::input::{CARET, CARET_LINES, INPUT_CONTEXT, Input, clamp_offset, clamp_range};
 use crate::theme::ActiveTheme as _;
 
@@ -270,6 +273,18 @@ impl Render for Input {
             })
             .child(Text {
                 input: cx.entity().clone(),
+            })
+            .when(self.clearable && !self.content.is_empty(), |this| {
+                this.child(
+                    Button::new("input-clear")
+                        .icon("icons/x.svg")
+                        .tooltip("common-clear")
+                        .aria_label(t!("common-clear"))
+                        .small()
+                        .ghost()
+                        .px_1()
+                        .on_click(cx.listener(|this, _, window, cx| this.clear(window, cx))),
+                )
             })
     }
 }

--- a/crates/ui/src/input/mod.rs
+++ b/crates/ui/src/input/mod.rs
@@ -98,6 +98,33 @@ fn next_word(text: &str, offset: usize) -> usize {
     offset + skipped + end
 }
 
+fn word_at(text: &str, offset: usize) -> Range<usize> {
+    let offset = clamp_offset(text, offset);
+    let after = text[offset..].chars().next();
+    let before = text[..offset].chars().next_back();
+    let Some(anchor) = after
+        .filter(|character| !character.is_whitespace())
+        .or(before)
+        .or(after)
+    else {
+        return offset..offset;
+    };
+
+    let space = anchor.is_whitespace();
+    let start = text[..offset]
+        .char_indices()
+        .rev()
+        .find(|(_, character)| character.is_whitespace() != space)
+        .map(|(index, character)| index + character.len_utf8())
+        .unwrap_or(0);
+    let end = text[offset..]
+        .char_indices()
+        .find(|(_, character)| character.is_whitespace() != space)
+        .map(|(index, _)| offset + index)
+        .unwrap_or(text.len());
+    start..end
+}
+
 fn offset_from_utf16(text: &str, offset: usize) -> usize {
     let mut utf8 = 0;
     let mut utf16 = 0;
@@ -320,12 +347,25 @@ impl Input {
         self.replace_text_in_range(None, &single_line, window, cx);
     }
 
-    fn on_mouse_down(&mut self, event: &MouseDownEvent, _: &mut Window, cx: &mut Context<Self>) {
-        self.selecting = true;
+    fn select_word(&mut self, offset: usize, cx: &mut Context<Self>) {
+        let word = word_at(&self.content, offset);
+        self.move_to(word.start, cx);
+        self.select_to(word.end, cx);
+    }
+
+    fn on_mouse_down(
+        &mut self,
+        event: &MouseDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.selecting = event.click_count < 2;
         let offset = self.offset_for(event.position);
-        match event.modifiers.shift {
-            true => self.select_to(offset, cx),
-            false => self.move_to(offset, cx),
+        match (event.click_count, event.modifiers.shift) {
+            (0 | 1, true) => self.select_to(offset, cx),
+            (0 | 1, false) => self.move_to(offset, cx),
+            (2, _) => self.select_word(offset, cx),
+            _ => self.select_all(&SelectAll, window, cx),
         }
     }
 

--- a/crates/ui/src/input/mod.rs
+++ b/crates/ui/src/input/mod.rs
@@ -156,6 +156,7 @@ pub struct Input {
     hint: SharedString,
     icon: Option<SharedString>,
     compact: bool,
+    clearable: bool,
     content: SharedString,
     selected_range: Range<usize>,
     selection_reversed: bool,
@@ -172,6 +173,7 @@ impl Input {
             hint: hint.into(),
             icon: None,
             compact: false,
+            clearable: false,
             content: SharedString::default(),
             selected_range: 0..0,
             selection_reversed: false,
@@ -189,6 +191,11 @@ impl Input {
 
     pub fn compact(mut self) -> Self {
         self.compact = true;
+        self
+    }
+
+    pub fn clearable(mut self) -> Self {
+        self.clearable = true;
         self
     }
 
@@ -218,6 +225,11 @@ impl Input {
 
     pub fn focus(&self, window: &mut Window, cx: &mut App) {
         window.focus(&self.focus_handle, cx);
+    }
+
+    fn clear(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.set_text("", cx);
+        self.focus(window, cx);
     }
 
     fn cursor(&self) -> usize {

--- a/crates/views/src/chrome/toolbar.rs
+++ b/crates/views/src/chrome/toolbar.rs
@@ -40,6 +40,7 @@ impl Toolbar {
             Input::new("common-search", cx)
                 .icon("icons/search.svg")
                 .compact()
+                .clearable()
         });
 
         cx.observe(&input, |this, input, cx| {


### PR DESCRIPTION
## Summary

- select the word under the cursor on a double click, and the whole field on a third click
- add an opt-in clear button that empties a text field and restores focus
- wire the clear button on the title bar search field