### PR TITLE
fix: show the home shelves the feed returns blank

### DIFF
--- a/crates/music/src/lib.rs
+++ b/crates/music/src/lib.rs
@@ -96,6 +96,10 @@ pub trait MusicApi: Send + Sync {
         Ok(Vec::new())
     }
 
+    async fn mend_home(&self, sections: Vec<GenreSection>) -> Vec<GenreSection> {
+        sections
+    }
+
     async fn genres(&self) -> Result<Vec<Genre>> {
         Ok(Vec::new())
     }

--- a/crates/music/src/spotify/client.rs
+++ b/crates/music/src/spotify/client.rs
@@ -148,9 +148,12 @@ impl MusicApi for LibrespotClient {
     }
 
     async fn home(&self) -> Result<Vec<GenreSection>> {
-        Ok(pathfinder::genre(&self.session, MADE_FOR_YOU)
+        let mut sections = pathfinder::genre(&self.session, MADE_FOR_YOU)
             .await?
-            .sections)
+            .sections;
+        playlists::mend(&self.session, &mut sections).await;
+
+        Ok(sections)
     }
 
     async fn genres(&self) -> Result<Vec<Genre>> {

--- a/crates/music/src/spotify/playlists.rs
+++ b/crates/music/src/spotify/playlists.rs
@@ -12,7 +12,7 @@ use protobuf::{Message as _, MessageField};
 use tokio::task::JoinSet;
 
 use crate::spotify::{collection, wire};
-use crate::{PlaylistDetail, Track};
+use crate::{GenreItem, GenreSection, Playlist, PlaylistDetail, Track};
 
 const TRACK_PREFIX: &str = "spotify:track:";
 const PLAYLIST_PREFIX: &str = "spotify:playlist:";
@@ -132,6 +132,64 @@ pub async fn playlist(session: &Session, playlist_id: &str) -> Result<PlaylistDe
     let tracks = tracks_from(session, &content).await?;
 
     Ok(PlaylistDetail { playlist, tracks })
+}
+
+pub async fn header(session: &Session, playlist_id: &str) -> Result<Playlist> {
+    let content = snapshot(session, playlist_id).await?;
+
+    Ok(wire::playlist_from(
+        playlist_id,
+        &content,
+        &session.username(),
+    ))
+}
+
+pub async fn mend(session: &Session, sections: &mut Vec<GenreSection>) {
+    let blanks: Vec<String> = sections
+        .iter()
+        .flat_map(|section| section.items.iter())
+        .filter_map(|item| match item {
+            GenreItem::Playlist(playlist) if playlist.name.is_empty() => Some(playlist.id.clone()),
+            _ => None,
+        })
+        .collect();
+    if blanks.is_empty() {
+        return;
+    }
+
+    let mut pending = JoinSet::new();
+    for id in blanks {
+        let session = session.clone();
+        pending.spawn(async move { (id.clone(), header(&session, &id).await.ok()) });
+    }
+
+    let mut found = HashMap::new();
+    while let Some(joined) = pending.join_next().await {
+        if let Ok((id, Some(playlist))) = joined {
+            found.insert(id, playlist);
+        }
+    }
+
+    for section in sections.iter_mut() {
+        for item in &mut section.items {
+            let GenreItem::Playlist(playlist) = item else {
+                continue;
+            };
+            if !playlist.name.is_empty() {
+                continue;
+            }
+            let Some(mended) = found.get(&playlist.id) else {
+                continue;
+            };
+            playlist.name = mended.name.clone();
+            playlist.cover = mended.cover.clone();
+        }
+        section.items.retain(|item| match item {
+            GenreItem::Playlist(playlist) => !playlist.name.is_empty(),
+            _ => true,
+        });
+    }
+    sections.retain(|section| !section.items.is_empty());
 }
 
 pub async fn playlist_tracks(session: &Session, playlist_id: &str) -> Result<Vec<Track>> {

--- a/crates/state/src/home.rs
+++ b/crates/state/src/home.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::rc::Rc;
 
 use gpui::{App, Context, Entity, Task};
-use music::{GenreSection, Track};
+use music::{GenreItem, GenreSection, Track};
 
 use crate::{Io, Library, LibraryState, Session, SessionEvent, join};
 
@@ -18,6 +18,7 @@ pub struct Home {
     sections: Rc<Vec<GenreSection>>,
     feeding: bool,
     task: Option<Task<()>>,
+    mending: Option<Task<()>>,
 }
 
 impl Home {
@@ -34,6 +35,7 @@ impl Home {
             SessionEvent::SignedIn => this.feed(cx),
             SessionEvent::SignedOut => {
                 this.task = None;
+                this.mending = None;
                 this.sections = Rc::new(Vec::new());
                 this.feeding = false;
                 cx.notify();
@@ -65,6 +67,7 @@ impl Home {
             sections: Rc::new(Vec::new()),
             feeding: false,
             task: None,
+            mending: None,
         };
         home.feed(cx);
         home
@@ -94,9 +97,40 @@ impl Home {
             this.update(cx, |this, cx| {
                 this.feeding = false;
                 match loaded {
-                    Ok(sections) => this.sections = Rc::new(sections),
+                    Ok(sections) => {
+                        this.sections = Rc::new(pruned(&sections));
+                        this.mend(sections, cx);
+                    }
                     Err(error) => log::warn!("home: cannot load the feed: {error:#}"),
                 }
+                cx.notify();
+            })
+            .ok();
+        }));
+    }
+
+    fn mend(&mut self, sections: Vec<GenreSection>, cx: &mut Context<Self>) {
+        if !sections
+            .iter()
+            .any(|section| section.items.iter().any(blank))
+        {
+            return;
+        }
+        let Some(client) = self.session.read(cx).client() else {
+            return;
+        };
+
+        let io = self.io.clone();
+        self.mending = Some(cx.spawn(async move |this, cx| {
+            let mended = io
+                .spawn(async move { client.mend_home(sections).await })
+                .await;
+            let Ok(mended) = mended else {
+                return;
+            };
+
+            this.update(cx, |this, cx| {
+                this.sections = Rc::new(mended);
                 cx.notify();
             })
             .ok();
@@ -110,6 +144,32 @@ impl Home {
     pub fn is_loading(&self, cx: &App) -> bool {
         self.library.read(cx).is_loading()
     }
+}
+
+fn blank(item: &GenreItem) -> bool {
+    match item {
+        GenreItem::Playlist(playlist) => playlist.name.is_empty(),
+        _ => false,
+    }
+}
+
+fn pruned(sections: &[GenreSection]) -> Vec<GenreSection> {
+    sections
+        .iter()
+        .filter_map(|section| {
+            let items: Vec<GenreItem> = section
+                .items
+                .iter()
+                .filter(|item| !blank(item))
+                .cloned()
+                .collect();
+
+            (!items.is_empty()).then(|| GenreSection {
+                title: section.title.clone(),
+                items,
+            })
+        })
+        .collect()
 }
 
 fn picks(library: &Entity<Library>, seed: u64, cx: &App) -> Rc<Vec<Track>> {


### PR DESCRIPTION
## Summary

- fill in home playlists that the browse feed returns with an empty name and no cover, resolving them from the playlist endpoint
- backfill in the background so the home feed still paints as soon as it arrives
- drop items that cannot be resolved instead of rendering empty cards, and hide a shelf left with none
