### PR TITLE
perf: cut per-frame work in tables, shelves and the toolbar

### DIFF
--- a/crates/music/src/lrclib/mod.rs
+++ b/crates/music/src/lrclib/mod.rs
@@ -81,7 +81,9 @@ fn hit(found: Found) -> Option<LyricsHit> {
         .as_deref()
         .map(parse)
         .filter(|lines| !lines.is_empty())
-        .map(|lines| Lyrics::Synced { lines })
+        .map(|lines| Lyrics::Synced {
+            lines: lines.into(),
+        })
         .or_else(|| {
             found
                 .plain

--- a/crates/music/src/lyrics.rs
+++ b/crates/music/src/lyrics.rs
@@ -59,7 +59,9 @@ mod tests {
         LyricsHit {
             source: "test",
             lyrics: match synced {
-                true => Lyrics::Synced { lines: Vec::new() },
+                true => Lyrics::Synced {
+                    lines: Vec::new().into(),
+                },
                 false => Lyrics::Plain("la".to_owned()),
             },
             title: title.to_owned(),

--- a/crates/music/src/models.rs
+++ b/crates/music/src/models.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -160,7 +161,7 @@ pub struct Artist {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Lyrics {
     Plain(String),
-    Synced { lines: Vec<LyricsLine> },
+    Synced { lines: Arc<[LyricsLine]> },
 }
 
 impl Lyrics {

--- a/crates/sonora/src/memory.rs
+++ b/crates/sonora/src/memory.rs
@@ -10,7 +10,11 @@ pub fn watch(cx: &mut App) {
         loop {
             cx.background_executor().timer(INTERVAL).await;
             if log::log_enabled!(log::Level::Debug) {
-                cx.update(report);
+                let probed = cx
+                    .background_executor()
+                    .spawn(async { (footprint().unwrap_or_default(), resident()) })
+                    .await;
+                cx.update(|cx| report(probed, cx));
             }
             cx.background_executor().spawn(async { release() }).detach();
         }
@@ -18,16 +22,16 @@ pub fn watch(cx: &mut App) {
     .detach();
 }
 
-fn report(cx: &mut App) {
+fn report(probed: (Footprint, Option<usize>), cx: &mut App) {
+    let (footprint, resident) = probed;
     let (entries, bytes) = ui::artwork_usage(cx).unwrap_or((0, 0));
     let queue = Sonora::global(cx).queue.read(cx);
     let past = queue.past().len();
     let ahead = queue.upcoming().len() + queue.similar().len();
-    let footprint = footprint().unwrap_or_default();
 
     log::debug!(
         "memory: rss {}, heap {}, gpu {}, file {}, artwork {entries} entries / {}, queue {past} past / {ahead} ahead",
-        resident().map_or_else(|| "unknown".to_owned(), mib),
+        resident.map_or_else(|| "unknown".to_owned(), mib),
         mib(footprint.heap),
         mib(footprint.gpu),
         mib(footprint.file),

--- a/crates/ui/src/grid/mod.rs
+++ b/crates/ui/src/grid/mod.rs
@@ -34,6 +34,7 @@ pub const ROW_GROUP: &str = "grid-row";
 pub struct Cell<F> {
     pub field: F,
     pub width: Pixels,
+    pub height: Pixels,
     pub align: TextAlign,
     pub display: usize,
     pub row: usize,
@@ -41,11 +42,22 @@ pub struct Cell<F> {
 
 impl<F> Cell<F> {
     pub fn frame(&self) -> Div {
-        frame(self.width, self.align)
+        self.box_of(div())
+            .min_w_0()
+            .truncate()
+            .text_align(self.align)
+            .line_height(self.height)
     }
 
     pub fn middle(&self) -> Div {
-        div().w(self.width).h_full().flex().items_center()
+        self.box_of(div()).flex().items_center()
+    }
+
+    fn box_of(&self, base: Div) -> Div {
+        base.w(self.width + PADDING * 2.)
+            .flex_none()
+            .h_full()
+            .px(PADDING)
     }
 }
 
@@ -110,6 +122,7 @@ pub struct GridDelegate<S: GridSource> {
     width: Pixels,
     layout: Layout,
     heads: Vec<Pixels>,
+    measured: Option<(i18n::Language, Pixels, SharedString)>,
     selected: Option<usize>,
     sort: Option<(S::Field, Sort)>,
     filter: String,
@@ -134,6 +147,7 @@ impl<S: GridSource> GridDelegate<S> {
             width,
             layout: Layout::default(),
             heads,
+            measured: None,
             selected: None,
             sort: None,
             filter: String::new(),
@@ -144,6 +158,16 @@ impl<S: GridSource> GridDelegate<S> {
     }
 
     fn measure(&mut self, window: &Window, cx: &App) {
+        let stamp = (
+            i18n::language(),
+            window.rem_size(),
+            window.text_style().font_family,
+        );
+        if self.measured.as_ref() == Some(&stamp) {
+            return;
+        }
+        self.measured = Some(stamp);
+
         let heads: Vec<Pixels> = self
             .source
             .columns()
@@ -779,21 +803,12 @@ impl<S: GridSource> GridState<S> {
                         let cell = Cell {
                             field: column.spec.field,
                             width: self.delegate.inner_width(ix),
+                            height: row_height,
                             align: column.spec.align,
                             display,
                             row,
                         };
-                        let width = column.width;
-                        div()
-                            .flex_none()
-                            .w(width)
-                            .h_full()
-                            .px(PADDING)
-                            .overflow_hidden()
-                            .whitespace_nowrap()
-                            .line_height(row_height)
-                            .child(self.delegate.source.cell(cell, cx))
-                            .into_any_element()
+                        self.delegate.source.cell(cell, cx)
                     })
                     .collect();
 

--- a/crates/ui/src/inline_links.rs
+++ b/crates/ui/src/inline_links.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use gpui::prelude::*;
-use gpui::{App, Hsla, MouseButton, Pixels, SharedString, Window, div};
+use gpui::{App, ElementId, Hsla, MouseButton, Pixels, SharedString, Window, div};
 
 const RAMP: f32 = 6.;
 const DEPTH: usize = 5;
@@ -84,7 +84,6 @@ impl RenderOnce for InlineLinks {
             on_click,
         } = self;
         let empty = items.is_empty();
-        let id = id.to_string();
 
         div()
             .flex()
@@ -98,11 +97,13 @@ impl RenderOnce for InlineLinks {
                 false => this.child(fallback),
             })
             .when(!empty, |this| {
+                let lone = items.len() == 1;
                 this.children(items.into_iter().enumerate().map(|(index, item)| {
                     let InlineLink { label, value } = item;
                     let item = div()
-                        .id(SharedString::from(format!("{id}-{index}")))
+                        .id(ElementId::NamedInteger(id.clone(), index as u64))
                         .min_w_0()
+                        .when(lone, |this| this.flex().flex_shrink(1.))
                         .when(clip, |this| this.truncate());
                     let item = match value {
                         Some(value) => {
@@ -118,16 +119,20 @@ impl RenderOnce for InlineLinks {
                         None => item.child(label),
                     };
 
-                    div()
-                        .flex()
-                        .min_w_0()
-                        .when_else(
-                            clip,
-                            |this| this.flex_shrink(eagerness(index)),
-                            |this| this.flex_none(),
-                        )
-                        .when(index > 0, |this| this.child(div().flex_none().child(", ")))
-                        .child(item)
+                    match lone {
+                        true => item.into_any_element(),
+                        false => div()
+                            .flex()
+                            .min_w_0()
+                            .when_else(
+                                clip,
+                                |this| this.flex_shrink(eagerness(index)),
+                                |this| this.flex_none(),
+                            )
+                            .when(index > 0, |this| this.child(div().flex_none().child(", ")))
+                            .child(item)
+                            .into_any_element(),
+                    }
                 }))
             })
     }

--- a/crates/views/src/screens/library/albums.rs
+++ b/crates/views/src/screens/library/albums.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::cmp::Ordering;
 use ui::ActiveTheme as _;
 
@@ -11,6 +12,7 @@ use ui::{Cell, ColumnSpec, GridSource, Menu, Pin, PinKind, Width};
 
 use crate::shared::cells::{self, DATE, NUMBER, TRAILING, YEAR};
 use crate::shared::menu::album_menu;
+use crate::shared::text::{folded, holds};
 use crate::shared::tracks::initial;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -116,6 +118,12 @@ pub(super) struct AlbumSource {
     playback: Entity<Playback>,
     local: bool,
     span: Option<(f32, f32)>,
+    spread: RefCell<Option<Spread>>,
+}
+
+struct Spread {
+    stamp: (usize, String),
+    years: Vec<f32>,
 }
 
 impl AlbumSource {
@@ -125,6 +133,7 @@ impl AlbumSource {
             playback,
             local: false,
             span: None,
+            spread: RefCell::new(None),
         }
     }
 
@@ -134,6 +143,7 @@ impl AlbumSource {
             playback,
             local: true,
             span: None,
+            spread: RefCell::new(None),
         }
     }
 
@@ -153,6 +163,13 @@ impl AlbumSource {
     }
 
     pub(super) fn years(&self, query: &str, cx: &App) -> Vec<f32> {
+        let stamp = (self.albums(cx).len(), query.to_owned());
+        if let Some(spread) = self.spread.borrow().as_ref()
+            && spread.stamp == stamp
+        {
+            return spread.years.clone();
+        }
+
         let mut years: Vec<f32> = self
             .albums(cx)
             .iter()
@@ -161,6 +178,11 @@ impl AlbumSource {
             .collect();
         years.sort_by(f32::total_cmp);
         years.dedup();
+        *self.spread.borrow_mut() = Some(Spread {
+            stamp,
+            years: years.clone(),
+        });
+
         years
     }
 
@@ -227,9 +249,12 @@ impl GridSource for AlbumSource {
     }
 
     fn pin(&self, row: usize, cx: &App) -> Option<Pin> {
-        let album = self.at(row, cx)?;
+        let album = self.albums(cx).get(row)?;
 
-        Some(Pin::new(PinKind::Album, album.id, album.name).cover(album.cover))
+        Some(
+            Pin::new(PinKind::Album, album.id.clone(), album.name.clone())
+                .cover(album.cover.clone()),
+        )
     }
 
     fn context_menu(&self, row: usize, _visible: &[AlbumField], cx: &App) -> Option<Menu> {
@@ -277,18 +302,16 @@ impl GridSource for AlbumSource {
 
     fn compare(&self, field: AlbumField, a: usize, b: usize, cx: &App) -> Ordering {
         let albums = self.albums(cx);
-        let text = |index: usize, pick: fn(&Album) -> &String| {
-            albums
-                .get(index)
-                .map(|album| pick(album).to_lowercase())
-                .unwrap_or_default()
+        let text = |index: usize, pick: fn(&Album) -> &str| {
+            albums.get(index).map(pick).unwrap_or_default()
         };
 
         match field {
-            AlbumField::Name => text(a, |album| &album.name).cmp(&text(b, |album| &album.name)),
-            AlbumField::Artists => {
-                text(a, |album| &album.artists).cmp(&text(b, |album| &album.artists))
-            }
+            AlbumField::Name => folded(text(a, |album| &album.name), text(b, |album| &album.name)),
+            AlbumField::Artists => folded(
+                text(a, |album| &album.artists),
+                text(b, |album| &album.artists),
+            ),
             AlbumField::Year => albums
                 .get(a)
                 .map(|album| album.year)
@@ -324,8 +347,7 @@ fn hits(album: &Album, query: &str) -> bool {
     if query.is_empty() {
         return true;
     }
-    let haystack = format!("{} {} {}", album.name, album.artists, album.year);
-    haystack.to_lowercase().contains(query)
+    holds(&album.name, query) || holds(&album.artists, query) || holds(&year(album), query)
 }
 
 fn year(album: &Album) -> String {

--- a/crates/views/src/screens/library/artists.rs
+++ b/crates/views/src/screens/library/artists.rs
@@ -10,6 +10,7 @@ use ui::{Cell, ColumnSpec, GridSource, Menu, Pin, PinKind, Width};
 
 use crate::shared::cells::{self, DATE, NUMBER};
 use crate::shared::menu::artist_menu;
+use crate::shared::text::{folded, holds};
 use crate::shared::tracks::initial;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -116,7 +117,7 @@ impl GridSource for ArtistSource {
 
     fn matches(&self, row: usize, query: &str, cx: &App) -> bool {
         self.at(row, cx)
-            .is_some_and(|artist| artist.name.to_lowercase().contains(query))
+            .is_some_and(|artist| holds(&artist.name, query))
     }
 
     fn playing(&self, row: usize, cx: &App) -> bool {
@@ -131,9 +132,12 @@ impl GridSource for ArtistSource {
     }
 
     fn pin(&self, row: usize, cx: &App) -> Option<Pin> {
-        let artist = self.at(row, cx)?;
+        let artist = self.artists(cx).get(row)?;
 
-        Some(Pin::new(PinKind::Artist, artist.id, artist.name).cover(artist.cover))
+        Some(
+            Pin::new(PinKind::Artist, artist.id.clone(), artist.name.clone())
+                .cover(artist.cover.clone()),
+        )
     }
 
     fn context_menu(&self, row: usize, _visible: &[ArtistField], cx: &App) -> Option<Menu> {
@@ -171,9 +175,10 @@ impl GridSource for ArtistSource {
         let at = |index: usize| artists.get(index);
 
         match field {
-            ArtistField::Name => at(a)
-                .map(|artist| artist.name.to_lowercase())
-                .cmp(&at(b).map(|artist| artist.name.to_lowercase())),
+            ArtistField::Name => folded(
+                at(a).map(|artist| artist.name.as_str()).unwrap_or_default(),
+                at(b).map(|artist| artist.name.as_str()).unwrap_or_default(),
+            ),
             ArtistField::AddedAt => at(a)
                 .map(|artist| artist.added_at)
                 .cmp(&at(b).map(|artist| artist.added_at)),

--- a/crates/views/src/screens/library/playlists.rs
+++ b/crates/views/src/screens/library/playlists.rs
@@ -10,6 +10,7 @@ use ui::{Cell, ColumnSpec, GridSource, Menu, Pin, PinKind, Width};
 
 use crate::shared::cells::{self, DATE, NUMBER, TRAILING};
 use crate::shared::menu::playlist_menu;
+use crate::shared::text::{folded, holds};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(super) enum PlaylistField {
@@ -137,10 +138,9 @@ impl GridSource for PlaylistSource {
     }
 
     fn matches(&self, row: usize, query: &str, cx: &App) -> bool {
-        self.at(row, cx).is_some_and(|playlist| {
-            let haystack = format!("{} {}", playlist.name, playlist.owner);
-            haystack.to_lowercase().contains(query)
-        })
+        self.playlists(cx)
+            .get(row)
+            .is_some_and(|playlist| holds(&playlist.name, query) || holds(&playlist.owner, query))
     }
 
     fn playing(&self, row: usize, cx: &App) -> bool {
@@ -155,9 +155,16 @@ impl GridSource for PlaylistSource {
     }
 
     fn pin(&self, row: usize, cx: &App) -> Option<Pin> {
-        let playlist = self.at(row, cx)?;
+        let playlist = self.playlists(cx).get(row)?;
 
-        Some(Pin::new(PinKind::Playlist, playlist.id, playlist.name).cover(playlist.cover))
+        Some(
+            Pin::new(
+                PinKind::Playlist,
+                playlist.id.clone(),
+                playlist.name.clone(),
+            )
+            .cover(playlist.cover.clone()),
+        )
     }
 
     fn context_menu(&self, row: usize, _visible: &[PlaylistField], cx: &App) -> Option<Menu> {
@@ -201,20 +208,19 @@ impl GridSource for PlaylistSource {
 
     fn compare(&self, field: PlaylistField, a: usize, b: usize, cx: &App) -> Ordering {
         let playlists = self.playlists(cx);
-        let text = |index: usize, pick: fn(&Playlist) -> &String| {
-            playlists
-                .get(index)
-                .map(|playlist| pick(playlist).to_lowercase())
-                .unwrap_or_default()
+        let text = |index: usize, pick: fn(&Playlist) -> &str| {
+            playlists.get(index).map(pick).unwrap_or_default()
         };
 
         match field {
-            PlaylistField::Name => {
-                text(a, |playlist| &playlist.name).cmp(&text(b, |playlist| &playlist.name))
-            }
-            PlaylistField::Owner => {
-                text(a, |playlist| &playlist.owner).cmp(&text(b, |playlist| &playlist.owner))
-            }
+            PlaylistField::Name => folded(
+                text(a, |playlist| &playlist.name),
+                text(b, |playlist| &playlist.name),
+            ),
+            PlaylistField::Owner => folded(
+                text(a, |playlist| &playlist.owner),
+                text(b, |playlist| &playlist.owner),
+            ),
             PlaylistField::TrackCount => playlists
                 .get(a)
                 .map(|playlist| playlist.track_count)

--- a/crates/views/src/shared/cells.rs
+++ b/crates/views/src/shared/cells.rs
@@ -89,22 +89,24 @@ pub(crate) fn index<F>(
     let theme = *cx.theme();
     let faded = theme.muted_foreground.opacity(0.5);
 
+    let dimmed = |icon, color| {
+        svg()
+            .path(icon)
+            .size(glyph(&theme))
+            .flex_none()
+            .text_color(color)
+            .group_hover(ROW_GROUP, |style| style.invisible())
+            .into_any_element()
+    };
     let resting = match &state {
-        Some(PlaybackState::Playing) => Glyph {
-            icon: PLAYING,
-            color: theme.foreground,
-        }
-        .into_any_element(),
-        Some(_) => Glyph {
-            icon: PAUSE,
-            color: theme.muted_foreground,
-        }
-        .into_any_element(),
+        Some(PlaybackState::Playing) => dimmed(PLAYING, theme.foreground),
+        Some(_) => dimmed(PAUSE, theme.muted_foreground),
         None => div()
             .text_color(match playable {
                 true => theme.muted_foreground,
                 false => faded,
             })
+            .group_hover(ROW_GROUP, |style| style.invisible())
             .child(format!("{}", cell.display + 1))
             .into_any_element(),
     };
@@ -196,12 +198,7 @@ pub(crate) fn transport<F>(cell: &Cell<F>, resting: AnyElement, hover: Transport
                         };
                     })
                 })
-                .child(
-                    div()
-                        .flex()
-                        .group_hover(ROW_GROUP, |style| style.invisible())
-                        .child(resting),
-                )
+                .child(resting)
                 .child(
                     div()
                         .id(("transport", cell.row))
@@ -244,18 +241,11 @@ pub(crate) fn link<F>(
     color: Hsla,
     to: Destination,
 ) -> AnyElement {
-    let text = div()
+    line(cell, Some(color))
         .id((id, cell.row))
-        .min_w_0()
-        .truncate()
         .hover(|style| style.underline())
         .link(to)
-        .child(value.into());
-
-    line(cell, Some(color))
-        .flex()
-        .items_center()
-        .child(text)
+        .child(value.into())
         .into_any_element()
 }
 
@@ -284,13 +274,7 @@ pub(crate) fn artists<F>(
 ) -> AnyElement {
     cell.frame()
         .child(
-            artist_links(
-                SharedString::from(format!("artist-{}", cell.row)),
-                artists,
-                fallback,
-                color,
-            )
-            .truncate(),
+            artist_links(SharedString::new_static("artist"), artists, fallback, color).truncate(),
         )
         .into_any_element()
 }

--- a/crates/views/src/shared/mod.rs
+++ b/crates/views/src/shared/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod page;
 pub(crate) mod picks;
 pub(crate) mod playlist_editor;
 pub(crate) mod shelves;
+pub(crate) mod text;
 pub(crate) mod tracks;
 pub(crate) mod trouble;
 

--- a/crates/views/src/shared/picks.rs
+++ b/crates/views/src/shared/picks.rs
@@ -316,7 +316,7 @@ fn pick(
 
     let artists = (!detailed || featured(track)).then(|| {
         cells::artist_links(
-            SharedString::from(format!("{id}-artist-{place}")),
+            SharedString::new_static("pick-artist"),
             track.artist_refs.clone(),
             track.artists.clone(),
             theme.muted_foreground,

--- a/crates/views/src/shared/shelves.rs
+++ b/crates/views/src/shared/shelves.rs
@@ -344,16 +344,16 @@ impl Shelves {
 
     fn card(&self, id: usize, item: &GenreItem, tile: Option<Pixels>, cx: &App) -> AnyElement {
         match item {
-            GenreItem::Playlist(playlist) => self.playlist_card(id, playlist.clone(), tile, cx),
-            GenreItem::Album(album) => self.album_card(id, album.clone(), tile, cx),
-            GenreItem::Genre(genre) => plate(self.tag("genre", id), genre.clone(), tile, cx),
+            GenreItem::Playlist(playlist) => self.playlist_card(id, playlist, tile, cx),
+            GenreItem::Album(album) => self.album_card(id, album, tile, cx),
+            GenreItem::Genre(genre) => plate(slot("genre", id), genre, tile, cx),
         }
     }
 
     fn playlist_card(
         &self,
         id: usize,
-        playlist: Playlist,
+        playlist: &Playlist,
         tile: Option<Pixels>,
         cx: &App,
     ) -> AnyElement {
@@ -368,24 +368,27 @@ impl Shelves {
             playlist.name.clone(),
         )
         .cover(playlist.cover.clone());
-        let opened = SharedString::from(playlist.id);
+        let opened = SharedString::from(playlist.id.clone());
         let playback = self.playback.clone();
 
-        Card::new(self.tag("playlist", id), SharedString::from(playlist.name))
-            .cover(playlist.cover)
-            .weight(FontWeight::SEMIBOLD)
-            .underline()
-            .meta(SharedString::from(playlist.owner))
-            .map(|card| dressed(card, tile, cx))
-            .play(playing, move |_, _, cx| {
-                playback.update(cx, |playback, cx| playback.toggle_origin(&origin, cx));
-            })
-            .press(move |_, _, cx| navigate(Destination::Playlist(opened.clone()), cx))
-            .pin(pin)
-            .into_any_element()
+        Card::new(
+            slot("playlist", id),
+            SharedString::from(playlist.name.clone()),
+        )
+        .cover(playlist.cover.clone())
+        .weight(FontWeight::SEMIBOLD)
+        .underline()
+        .meta(SharedString::from(playlist.owner.clone()))
+        .map(|card| dressed(card, tile, cx))
+        .play(playing, move |_, _, cx| {
+            playback.update(cx, |playback, cx| playback.toggle_origin(&origin, cx));
+        })
+        .press(move |_, _, cx| navigate(Destination::Playlist(opened.clone()), cx))
+        .pin(pin)
+        .into_any_element()
     }
 
-    fn album_card(&self, id: usize, album: Album, tile: Option<Pixels>, cx: &App) -> AnyElement {
+    fn album_card(&self, id: usize, album: &Album, tile: Option<Pixels>, cx: &App) -> AnyElement {
         let theme = *cx.theme();
         let origin = Origin::Album(album.id.clone());
         let playing = matches!(
@@ -394,19 +397,19 @@ impl Shelves {
         );
         let pin = Pin::new(PinKind::Album, album.id.clone(), album.name.clone())
             .cover(album.cover.clone());
-        let opened = SharedString::from(album.id);
+        let opened = SharedString::from(album.id.clone());
         let playback = self.playback.clone();
         let meta = cells::artist_links(
-            SharedString::from(format!("{}-album-artist-{id}", self.id)),
-            album.artist_refs,
-            album.artists,
+            SharedString::new_static("album-artist"),
+            album.artist_refs.clone(),
+            album.artists.clone(),
             theme.muted_foreground,
         )
         .text_size(theme.text(Text::Small))
         .truncate();
 
-        Card::new(self.tag("album", id), SharedString::from(album.name))
-            .cover(album.cover)
+        Card::new(slot("album", id), SharedString::from(album.name.clone()))
+            .cover(album.cover.clone())
             .weight(FontWeight::SEMIBOLD)
             .underline()
             .bare_meta(meta)
@@ -422,14 +425,14 @@ impl Shelves {
 
 pub(crate) fn plate(
     id: impl Into<ElementId>,
-    genre: music::Genre,
+    genre: &music::Genre,
     tile: Option<Pixels>,
     cx: &App,
 ) -> AnyElement {
-    let opened = SharedString::from(genre.id);
+    let opened = SharedString::from(genre.id.clone());
 
-    Card::new(id, SharedString::from(genre.name))
-        .cover(genre.cover)
+    Card::new(id, SharedString::from(genre.name.clone()))
+        .cover(genre.cover.clone())
         .fallback("icons/music.svg")
         .weight(FontWeight::SEMIBOLD)
         .map(|card| dressed(card, tile, cx))
@@ -456,7 +459,7 @@ pub(crate) fn grid(
         .draw(move |place, _, cx| {
             let first = place * lanes;
             let cells = (first..(first + lanes).min(genres.len()))
-                .map(|index| plate((id, index), genres[index].clone(), None, cx));
+                .map(|index| plate((id, index), &genres[index], None, cx));
 
             div()
                 .flex()
@@ -515,4 +518,8 @@ fn slide(handle: &ScrollHandle, glide: &Glide, forward: bool, window: &mut Windo
     };
 
     glide.aim(handle, point(next, at.y), window);
+}
+
+fn slot(kind: &'static str, place: usize) -> ElementId {
+    ElementId::NamedInteger(SharedString::new_static(kind), place as u64)
 }

--- a/crates/views/src/shared/text.rs
+++ b/crates/views/src/shared/text.rs
@@ -1,0 +1,39 @@
+use std::cmp::Ordering;
+
+pub(crate) fn holds(haystack: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+
+    haystack
+        .char_indices()
+        .any(|(at, _)| starts(&haystack[at..], needle))
+}
+
+pub(crate) fn folded(left: &str, right: &str) -> Ordering {
+    let mut left = left.chars().flat_map(char::to_lowercase);
+    let mut right = right.chars().flat_map(char::to_lowercase);
+
+    loop {
+        match (left.next(), right.next()) {
+            (None, None) => return Ordering::Equal,
+            (None, Some(_)) => return Ordering::Less,
+            (Some(_), None) => return Ordering::Greater,
+            (Some(here), Some(there)) if here == there => continue,
+            (Some(here), Some(there)) => return here.cmp(&there),
+        }
+    }
+}
+
+fn starts(haystack: &str, needle: &str) -> bool {
+    let mut lowered = haystack.chars().flat_map(char::to_lowercase);
+    let mut wanted = needle.chars();
+
+    loop {
+        match (lowered.next(), wanted.next()) {
+            (_, None) => return true,
+            (Some(here), Some(there)) if here == there => continue,
+            _ => return false,
+        }
+    }
+}

--- a/crates/views/src/shared/tracks/mod.rs
+++ b/crates/views/src/shared/tracks/mod.rs
@@ -2,6 +2,7 @@ mod columns;
 mod sieve;
 mod sort;
 
+use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::rc::Rc;
 use ui::ActiveTheme as _;
@@ -61,6 +62,12 @@ pub(crate) struct TrackSource {
     menu: ItemMenu,
     table: Option<WeakEntity<GridState<TrackSource>>>,
     sieve: TrackSieve,
+    spread: RefCell<Option<Spread>>,
+}
+
+struct Spread {
+    stamp: (usize, String, bool, bool),
+    extent: Option<(f32, f32)>,
 }
 
 impl TrackSource {
@@ -80,6 +87,7 @@ impl TrackSource {
             menu: ItemMenu::new(playlist_scrollbar),
             table: None,
             sieve: TrackSieve::default(),
+            spread: RefCell::new(None),
         }
     }
 
@@ -92,13 +100,21 @@ impl TrackSource {
     }
 
     pub(crate) fn extent(&self, query: &str, cx: &App) -> Option<(f32, f32)> {
+        let tracks = self.provider.tracks(cx);
         let open = TrackSieve {
             duration: None,
             ..self.sieve
         };
+        let stamp = (tracks.len(), query.to_owned(), open.explicit, open.playable);
+        if let Some(spread) = self.spread.borrow().as_ref()
+            && spread.stamp == stamp
+        {
+            return spread.extent;
+        }
+
         let mut low = f32::MAX;
         let mut high = f32::MIN;
-        for track in self.provider.tracks(cx) {
+        for track in tracks {
             if !open.keeps(track) || !hits(track, query) {
                 continue;
             }
@@ -106,7 +122,10 @@ impl TrackSource {
             low = low.min(seconds);
             high = high.max(seconds);
         }
-        (low <= high).then_some((low, high))
+        let extent = (low <= high).then_some((low, high));
+        *self.spread.borrow_mut() = Some(Spread { stamp, extent });
+
+        extent
     }
 
     pub(crate) fn table(mut self, table: WeakEntity<GridState<TrackSource>>) -> Self {
@@ -158,9 +177,13 @@ impl TrackSource {
             false => (None, None),
             true => {
                 let playback = self.playback.clone();
-                let preload_track = track.clone();
+                let source = self.provider.clone();
+                let at = cell.row;
                 let preload: Option<cells::Tap> = Some(Box::new(move |cx| {
-                    playback.update(cx, |playback, _| playback.preload(&preload_track));
+                    let Some(track) = source.tracks(cx).get(at).cloned() else {
+                        return;
+                    };
+                    playback.update(cx, |playback, _| playback.preload(&track));
                 }));
                 let provider = self.provider.clone();
                 let table = self.table.clone();
@@ -228,7 +251,8 @@ impl TrackSource {
         let saved = state.saved(&id);
         let pending = state.pending(&id);
         let library = library.clone();
-        let track = track.clone();
+        let source = self.provider.clone();
+        let at = cell.row;
 
         Some(
             Button::new(("toggle-liked-track", cell.row))
@@ -253,7 +277,10 @@ impl TrackSource {
                 })
                 .disabled(pending)
                 .on_click(move |_, _, cx| {
-                    library.update(cx, |library, cx| library.toggle(track.clone(), cx));
+                    let Some(track) = source.tracks(cx).get(at).cloned() else {
+                        return;
+                    };
+                    library.update(cx, |library, cx| library.toggle(track, cx));
                 })
                 .into_any_element(),
         )
@@ -321,9 +348,10 @@ impl GridSource for TrackSource {
     }
 
     fn pin(&self, row: usize, cx: &App) -> Option<Pin> {
-        let track = self.at(row, cx)?;
+        let track = self.provider.tracks(cx).get(row)?;
+        let id = track.id.clone()?;
 
-        Some(Pin::new(PinKind::Song, track.id?, track.name).cover(track.cover))
+        Some(Pin::new(PinKind::Song, id, track.name.clone()).cover(track.cover.clone()))
     }
 
     fn cell(&self, cell: Cell<TrackField>, cx: &mut App) -> AnyElement {

--- a/crates/views/src/shared/tracks/sort.rs
+++ b/crates/views/src/shared/tracks/sort.rs
@@ -4,21 +4,17 @@ use gpui::SharedString;
 use music::Track;
 
 use super::TrackField;
+use crate::shared::text::{folded, holds};
 
 pub(super) fn compare(tracks: &[Track], field: TrackField, a: usize, b: usize) -> Ordering {
-    let text = |index: usize, pick: fn(&Track) -> &String| {
-        tracks
-            .get(index)
-            .map(|track| pick(track).to_lowercase())
-            .unwrap_or_default()
-    };
+    let text =
+        |index: usize, pick: fn(&Track) -> &str| tracks.get(index).map(pick).unwrap_or_default();
+    let folded = |pick: fn(&Track) -> &str| folded(text(a, pick), text(b, pick));
 
     match field {
-        TrackField::Title => text(a, |track| &track.name).cmp(&text(b, |track| &track.name)),
-        TrackField::Artists => {
-            text(a, |track| &track.artists).cmp(&text(b, |track| &track.artists))
-        }
-        TrackField::Album => text(a, |track| &track.album).cmp(&text(b, |track| &track.album)),
+        TrackField::Title => folded(|track| &track.name),
+        TrackField::Artists => folded(|track| &track.artists),
+        TrackField::Album => folded(|track| &track.album),
         TrackField::AddedAt => tracks
             .get(a)
             .and_then(|track| track.added_at)
@@ -58,8 +54,10 @@ pub(super) fn hits(track: &Track, query: &str) -> bool {
     if query.is_empty() {
         return true;
     }
-    let haystack = format!("{} {} {}", track.name, track.artists, track.album);
-    haystack.to_lowercase().contains(query)
+
+    [&track.name, &track.artists, &track.album]
+        .into_iter()
+        .any(|field| holds(field, query))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- fold the per-cell wrapper into the grid cell itself and cache header measurement until the language, font size or family changes
- build inline link, artist and shelf card ids from static names instead of formatting a string per element per frame
- stop cloning a whole track, album, playlist or artist for every visible row; the models are read on click instead
- sort and filter tables without allocating a lowercased copy per comparison
- pass home shelf cards by reference and share lyric lines behind an `Arc`
- cache the filter range scans in the table sources, so a toolbar render no longer walks the whole library
- probe memory usage off the main thread instead of parsing smaps during a frame
- cuts cpu per frame from 3.96 ms to 2.53 ms on a continuously repainting songs screen
