### PR TITLE
feat: global album and playlist search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Searching now reaches the whole catalogue for albums and playlists, not just the ones your library
+  already knows about. The third column of results holds both, tagged so you can tell them apart,
+  and a playlist behaves like one everywhere: open it, play it, pin it or right-click it for the
+  usual menu. Albums and playlists you have saved still come first.
+
 ### Changed
 
 - The songs, artists and albums columns in search scroll smoothly however many matches come back,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9330,7 +9330,7 @@ dependencies = [
 [[package]]
 name = "ytmusic"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/ytmusic-rs?rev=af7d2caddf1a0f681efd35c3385ce4e3456a9ed8#af7d2caddf1a0f681efd35c3385ce4e3456a9ed8"
+source = "git+https://github.com/nolight132/ytmusic-rs?rev=f771acf85e737b46922e32e7d4f5bc1164216ea5#f771acf85e737b46922e32e7d4f5bc1164216ea5"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ serde_json = "1.0"
 souvlaki = "0.8"
 sys-locale = "0.3"
 unic-langid = { version = "0.9", features = ["macros"] }
-ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "af7d2caddf1a0f681efd35c3385ce4e3456a9ed8" }
+ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "f771acf85e737b46922e32e7d4f5bc1164216ea5" }
 
 librespot-core = { version = "0.8.0", default-features = false, features = [
   "rustls-tls-native-roots",

--- a/assets/i18n/de/main.ftl
+++ b/assets/i18n/de/main.ftl
@@ -222,7 +222,7 @@ search-no-matches = Keine Treffer
 search-results = Ergebnisse
 search-songs = Songs
 search-artists = Künstler
-search-albums = Alben
+search-albums-playlists = Alben & Playlists
 search-tag = { $kind } ·
 search-saved =
     { $count ->

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -222,7 +222,7 @@ search-no-matches = No matches
 search-results = Results
 search-songs = Songs
 search-artists = Artists
-search-albums = Albums
+search-albums-playlists = Albums & playlists
 search-tag = { $kind } ·
 search-saved =
     { $count ->

--- a/assets/i18n/fr/main.ftl
+++ b/assets/i18n/fr/main.ftl
@@ -222,7 +222,7 @@ search-no-matches = Aucun résultat
 search-results = Résultats
 search-songs = Titres
 search-artists = Artistes
-search-albums = Albums
+search-albums-playlists = Albums et playlists
 search-tag = { $kind } ·
 search-saved =
     { $count ->

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -223,7 +223,7 @@ search-no-matches = Brak wyników
 search-results = Wyniki
 search-songs = Utwory
 search-artists = Wykonawcy
-search-albums = Albumy
+search-albums-playlists = Albumy i playlisty
 search-tag = { $kind } ·
 search-saved =
     { $count ->

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -223,7 +223,7 @@ search-no-matches = Ничего не найдено
 search-results = Результаты
 search-songs = Треки
 search-artists = Исполнители
-search-albums = Альбомы
+search-albums-playlists = Альбомы и плейлисты
 search-tag = { $kind } ·
 search-saved =
     { $count ->

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -223,7 +223,7 @@ search-no-matches = Нічого не знайдено
 search-results = Результати
 search-songs = Треки
 search-artists = Виконавці
-search-albums = Альбоми
+search-albums-playlists = Альбоми та плейлисти
 search-tag = { $kind } ·
 search-saved =
     { $count ->

--- a/crates/music/src/lib.rs
+++ b/crates/music/src/lib.rs
@@ -84,6 +84,14 @@ pub trait MusicApi: Send + Sync {
     async fn track_radio(&self, track_id: &str) -> Result<Vec<Track>>;
     async fn search(&self, query: &str) -> Result<Vec<Track>>;
 
+    async fn search_albums(&self, _query: &str) -> Result<Vec<Album>> {
+        Ok(Vec::new())
+    }
+
+    async fn search_playlists(&self, _query: &str) -> Result<Vec<Playlist>> {
+        Ok(Vec::new())
+    }
+
     async fn home(&self) -> Result<Vec<GenreSection>> {
         Ok(Vec::new())
     }

--- a/crates/music/src/youtube/client.rs
+++ b/crates/music/src/youtube/client.rs
@@ -317,6 +317,26 @@ impl MusicApi for YouTubeClient {
             .collect())
     }
 
+    async fn search_albums(&self, query: &str) -> Result<Vec<Album>> {
+        Ok(self
+            .api
+            .search_albums(query)
+            .await?
+            .into_iter()
+            .map(wire::album)
+            .collect())
+    }
+
+    async fn search_playlists(&self, query: &str) -> Result<Vec<Playlist>> {
+        Ok(self
+            .api
+            .search_playlists(query)
+            .await?
+            .into_iter()
+            .map(|playlist| wire::playlist(playlist, false, false))
+            .collect())
+    }
+
     async fn home(&self) -> Result<Vec<GenreSection>> {
         genres::home(&self.api).await
     }

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -23,7 +23,7 @@ pub use lyrics::{Lyrics, LyricsState};
 pub use playback::{Origin, Playback, PlaybackState, Repeat};
 pub use queue::{Named, Queue, Resume, Stub};
 pub use remote::{Remote, attach as attach_remote};
-pub use search::{AlbumHit, ArtistHit, Hit, Kind, Search};
+pub use search::{AlbumHit, ArtistHit, Hit, Kind, PlaylistHit, Search};
 pub use session::{ProviderInfo, Session, SessionEvent, SessionState};
 pub use settings::{AppSettings, SideTab};
 pub use song::SongDetail;

--- a/crates/state/src/search.rs
+++ b/crates/state/src/search.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
+use anyhow::Result;
 use gpui::{Context, Entity, Task};
-use music::{Album, ArtistRef, Track};
+use music::{Album, ArtistRef, Playlist, Track};
 
 use crate::{Io, Library, LibraryState, Session, SessionEvent, join};
 
@@ -26,6 +27,11 @@ pub enum Kind {
     Song,
     Artist,
     Album,
+    Playlist,
+}
+
+impl Kind {
+    pub const ALL: [Kind; 4] = [Kind::Song, Kind::Artist, Kind::Album, Kind::Playlist];
 }
 
 #[derive(Clone)]
@@ -46,19 +52,44 @@ pub struct AlbumHit {
 }
 
 #[derive(Clone)]
+pub struct PlaylistHit {
+    pub id: String,
+    pub name: String,
+    pub owner: String,
+    pub cover: Option<String>,
+}
+
+#[derive(Clone)]
 pub enum Hit {
     Song(Track),
     Artist(ArtistHit),
     Album(AlbumHit),
+    Playlist(PlaylistHit),
 }
 
 impl Hit {
-    fn kind(&self) -> Kind {
+    pub fn kind(&self) -> Kind {
         match self {
             Hit::Song(_) => Kind::Song,
             Hit::Artist(_) => Kind::Artist,
             Hit::Album(_) => Kind::Album,
+            Hit::Playlist(_) => Kind::Playlist,
         }
+    }
+}
+
+#[derive(Default)]
+struct Catalog {
+    tracks: Vec<Track>,
+    albums: Vec<Album>,
+    playlists: Vec<Playlist>,
+}
+
+impl Catalog {
+    fn clear(&mut self) {
+        self.tracks.clear();
+        self.albums.clear();
+        self.playlists.clear();
     }
 }
 
@@ -86,7 +117,7 @@ struct Scored {
 pub struct Search {
     query: String,
     served: Option<String>,
-    catalog: Vec<Track>,
+    catalog: Catalog,
     portraits: HashMap<String, String>,
     hits: Vec<Hit>,
     loading: bool,
@@ -130,7 +161,7 @@ impl Search {
         Self {
             query: String::new(),
             served: None,
-            catalog: Vec::new(),
+            catalog: Catalog::default(),
             portraits: HashMap::new(),
             hits: Vec::new(),
             loading: false,
@@ -200,8 +231,20 @@ impl Search {
         self.task = Some(cx.spawn(async move |this, cx| {
             cx.background_executor().timer(DEBOUNCE).await;
 
+            let songs = {
+                let client = client.clone();
+                let asked = query.clone();
+                io.spawn(async move { client.search(&asked).await })
+            };
+            let albums = {
+                let client = client.clone();
+                let asked = query.clone();
+                io.spawn(async move { client.search_albums(&asked).await })
+            };
             let asked = query.clone();
-            let catalog = join(io.spawn(async move { client.search(&asked).await })).await;
+            let playlists = io.spawn(async move { client.search_playlists(&asked).await });
+            let (songs, albums, playlists) =
+                (join(songs).await, join(albums).await, join(playlists).await);
 
             this.update(cx, |this, cx| {
                 if this.query != query {
@@ -209,13 +252,14 @@ impl Search {
                 }
                 this.loading = false;
                 this.served = Some(query);
-                match catalog {
-                    Ok(tracks) => this.catalog = tracks,
-                    Err(error) => {
-                        this.catalog.clear();
-                        this.error = Some(format!("{error:#}"));
-                    }
-                }
+
+                let mut trouble = Vec::new();
+                this.catalog = Catalog {
+                    tracks: salvaged(songs, &mut trouble),
+                    albums: salvaged(albums, &mut trouble),
+                    playlists: salvaged(playlists, &mut trouble),
+                };
+                this.error = (!trouble.is_empty()).then(|| trouble.join(" · "));
                 this.rank(cx);
             })
             .ok();
@@ -228,7 +272,7 @@ impl Search {
             .iter()
             .filter_map(|hit| match hit {
                 Hit::Artist(artist) => artist.id.clone(),
-                _ => None,
+                Hit::Song(_) | Hit::Album(_) | Hit::Playlist(_) => None,
             })
             .filter(|id| !self.portraits.contains_key(id))
             .collect();
@@ -270,13 +314,23 @@ impl Search {
 
         self.hits = {
             let held = self.library.read(cx);
-            let (tracks, albums) = match held.state() {
-                LibraryState::Ready { tracks, albums, .. } => {
-                    (tracks.as_slice(), albums.as_slice())
-                }
-                _ => (&[][..], &[][..]),
+            let (tracks, albums, playlists) = match held.state() {
+                LibraryState::Ready {
+                    tracks,
+                    albums,
+                    playlists,
+                    ..
+                } => (tracks.as_slice(), albums.as_slice(), playlists.as_slice()),
+                _ => (&[][..], &[][..], &[][..]),
             };
-            rank(tracks, albums, &self.catalog, &self.portraits, query)
+            rank(
+                tracks,
+                albums,
+                playlists,
+                &self.catalog,
+                &self.portraits,
+                query,
+            )
         };
         self.fetch_portraits(cx);
         cx.notify();
@@ -286,7 +340,8 @@ impl Search {
 fn rank(
     library: &[Track],
     albums: &[Album],
-    catalog: &[Track],
+    playlists: &[Playlist],
+    catalog: &Catalog,
     portraits: &HashMap<String, String>,
     asked: &str,
 ) -> Vec<Hit> {
@@ -295,9 +350,10 @@ fn rank(
         return Vec::new();
     }
 
-    let mut all = songs(library, catalog, &query);
-    all.extend(artists(library, catalog, albums, portraits, &query));
+    let mut all = songs(library, &catalog.tracks, &query);
+    all.extend(artists(library, &catalog.tracks, albums, portraits, &query));
     all.extend(albums_of(albums, library, catalog, &query));
+    all.extend(playlists_of(playlists, &catalog.playlists, &query));
     order(&mut all);
 
     all.into_iter().map(|scored| scored.hit).collect()
@@ -330,7 +386,7 @@ fn songs(library: &[Track], catalog: &[Track], query: &Query) -> Vec<Scored> {
     capped(scored)
 }
 
-fn albums_of(albums: &[Album], library: &[Track], catalog: &[Track], query: &Query) -> Vec<Scored> {
+fn albums_of(albums: &[Album], library: &[Track], catalog: &Catalog, query: &Query) -> Vec<Scored> {
     let saved = albums.iter().map(|album| {
         (
             &album.id,
@@ -342,7 +398,19 @@ fn albums_of(albums: &[Album], library: &[Track], catalog: &[Track], query: &Que
             0,
         )
     });
-    let derived = sources(library, catalog).filter_map(|(track, rank)| {
+    let total = catalog.albums.len();
+    let found = catalog.albums.iter().enumerate().map(move |(at, album)| {
+        (
+            &album.id,
+            &album.name,
+            &album.artists,
+            &album.artist_refs,
+            &album.cover,
+            Some(placed(at, total)),
+            0,
+        )
+    });
+    let derived = sources(library, &catalog.tracks).filter_map(|(track, rank)| {
         let id = track.album_id.as_ref()?;
         Some((
             id,
@@ -357,7 +425,9 @@ fn albums_of(albums: &[Album], library: &[Track], catalog: &[Track], query: &Que
 
     let mut scored: Vec<Scored> = Vec::new();
     let mut seen: Vec<&String> = Vec::new();
-    for (id, name, artists, artist_refs, cover, rank, popularity) in saved.chain(derived) {
+    for (id, name, artists, artist_refs, cover, rank, popularity) in
+        saved.chain(found).chain(derived)
+    {
         let fields = [(TITLE, name.as_str()), (ARTIST, artists.as_str())];
         let Some(score) = favored(fit(&fields, query), rank).max(inherited(rank)) else {
             continue;
@@ -376,6 +446,44 @@ fn albums_of(albums: &[Album], library: &[Track], catalog: &[Track], query: &Que
                 artists: artists.clone(),
                 artist_refs: artist_refs.clone(),
                 cover: cover.clone(),
+            }),
+        });
+    }
+
+    capped(scored)
+}
+
+fn playlists_of(playlists: &[Playlist], catalog: &[Playlist], query: &Query) -> Vec<Scored> {
+    let total = catalog.len();
+    let saved = playlists.iter().map(|playlist| (playlist, None));
+    let found = catalog
+        .iter()
+        .enumerate()
+        .map(move |(at, playlist)| (playlist, Some(placed(at, total))));
+
+    let mut scored: Vec<Scored> = Vec::new();
+    let mut seen: Vec<&String> = Vec::new();
+    for (playlist, rank) in saved.chain(found) {
+        let fields = [
+            (TITLE, playlist.name.as_str()),
+            (ARTIST, playlist.owner.as_str()),
+        ];
+        let Some(score) = favored(fit(&fields, query), rank).max(inherited(rank)) else {
+            continue;
+        };
+        if seen.contains(&&playlist.id) {
+            continue;
+        }
+        seen.push(&playlist.id);
+
+        scored.push(Scored {
+            score,
+            popularity: 0,
+            hit: Hit::Playlist(PlaylistHit {
+                id: playlist.id.clone(),
+                name: playlist.name.clone(),
+                owner: playlist.owner.clone(),
+                cover: playlist.cover.clone(),
             }),
         });
     }
@@ -504,6 +612,16 @@ fn capped(mut scored: Vec<Scored>) -> Vec<Scored> {
     scored
 }
 
+fn salvaged<T>(found: Result<Vec<T>>, trouble: &mut Vec<String>) -> Vec<T> {
+    match found {
+        Ok(found) => found,
+        Err(error) => {
+            trouble.push(format!("{error:#}"));
+            Vec::new()
+        }
+    }
+}
+
 fn kept(library: &[Track], track: &Track) -> bool {
     track
         .id
@@ -556,7 +674,12 @@ mod tests {
     use super::*;
 
     fn rank(library: &[Track], albums: &[Album], catalog: &[Track], asked: &str) -> Vec<Hit> {
-        super::rank(library, albums, catalog, &HashMap::new(), asked)
+        let catalog = Catalog {
+            tracks: catalog.to_vec(),
+            ..Catalog::default()
+        };
+
+        super::rank(library, albums, &[], &catalog, &HashMap::new(), asked)
     }
 
     fn track(name: &str, artists: &str, album: &str) -> Track {
@@ -735,7 +858,14 @@ mod tests {
         portrait.cover = Some("https://album-cover".to_owned());
 
         let portraits = HashMap::from([("artist-one".to_owned(), "https://portrait".to_owned())]);
-        let hits = super::rank(&[portrait], &[], &[], &portraits, "echo");
+        let hits = super::rank(
+            &[portrait],
+            &[],
+            &[],
+            &Catalog::default(),
+            &portraits,
+            "echo",
+        );
 
         let Some(Hit::Artist(artist)) = hits.iter().find(|hit| hit.kind() == Kind::Artist) else {
             panic!("expected an artist hit");

--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -22,12 +22,16 @@ use crate::shared::shelves;
 
 const RAIL: Pixels = gpui::px(12.);
 const ROW_GAP: f32 = 0.25;
+const SONGS: &[Kind] = &[Kind::Song];
+const ARTISTS: &[Kind] = &[Kind::Artist];
+const RELEASES: &[Kind] = &[Kind::Album, Kind::Playlist];
 use crate::shared::tracks::{PlaybackStatus, playback_status};
 
 enum Press {
     Song(Box<Track>),
     Artist(String),
     Album(String),
+    Playlist(String),
 }
 
 #[derive(Clone)]
@@ -40,7 +44,7 @@ impl HitMenu {
     fn of(hit: &Hit) -> Option<Self> {
         match hit {
             Hit::Song(track) => Some(Self::Song(Box::new(track.clone()))),
-            _ => pin(hit).map(Self::Item),
+            Hit::Artist(_) | Hit::Album(_) | Hit::Playlist(_) => pin(hit).map(Self::Item),
         }
     }
 }
@@ -142,7 +146,15 @@ impl SearchView {
                 album.artist_refs.clone(),
                 album.artists.clone(),
             ),
-            Hit::Artist(_) => return meta(hit, compact).into_any_element(),
+            Hit::Playlist(list) if !list.owner.is_empty() => (
+                Kind::Playlist,
+                format!("playlist-owner-{place}"),
+                Vec::new(),
+                list.owner.clone(),
+            ),
+            Hit::Artist(_) | Hit::Playlist(_) => {
+                return meta(hit, compact).into_any_element();
+            }
         };
 
         let links = cells::artist_links(id, artists, fallback, theme.muted_foreground).truncate();
@@ -252,6 +264,24 @@ impl SearchView {
                     })
                     .press(pressed(Press::Album(album.id.clone()), me))
             }
+            Hit::Playlist(list) => {
+                let origin = state::Origin::Playlist(list.id.clone());
+                let playing = self.playback.read(cx).playing_from(&origin)
+                    == Some(state::PlaybackState::Playing);
+                let toggled = me.clone();
+                Card::new(("playlist", place), list.name.clone())
+                    .cover(list.cover.clone())
+                    .meta(meta)
+                    .play(playing, move |_, _, cx| {
+                        toggled
+                            .update(cx, |this, cx| {
+                                this.playback
+                                    .update(cx, |playback, cx| playback.toggle_origin(&origin, cx));
+                            })
+                            .ok();
+                    })
+                    .press(pressed(Press::Playlist(list.id.clone()), me))
+            }
         };
 
         card.when_some(pin(hit), Pinnable::pin)
@@ -282,6 +312,12 @@ impl SearchView {
                 album.name.clone(),
                 album.artist_refs.clone(),
                 Some(Press::Album(album.id.clone())),
+            ),
+            Hit::Playlist(list) => (
+                Kind::Playlist,
+                list.name.clone(),
+                Vec::new(),
+                Some(Press::Playlist(list.id.clone())),
             ),
         };
 
@@ -358,12 +394,22 @@ impl SearchView {
     }
 
     fn column(&self, kind: Kind, window: &Window, cx: &Context<Self>) -> AnyElement {
-        let (id, bar, title) = match kind {
-            Kind::Song => ("search-songs", &self.songs, t!("search-songs")),
-            Kind::Artist => ("search-artists", &self.artists, t!("search-artists")),
-            Kind::Album => ("search-albums", &self.albums, t!("search-albums")),
+        let (id, bar, title, only) = match kind {
+            Kind::Song => ("search-songs", &self.songs, t!("search-songs"), SONGS),
+            Kind::Artist => (
+                "search-artists",
+                &self.artists,
+                t!("search-artists"),
+                ARTISTS,
+            ),
+            Kind::Album | Kind::Playlist => (
+                "search-albums",
+                &self.albums,
+                t!("search-albums-playlists"),
+                RELEASES,
+            ),
         };
-        let body = self.deck(id, bar, Some(kind), RAIL, window, cx);
+        let body = self.deck(id, bar, only, RAIL, window, cx);
 
         self.shell(title, body, RAIL, cx)
     }
@@ -409,13 +455,13 @@ impl SearchView {
     }
 
     fn everything(&self, gutter: Pixels, window: &Window, cx: &Context<Self>) -> AnyElement {
-        let body = self.deck("search-all", &self.mixed, None, gutter, window, cx);
+        let body = self.deck("search-all", &self.mixed, &Kind::ALL, gutter, window, cx);
 
         self.shell(t!("search-results"), body, gutter, cx)
     }
 
-    fn seats(&self, only: Option<Kind>, cx: &Context<Self>) -> Vec<(usize, usize)> {
-        let mut taken = [0; 3];
+    fn seats(&self, only: &[Kind], cx: &Context<Self>) -> Vec<(usize, usize)> {
+        let mut taken = [0; Kind::ALL.len()];
 
         self.search
             .read(cx)
@@ -423,11 +469,10 @@ impl SearchView {
             .iter()
             .enumerate()
             .filter_map(|(at, hit)| {
-                let slot = slot(hit);
-                let place = taken[slot];
-                taken[slot] += 1;
-                only.is_none_or(|kind| seat(kind) == slot)
-                    .then_some((at, place))
+                let kind = hit.kind();
+                let place = taken[seat(kind)];
+                taken[seat(kind)] += 1;
+                only.contains(&kind).then_some((at, place))
             })
             .collect()
     }
@@ -436,7 +481,7 @@ impl SearchView {
         &self,
         id: &'static str,
         bar: &Entity<Scrollbar>,
-        only: Option<Kind>,
+        only: &[Kind],
         gutter: Pixels,
         window: &Window,
         cx: &Context<Self>,
@@ -448,7 +493,7 @@ impl SearchView {
                 .into_any_element();
         }
 
-        let compact = only.is_none();
+        let compact = only.len() > 1;
         let theme = *cx.theme();
         let row = snapped(theme.metrics.list_row, window);
         let scroll = bar.read(cx).scroll().clone();
@@ -493,19 +538,12 @@ impl SearchView {
     }
 }
 
-fn slot(hit: &Hit) -> usize {
-    match hit {
-        Hit::Song(_) => 0,
-        Hit::Artist(_) => 1,
-        Hit::Album(_) => 2,
-    }
-}
-
 fn seat(kind: Kind) -> usize {
     match kind {
         Kind::Song => 0,
         Kind::Artist => 1,
         Kind::Album => 2,
+        Kind::Playlist => 3,
     }
 }
 
@@ -522,6 +560,7 @@ fn pressed(
                 .update(cx, |playback, cx| playback.play_radio(track, cx)),
             Press::Artist(id) => navigate(Destination::Artist(id.clone().into()), cx),
             Press::Album(id) => navigate(Destination::Album(id.clone().into()), cx),
+            Press::Playlist(id) => navigate(Destination::Playlist(id.clone().into()), cx),
         })
         .ok();
     }
@@ -549,6 +588,7 @@ fn cover(hit: &Hit) -> Option<String> {
         Hit::Song(track) => track.cover.clone(),
         Hit::Artist(artist) => artist.cover.clone(),
         Hit::Album(album) => album.cover.clone(),
+        Hit::Playlist(list) => list.cover.clone(),
     }
 }
 
@@ -557,6 +597,7 @@ fn pin(hit: &Hit) -> Option<Pin> {
         Hit::Song(track) => (PinKind::Song, track.id.clone()?, track.name.clone()),
         Hit::Artist(artist) => (PinKind::Artist, artist.id.clone()?, artist.name.clone()),
         Hit::Album(album) => (PinKind::Album, album.id.clone(), album.name.clone()),
+        Hit::Playlist(list) => (PinKind::Playlist, list.id.clone(), list.name.clone()),
     };
 
     Some(Pin::new(kind, id, name).cover(cover(hit)))
@@ -569,6 +610,10 @@ fn meta(hit: &Hit, compact: bool) -> SharedString {
         Hit::Artist(artist) => match compact {
             true => noun(Kind::Artist),
             false => held(artist.saved),
+        },
+        Hit::Playlist(list) => match list.owner.is_empty() {
+            true => noun(Kind::Playlist),
+            false => SharedString::from(list.owner.clone()),
         },
     }
 }
@@ -590,6 +635,7 @@ fn noun(kind: Kind) -> SharedString {
         Kind::Song => t!("kind-song"),
         Kind::Artist => t!("kind-artist"),
         Kind::Album => t!("kind-album"),
+        Kind::Playlist => t!("kind-playlist"),
     }
 }
 


### PR DESCRIPTION
## Summary

- search the whole catalogue for albums and playlists, not only the library
- add defaulted `search_albums` and `search_playlists` to the provider api, implemented for youtube
- fetch songs, albums and playlists concurrently, keeping the other two when one kind fails
- merge library matches above catalogue results and drop duplicates by id
- show albums and playlists together in the third search column, tagged by kind
- give a playlist hit its own navigation, pin, play origin and context menu
