### PR TITLE
fix(views): give the library lists the same trailing space as every page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   context menu they have elsewhere in the app, in the combined list as well as the three columns.
 - The genre grid on search scrolls all the way to its end, so the last row of plates no longer sits
   flush against the player bar with its bottom cut off.
+- Album, playlist and artist lists in your library end with the same breathing room as every other
+  page instead of stopping against the player bar.
 
 ## [0.12.1] - 2026-08-13
 

--- a/crates/views/src/screens/library/mod.rs
+++ b/crates/views/src/screens/library/mod.rs
@@ -893,6 +893,7 @@ impl Render for LibraryView {
                 .when_some(note, |this, note| this.child(vacant(note, cx)))
                 .into_any_element(),
             (_, Mode::List) => Scroller::new("library-page", &self.scrollbar)
+                .pb(inset)
                 .child(self.table(self.section).element())
                 .when_some(note, |this, note| this.child(vacant(note, cx)))
                 .into_any_element(),


### PR DESCRIPTION
## Summary

- end the album, playlist and artist lists in the library with the same trailing space the saved songs list already has
