### PR TITLE
feat(music): search the spotify catalogue for albums and playlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Searching now reaches the whole catalogue for albums and playlists, not just the ones your library
   already knows about. The third column of results holds both, tagged so you can tell them apart,
   and a playlist behaves like one everywhere: open it, play it, pin it or right-click it for the
-  usual menu. Albums and playlists you have saved still come first.
+  usual menu. Albums and playlists you have saved still come first. Spotify and YouTube Music both
+  answer these searches from their own catalogue.
 
 ### Changed
 

--- a/crates/music/examples/search.rs
+++ b/crates/music/examples/search.rs
@@ -1,0 +1,33 @@
+use anyhow::{Result, bail};
+use music::MusicApi as _;
+use music::spotify::{AuthConfig, LibrespotClient, auth};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let term = std::env::args().skip(1).collect::<Vec<_>>().join(" ");
+    let Some(session) = auth::restore(&AuthConfig::from_env()).await? else {
+        bail!("no cached Spotify credentials");
+    };
+    let client = LibrespotClient::new(session);
+
+    for album in client.search_albums(&term).await? {
+        println!(
+            "album    {} {} — {} ({}) {:?}",
+            album.id,
+            album.name,
+            album.artists,
+            album.year,
+            album.cover.as_deref()
+        );
+    }
+    for playlist in client.search_playlists(&term).await? {
+        println!(
+            "playlist {} {} — {} {:?}",
+            playlist.id,
+            playlist.name,
+            playlist.owner,
+            playlist.cover.as_deref()
+        );
+    }
+    Ok(())
+}

--- a/crates/music/src/spotify/client.rs
+++ b/crates/music/src/spotify/client.rs
@@ -139,6 +139,14 @@ impl MusicApi for LibrespotClient {
         search::search(&self.session, query).await
     }
 
