### PR TITLE
fix(music): keep sonora alive when the account has no premium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   cancelled browser approval — instead of showing the raw message from the streaming library. An
   unrecognised failure is trimmed down to one readable sentence too.
 
+### Fixed
+
+- Signing in with an account that has no Spotify Premium closed Sonora outright, and it kept closing
+  on every launch until the cached session was deleted by hand. Sonora now stays open, forgets that
+  session and explains on the login screen that streaming needs Premium.
+
 ## [0.14.0] - 2026-08-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3736,7 +3736,7 @@ dependencies = [
 [[package]]
 name = "librespot-audio"
 version = "0.8.0"
-source = "git+https://github.com/nolight132/librespot?rev=81b99cf12a29ba2915894f24d67aec85a963dc06#81b99cf12a29ba2915894f24d67aec85a963dc06"
+source = "git+https://github.com/nolight132/librespot?rev=e7eb953d5848fd97bacd00e6c0e33500765eaa63#e7eb953d5848fd97bacd00e6c0e33500765eaa63"
 dependencies = [
  "aes",
  "bytes",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "librespot-core"
 version = "0.8.0"
-source = "git+https://github.com/nolight132/librespot?rev=81b99cf12a29ba2915894f24d67aec85a963dc06#81b99cf12a29ba2915894f24d67aec85a963dc06"
+source = "git+https://github.com/nolight132/librespot?rev=e7eb953d5848fd97bacd00e6c0e33500765eaa63#e7eb953d5848fd97bacd00e6c0e33500765eaa63"
 dependencies = [
  "aes",
  "base64",
@@ -3811,7 +3811,7 @@ dependencies = [
 [[package]]
 name = "librespot-metadata"
 version = "0.8.0"
-source = "git+https://github.com/nolight132/librespot?rev=81b99cf12a29ba2915894f24d67aec85a963dc06#81b99cf12a29ba2915894f24d67aec85a963dc06"
+source = "git+https://github.com/nolight132/librespot?rev=e7eb953d5848fd97bacd00e6c0e33500765eaa63#e7eb953d5848fd97bacd00e6c0e33500765eaa63"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3828,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "librespot-oauth"
 version = "0.8.0"
-source = "git+https://github.com/nolight132/librespot?rev=81b99cf12a29ba2915894f24d67aec85a963dc06#81b99cf12a29ba2915894f24d67aec85a963dc06"
+source = "git+https://github.com/nolight132/librespot?rev=e7eb953d5848fd97bacd00e6c0e33500765eaa63#e7eb953d5848fd97bacd00e6c0e33500765eaa63"
 dependencies = [
  "log",
  "oauth2",
@@ -3841,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "librespot-playback"
 version = "0.8.0"
-source = "git+https://github.com/nolight132/librespot?rev=81b99cf12a29ba2915894f24d67aec85a963dc06#81b99cf12a29ba2915894f24d67aec85a963dc06"
+source = "git+https://github.com/nolight132/librespot?rev=e7eb953d5848fd97bacd00e6c0e33500765eaa63#e7eb953d5848fd97bacd00e6c0e33500765eaa63"
 dependencies = [
  "cpal",
  "form_urlencoded",
@@ -3864,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "librespot-protocol"
 version = "0.8.0"
-source = "git+https://github.com/nolight132/librespot?rev=81b99cf12a29ba2915894f24d67aec85a963dc06#81b99cf12a29ba2915894f24d67aec85a963dc06"
+source = "git+https://github.com/nolight132/librespot?rev=e7eb953d5848fd97bacd00e6c0e33500765eaa63#e7eb953d5848fd97bacd00e6c0e33500765eaa63"
 dependencies = [
  "protobuf",
  "protobuf-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,12 +79,12 @@ tokio = { version = "1.53", features = [
 ] }
 
 [patch.crates-io]
-librespot-audio = { git = "https://github.com/nolight132/librespot", rev = "81b99cf12a29ba2915894f24d67aec85a963dc06" }
-librespot-core = { git = "https://github.com/nolight132/librespot", rev = "81b99cf12a29ba2915894f24d67aec85a963dc06" }
-librespot-metadata = { git = "https://github.com/nolight132/librespot", rev = "81b99cf12a29ba2915894f24d67aec85a963dc06" }
-librespot-oauth = { git = "https://github.com/nolight132/librespot", rev = "81b99cf12a29ba2915894f24d67aec85a963dc06" }
-librespot-playback = { git = "https://github.com/nolight132/librespot", rev = "81b99cf12a29ba2915894f24d67aec85a963dc06" }
-librespot-protocol = { git = "https://github.com/nolight132/librespot", rev = "81b99cf12a29ba2915894f24d67aec85a963dc06" }
+librespot-audio = { git = "https://github.com/nolight132/librespot", rev = "e7eb953d5848fd97bacd00e6c0e33500765eaa63" }
+librespot-core = { git = "https://github.com/nolight132/librespot", rev = "e7eb953d5848fd97bacd00e6c0e33500765eaa63" }
+librespot-metadata = { git = "https://github.com/nolight132/librespot", rev = "e7eb953d5848fd97bacd00e6c0e33500765eaa63" }
+librespot-oauth = { git = "https://github.com/nolight132/librespot", rev = "e7eb953d5848fd97bacd00e6c0e33500765eaa63" }
+librespot-playback = { git = "https://github.com/nolight132/librespot", rev = "e7eb953d5848fd97bacd00e6c0e33500765eaa63" }
+librespot-protocol = { git = "https://github.com/nolight132/librespot", rev = "e7eb953d5848fd97bacd00e6c0e33500765eaa63" }
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ partial translation is welcome — pick a language below and fill in what it lac
 
 | Language | Translated | Coverage |
 | --- | --- | --- |
-| English (`en-US`) | 360/360 | 100% |
-| Deutsch (`de`) | 354/360 | 98% |
-| Français (`fr`) | 354/360 | 98% |
-| Русский (`ru`) | 360/360 | 100% |
-| Українська (`uk`) | 360/360 | 100% |
-| Polski (`pl`) | 360/360 | 100% |
+| English (`en-US`) | 361/361 | 100% |
+| Deutsch (`de`) | 354/361 | 98% |
+| Français (`fr`) | 354/361 | 98% |
+| Русский (`ru`) | 361/361 | 100% |
+| Українська (`uk`) | 361/361 | 100% |
+| Polski (`pl`) | 361/361 | 100% |
 
 <!-- i18n:end -->
 

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -154,6 +154,7 @@ login-problem-credentials = Your saved Spotify session is no longer valid. Sign 
 login-problem-network = Sonora could not reach Spotify. Check your internet connection and try again.
 login-problem-cancelled = You closed the browser page before approving the sign-in. Start again to finish.
 login-problem-refused = Spotify turned down the sign-in. Wait a moment and try again.
+login-problem-premium = Sonora streams through Spotify Premium, and this account does not have it. Sign in with a Premium account to continue.
 login-sign-in = Sign in with { $provider }
 login-connect-cookies = Paste cookies manually
 login-import-browser = Import from browser*

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -154,6 +154,7 @@ login-problem-credentials = Zapisana sesja Spotify straciła ważność. Zaloguj
 login-problem-network = Sonora nie mogła połączyć się ze Spotify. Sprawdź połączenie internetowe i spróbuj ponownie.
 login-problem-cancelled = Zamknięto stronę przeglądarki przed zatwierdzeniem logowania. Zacznij od nowa.
 login-problem-refused = Spotify odrzucił logowanie. Odczekaj chwilę i spróbuj ponownie.
+login-problem-premium = Sonora odtwarza muzykę przez Spotify Premium, a to konto go nie ma. Zaloguj się na konto z Premium, aby kontynuować.
 login-sign-in = Zaloguj się przez { $provider }
 login-connect-cookies = Wklej pliki cookie ręcznie
 login-import-browser = Importuj z przeglądarki*

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -154,6 +154,7 @@ login-problem-credentials = Сохранённая сессия Spotify боль
 login-problem-network = Sonora не смогла связаться со Spotify. Проверьте интернет-соединение и попробуйте снова.
 login-problem-cancelled = Вы закрыли страницу браузера, не подтвердив вход. Начните заново.
 login-problem-refused = Spotify отклонил вход. Подождите немного и попробуйте снова.
+login-problem-premium = Sonora воспроизводит музыку через Spotify Premium, а у этого аккаунта его нет. Войдите в аккаунт с Premium, чтобы продолжить.
 login-sign-in = Войти через { $provider }
 login-connect-cookies = Вставить cookie вручную
 login-import-browser = Импорт из браузера*

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -154,6 +154,7 @@ login-problem-credentials = Збережена сесія Spotify більше �
 login-problem-network = Sonora не змогла зв'язатися зі Spotify. Перевірте інтернет-з'єднання та спробуйте ще раз.
 login-problem-cancelled = Ви закрили сторінку браузера, не підтвердивши вхід. Почніть знову.
 login-problem-refused = Spotify відхилив вхід. Зачекайте трохи і спробуйте ще раз.
+login-problem-premium = Sonora відтворює музику через Spotify Premium, а цей акаунт його не має. Увійдіть в акаунт з Premium, щоб продовжити.
 login-sign-in = Увійти через { $provider }
 login-connect-cookies = Вставити cookie вручну
 login-import-browser = Імпорт із браузера*

--- a/crates/music/src/lib.rs
+++ b/crates/music/src/lib.rs
@@ -176,6 +176,7 @@ pub enum SignIn {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SignInProblem {
+    Premium,
     Region,
     Credentials,
     Network,
@@ -189,6 +190,7 @@ pub struct SignInFailure(pub SignInProblem);
 impl std::fmt::Display for SignInFailure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let reason = match self.0 {
+            SignInProblem::Premium => "the account has no Spotify Premium",
             SignInProblem::Region => "the account is out of its home region",
             SignInProblem::Credentials => "the stored credentials are no longer valid",
             SignInProblem::Network => "Spotify could not be reached",

--- a/crates/music/src/spotify/auth.rs
+++ b/crates/music/src/spotify/auth.rs
@@ -11,6 +11,9 @@ use librespot_oauth::OAuthClientBuilder;
 pub const DEFAULT_CLIENT_ID: &str = "65b708073fc0480ea92a077233ca87bd";
 pub const DEFAULT_REDIRECT_URI: &str = "http://127.0.0.1:8989/login";
 
+const PRODUCT_WAIT: std::time::Duration = std::time::Duration::from_secs(5);
+const PRODUCT_POLL: std::time::Duration = std::time::Duration::from_millis(100);
+
 pub const SCOPES: &[&str] = &[
     "playlist-read-collaborative",
     "playlist-read-private",
@@ -91,6 +94,7 @@ pub async fn restore(config: &AuthConfig) -> Result<Option<Session>> {
     };
 
     session.connect(credentials, true).await.map_err(denied)?;
+    premium(&session).await?;
     Ok(Some(session))
 }
 
@@ -112,7 +116,27 @@ pub async fn login(config: &AuthConfig) -> Result<Session> {
         .connect(Credentials::with_access_token(token.access_token), true)
         .await
         .map_err(denied)?;
+    premium(&session).await?;
     Ok(session)
+}
+
+async fn premium(session: &Session) -> Result<()> {
+    let deadline = tokio::time::Instant::now() + PRODUCT_WAIT;
+    loop {
+        if let Some(account) = session.user_data().attributes.get("type") {
+            match account.as_str() {
+                "premium" => return Ok(()),
+                _ => {
+                    session.shutdown();
+                    return Err(anyhow::Error::new(SignInFailure(SignInProblem::Premium)));
+                }
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Ok(());
+        }
+        tokio::time::sleep(PRODUCT_POLL).await;
+    }
 }
 
 fn denied(error: librespot_core::Error) -> anyhow::Error {

--- a/crates/music/src/spotify/mod.rs
+++ b/crates/music/src/spotify/mod.rs
@@ -21,7 +21,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use crate::spotify::playback::Factory;
-use crate::{MusicApi as _, MusicProvider, ProviderSession};
+use crate::{MusicApi as _, MusicProvider, ProviderSession, SignInFailure, SignInProblem};
 
 pub use auth::AuthConfig;
 pub use client::LibrespotClient;
@@ -37,6 +37,16 @@ impl SpotifyProvider {
 
     pub fn from_env() -> Self {
         Self::new(AuthConfig::from_env())
+    }
+
+    fn drop_free(&self, error: anyhow::Error) -> anyhow::Error {
+        if matches!(
+            error.downcast_ref::<SignInFailure>(),
+            Some(SignInFailure(SignInProblem::Premium))
+        ) {
+            auth::forget(&self.config);
+        }
+        error
     }
 
     async fn session(&self, client: LibrespotClient) -> Result<ProviderSession> {
@@ -75,7 +85,10 @@ impl MusicProvider for SpotifyProvider {
     }
 
     async fn restore(&self) -> Result<Option<ProviderSession>> {
-        let Some(session) = auth::restore(&self.config).await? else {
+        let Some(session) = auth::restore(&self.config)
+            .await
+            .map_err(|error| self.drop_free(error))?
+        else {
             return Ok(None);
         };
         self.session(LibrespotClient::new(session)).await.map(Some)
@@ -87,7 +100,9 @@ impl MusicProvider for SpotifyProvider {
         _prompt: crate::PromptSink,
         _input: crate::InputSource,
     ) -> Result<ProviderSession> {
-        let session = auth::login(&self.config).await?;
+        let session = auth::login(&self.config)
+            .await
+            .map_err(|error| self.drop_free(error))?;
         self.session(LibrespotClient::new(session)).await
     }
 

--- a/crates/views/src/shared/trouble.rs
+++ b/crates/views/src/shared/trouble.rs
@@ -53,6 +53,7 @@ fn tidy(text: &str) -> String {
 
 fn reason(problem: SignInProblem) -> &'static str {
     match problem {
+        SignInProblem::Premium => "login-problem-premium",
         SignInProblem::Region => "login-problem-region",
         SignInProblem::Credentials => "login-problem-credentials",
         SignInProblem::Network => "login-problem-network",


### PR DESCRIPTION
## Summary

- stop sonora from closing when the signed-in account has no spotify premium
- forget the cached spotify session so the login screen is reachable again
- show the premium requirement on the sign-in failure card
- point librespot at a patched revision that warns instead of exiting
