### PR TITLE
fix(ui): keep a scroll region within the room its parent gives it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   space away from its title.
 - Every search result answers a right-click now, not just songs. Artists and albums open the same
   context menu they have elsewhere in the app, in the combined list as well as the three columns.
+- The genre grid on search scrolls all the way to its end, so the last row of plates no longer sits
+  flush against the player bar with its bottom cut off.
 
 ## [0.12.1] - 2026-08-13
 

--- a/crates/ui/src/scroller.rs
+++ b/crates/ui/src/scroller.rs
@@ -74,6 +74,11 @@ impl RenderOnce for Scroller {
 
         surface.style().refine(&overrides);
 
-        div().relative().size_full().child(surface).child(bar)
+        div()
+            .relative()
+            .size_full()
+            .min_h_0()
+            .child(surface)
+            .child(bar)
     }
 }


### PR DESCRIPTION
## Summary

- keep a scroll region inside the height its parent gives it instead of overflowing under the player bar
- restore the trailing space at the end of the genre grid in search, so the last row of plates is fully reachable