+    async fn search_albums(&self, query: &str) -> Result<Vec<Album>> {
+        pathfinder::search_albums(&self.session, query).await
+    }
+
+    async fn search_playlists(&self, query: &str) -> Result<Vec<Playlist>> {
+        pathfinder::search_playlists(&self.session, query).await
+    }
+
     async fn home(&self) -> Result<Vec<GenreSection>> {
         Ok(pathfinder::genre(&self.session, MADE_FOR_YOU)
             .await?

--- a/crates/music/src/spotify/pathfinder.rs
+++ b/crates/music/src/spotify/pathfinder.rs
@@ -10,11 +10,13 @@ mod artist;
 mod browse;
 mod hashes;
 mod plays;
+mod search;
 
 pub(crate) use album::album;
 pub(crate) use artist::{Overview, artist};
 pub(crate) use browse::{all as genres, page as genre};
 pub(crate) use plays::track;
+pub(crate) use search::{albums as search_albums, playlists as search_playlists};
 
 const ENDPOINT: &str = "https://api-partner.spotify.com/pathfinder/v2/query";
 const APP_PLATFORM: &str = "WebPlayer";

--- a/crates/music/src/spotify/pathfinder/album.rs
+++ b/crates/music/src/spotify/pathfinder/album.rs
@@ -302,7 +302,7 @@ fn date(date: &PathDate) -> String {
     date.iso.get(..length).unwrap_or(&date.iso).to_owned()
 }
 
-fn release_type(kind: &str) -> ReleaseType {
+pub(super) fn release_type(kind: &str) -> ReleaseType {
     match kind {
         "SINGLE" => ReleaseType::Single,
         "COMPILATION" => ReleaseType::Compilation,

--- a/crates/music/src/spotify/pathfinder/search.rs
+++ b/crates/music/src/spotify/pathfinder/search.rs
@@ -1,0 +1,295 @@
+use anyhow::{Context as _, Result};
+use librespot_core::Session;
+use serde::Deserialize;
+
+use super::album::release_type;
+use super::query;
+use crate::{Album, ArtistRef, Playlist};
+
+const ALBUMS: &str = "searchAlbums";
+const PLAYLISTS: &str = "searchPlaylists";
+const ALBUM_PREFIX: &str = "spotify:album:";
+const ARTIST_PREFIX: &str = "spotify:artist:";
+const PLAYLIST_PREFIX: &str = "spotify:playlist:";
+const HEADER: u32 = 300;
+const LIMIT: u32 = 20;
+
+#[derive(Deserialize)]
+struct AlbumSearch {
+    #[serde(rename = "searchV2")]
+    search: Option<AlbumResults>,
+}
+
+#[derive(Deserialize)]
+struct AlbumResults {
+    #[serde(rename = "albumsV2", default)]
+    albums: AlbumHits,
+}
+
+#[derive(Default, Deserialize)]
+struct AlbumHits {
+    #[serde(default)]
+    items: Vec<AlbumHit>,
+}
+
+#[derive(Deserialize)]
+struct AlbumHit {
+    data: Option<AlbumEntity>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "__typename")]
+enum AlbumEntity {
+    Album(WireAlbum),
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Deserialize)]
+struct WireAlbum {
+    #[serde(default)]
+    uri: String,
+    #[serde(default)]
+    name: String,
+    #[serde(rename = "type", default)]
+    kind: String,
+    date: Option<Year>,
+    #[serde(default)]
+    artists: Artists,
+    #[serde(rename = "coverArt", default)]
+    cover: Artwork,
+}
+
+#[derive(Deserialize)]
+struct PlaylistSearch {
+    #[serde(rename = "searchV2")]
+    search: Option<PlaylistResults>,
+}
+
+#[derive(Deserialize)]
+struct PlaylistResults {
+    #[serde(default)]
+    playlists: PlaylistHits,
+}
+
+#[derive(Default, Deserialize)]
+struct PlaylistHits {
+    #[serde(default)]
+    items: Vec<PlaylistHit>,
+}
+
+#[derive(Deserialize)]
+struct PlaylistHit {
+    data: Option<PlaylistEntity>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "__typename")]
+enum PlaylistEntity {
+    Playlist(WirePlaylist),
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Deserialize)]
+struct WirePlaylist {
+    #[serde(default)]
+    uri: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    images: Images,
+    #[serde(rename = "ownerV2")]
+    owner: Option<Owner>,
+}
+
+#[derive(Deserialize)]
+struct Year {
+    #[serde(default)]
+    year: i32,
+}
+
+#[derive(Default, Deserialize)]
+struct Artists {
+    #[serde(default)]
+    items: Vec<Artist>,
+}
+
+#[derive(Deserialize)]
+struct Artist {
+    #[serde(default)]
+    uri: String,
+    profile: Option<Profile>,
+}
+
+#[derive(Deserialize)]
+struct Profile {
+    #[serde(default)]
+    name: String,
+}
+
+#[derive(Default, Deserialize)]
+struct Images {
+    #[serde(default)]
+    items: Vec<Artwork>,
+}
+
+#[derive(Default, Deserialize)]
+struct Artwork {
+    #[serde(default)]
+    sources: Vec<Image>,
+}
+
+#[derive(Deserialize)]
+struct Image {
+    height: Option<u32>,
+    url: String,
+}
+
+#[derive(Deserialize)]
+struct Owner {
+    data: Option<Account>,
+}
+
+#[derive(Deserialize)]
+struct Account {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    username: String,
+}
+
+pub(crate) async fn albums(session: &Session, term: &str) -> Result<Vec<Album>> {
+    let Some(term) = wanted(term) else {
+        return Ok(Vec::new());
+    };
+    let data = query::<AlbumSearch>(session, ALBUMS, variables(term)).await?;
+    let results = data
+        .search
+        .context("searchAlbums Pathfinder response has no search")?;
+
+    Ok(results.albums.items.into_iter().filter_map(album).collect())
+}
+
+pub(crate) async fn playlists(session: &Session, term: &str) -> Result<Vec<Playlist>> {
+    let Some(term) = wanted(term) else {
+        return Ok(Vec::new());
+    };
+    let data = query::<PlaylistSearch>(session, PLAYLISTS, variables(term)).await?;
+    let results = data
+        .search
+        .context("searchPlaylists Pathfinder response has no search")?;
+    let username = session.username();
+
+    Ok(results
+        .playlists
+        .items
+        .into_iter()
+        .filter_map(|hit| playlist(hit, &username))
+        .collect())
+}
+
+fn album(hit: AlbumHit) -> Option<Album> {
+    let AlbumEntity::Album(album) = hit.data? else {
+        return None;
+    };
+    let (names, refs) = artists(album.artists);
+    let year = album.date.map(|date| date.year).unwrap_or_default();
+
+    Some(Album {
+        id: trimmed(&album.uri, ALBUM_PREFIX)?,
+        name: album.name,
+        artists: names,
+        artist_refs: refs,
+        cover: cover(&album.cover.sources, false),
+        cover_large: cover(&album.cover.sources, true),
+        release_type: release_type(&album.kind),
+        year,
+        track_count: 0,
+        release_date: match year {
+            0 => String::new(),
+            year => year.to_string(),
+        },
+        label: String::new(),
+        copyrights: Vec::new(),
+        added_at: None,
+    })
+}
+
+fn playlist(hit: PlaylistHit, username: &str) -> Option<Playlist> {
+    let PlaylistEntity::Playlist(playlist) = hit.data? else {
+        return None;
+    };
+    let owner = playlist.owner.and_then(|owner| owner.data);
+
+    Some(Playlist {
+        id: trimmed(&playlist.uri, PLAYLIST_PREFIX)?,
+        name: playlist.name,
+        owned: owner
+            .as_ref()
+            .is_some_and(|account| account.username == username),
+        owner: owner.map(|account| account.name).unwrap_or_default(),
+        collaborative: false,
+        public: true,
+        cover: playlist
+            .images
+            .items
+            .first()
+            .and_then(|artwork| cover(&artwork.sources, false)),
+        track_count: 0,
+        modified_at: None,
+    })
+}
+
+fn artists(artists: Artists) -> (String, Vec<ArtistRef>) {
+    let refs: Vec<_> = artists
+        .items
+        .into_iter()
+        .filter_map(|artist| {
+            Some(ArtistRef {
+                name: artist.profile.map(|profile| profile.name)?,
+                id: trimmed(&artist.uri, ARTIST_PREFIX),
+            })
+        })
+        .collect();
+    let names = refs
+        .iter()
+        .map(|artist| artist.name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    (names, refs)
+}
+
+fn cover(sources: &[Image], large: bool) -> Option<String> {
+    let source = match large {
+        true => sources
+            .iter()
+            .filter(|source| height(source) >= HEADER)
+            .min_by_key(height)
+            .or_else(|| sources.iter().max_by_key(height)),
+        false => sources.iter().min_by_key(height),
+    }?;
+    (!source.url.is_empty()).then(|| source.url.clone())
+}
+
+fn height(source: &&Image) -> u32 {
+    source.height.unwrap_or_default()
+}
+
+fn variables(term: &str) -> serde_json::Value {
+    serde_json::json!({
+        "searchTerm": term,
+        "offset": 0,
+        "limit": LIMIT,
+    })
+}
+
+fn wanted(term: &str) -> Option<&str> {
+    Some(term.trim()).filter(|term| !term.is_empty())
+}
+
+fn trimmed(uri: &str, prefix: &str) -> Option<String> {
+    uri.strip_prefix(prefix)
+        .filter(|id| !id.is_empty())
+        .map(str::to_owned)
+}


### PR DESCRIPTION
## Summary

- search the Spotify catalogue for albums and playlists through the searchAlbums and searchPlaylists Pathfinder queries
- map catalogue hits onto Album and Playlist with base62 ids, cover art, artists, year and playlist owner
- add a music example that prints live catalogue search results for a term
