### PR TITLE
fix(player): pin the volume percentage to the slider handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Switches now slide and fade between on and off instead of snapping, at a fixed control speed that
   the animation speed setting deliberately leaves alone.
 
+### Fixed
+
+- The volume percentage now sits above the slider handle instead of trailing the pointer, so it
+  reads as a label on the handle you are dragging.
+
 ## [0.14.0] - 2026-08-14
 
 ### Added

--- a/crates/views/src/chrome/player_bar.rs
+++ b/crates/views/src/chrome/player_bar.rs
@@ -186,7 +186,7 @@ impl PlayerBar {
         let theme = *cx.theme();
         let empty = theme.muted_foreground.opacity(0.3);
         let level = self.playback.read(cx).volume();
-        let bubble = self.over_volume.map(|at| (at, percent(level)));
+        let bubble = self.over_volume.map(|_| (level, percent(level)));
         let restore = self.muted.unwrap_or(0.7);
 
         div()


### PR DESCRIPTION
## Summary

- pin the volume percentage above the slider handle instead of the pointer
