### PR TITLE
fix: play youtube again and reconnect a stale session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- YouTube Music plays again. YouTube stopped serving the client Sonora asked for — the download of
+  every track was refused part-way through — and the fallback it tried next was refused outright.
+  Sonora now asks with a client YouTube still answers and, just as importantly, uses a visitor id
+  issued by YouTube instead of one it made up, which is what the refusals were really about.
+- A signed-in YouTube session survives a restart. Sonora used to keep the cookies it copied from
+  your browser the day you signed in, and YouTube rotates those every few hours, so your library
+  quietly went missing. When you signed in through a browser, Sonora now re-reads its cookies each
+  time it starts and keeps the copy fresh.
+- Playing after the app had been open for a long time no longer says the track cannot be played.
+  Suspending the machine, or any long enough network break, killed Sonora's connection to Spotify for
+  good and every track after that failed to load. Sonora now notices the connection went stale and
+  reconnects on its own, keeping the track you were on and resuming it where it stopped.
+
 ## [0.15.0] - 2026-08-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   every track was refused part-way through, and the fallback it tried next was refused outright. A
   signed-in session now streams through the YouTube Music client itself, which also hands over a
   better stream — 256 kbps instead of 128. Without an account Sonora asks as a headset would, with a
-  visitor id issued by YouTube rather than one it made up, though YouTube now turns most music away
-  from anonymous listeners regardless.
+  visitor id issued by YouTube rather than one it made up.
+- Playing without a YouTube account says so once instead of failing track after track. YouTube now
+  turns anonymous listeners away from most music, and Sonora used to work through the whole queue,
+  waiting six seconds between refusals. It now stops at the first one and asks you to sign in.
 - A signed-in YouTube session survives a restart. Sonora used to keep the cookies it copied from
   your browser the day you signed in, and YouTube rotates those every few hours, so your library
   quietly went missing. When you signed in through a browser, Sonora now re-reads its cookies each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- YouTube Music plays again. YouTube stopped serving the client Sonora asked for — the download of
-  every track was refused part-way through — and the fallback it tried next was refused outright.
-  Sonora now asks with a client YouTube still answers and, just as importantly, uses a visitor id
-  issued by YouTube instead of one it made up, which is what the refusals were really about.
+- YouTube Music plays again. YouTube stopped serving the clients Sonora asked for: the download of
+  every track was refused part-way through, and the fallback it tried next was refused outright. A
+  signed-in session now streams through the YouTube Music client itself, which also hands over a
+  better stream — 256 kbps instead of 128. Without an account Sonora asks as a headset would, with a
+  visitor id issued by YouTube rather than one it made up, though YouTube now turns most music away
+  from anonymous listeners regardless.
 - A signed-in YouTube session survives a restart. Sonora used to keep the cookies it copied from
   your browser the day you signed in, and YouTube rotates those every few hours, so your library
   quietly went missing. When you signed in through a browser, Sonora now re-reads its cookies each

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "ytmusic"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/ytmusic-rs?rev=89d62e25da6fad53eec796e1606e874e48b7a72c#89d62e25da6fad53eec796e1606e874e48b7a72c"
+source = "git+https://github.com/nolight132/ytmusic-rs?rev=3c8174afc1a6bbe1ea71a52a61ed3a92464b425f#3c8174afc1a6bbe1ea71a52a61ed3a92464b425f"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,11 +2879,6 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "hashlink"
@@ -5867,15 +5862,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "relative-path"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca40a312222d8ba74837cb474edef44b37f561da5f773981007a10bbaa992b0"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5995,35 +5981,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "rquickjs"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e04e4eedfb060b503b5f0a2644abb890b0b3620d3fb674f9455f230014964e4"
-dependencies = [
- "rquickjs-core",
-]
-
-[[package]]
-name = "rquickjs-core"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e4f499ac5b943d97ee6dbc44f23c2c10426f420f7d2f1793d6318911b6608c"
-dependencies = [
- "hashbrown 0.17.1",
- "relative-path",
- "rquickjs-sys",
-]
-
-[[package]]
-name = "rquickjs-sys"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13ac243b86a74120814ef7e9e30ad5a2c1199b7b9963b1cf7c84e4cdc1cad99"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -9321,7 +9278,7 @@ dependencies = [
 [[package]]
 name = "ytmusic"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/ytmusic-rs?rev=f771acf85e737b46922e32e7d4f5bc1164216ea5#f771acf85e737b46922e32e7d4f5bc1164216ea5"
+source = "git+https://github.com/nolight132/ytmusic-rs?rev=4007cfe537b3c1d9a80550a8779ebe89fd401b2a#4007cfe537b3c1d9a80550a8779ebe89fd401b2a"
 dependencies = [
  "aes",
  "anyhow",
@@ -9333,7 +9290,6 @@ dependencies = [
  "rand 0.9.5",
  "regex-lite",
  "reqwest",
- "rquickjs",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,6 +2879,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -5862,6 +5867,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "relative-path"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca40a312222d8ba74837cb474edef44b37f561da5f773981007a10bbaa992b0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5981,6 +5995,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "rquickjs"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e04e4eedfb060b503b5f0a2644abb890b0b3620d3fb674f9455f230014964e4"
+dependencies = [
+ "rquickjs-core",
+]
+
+[[package]]
+name = "rquickjs-core"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e4f499ac5b943d97ee6dbc44f23c2c10426f420f7d2f1793d6318911b6608c"
+dependencies = [
+ "hashbrown 0.17.1",
+ "relative-path",
+ "rquickjs-sys",
+]
+
+[[package]]
+name = "rquickjs-sys"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13ac243b86a74120814ef7e9e30ad5a2c1199b7b9963b1cf7c84e4cdc1cad99"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -9278,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "ytmusic"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/ytmusic-rs?rev=4007cfe537b3c1d9a80550a8779ebe89fd401b2a#4007cfe537b3c1d9a80550a8779ebe89fd401b2a"
+source = "git+https://github.com/nolight132/ytmusic-rs?rev=89d62e25da6fad53eec796e1606e874e48b7a72c#89d62e25da6fad53eec796e1606e874e48b7a72c"
 dependencies = [
  "aes",
  "anyhow",
@@ -9290,6 +9333,7 @@ dependencies = [
  "rand 0.9.5",
  "regex-lite",
  "reqwest",
+ "rquickjs",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ serde_json = "1.0"
 souvlaki = "0.8"
 sys-locale = "0.3"
 unic-langid = { version = "0.9", features = ["macros"] }
-ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "4007cfe537b3c1d9a80550a8779ebe89fd401b2a" }
+ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "89d62e25da6fad53eec796e1606e874e48b7a72c" }
 
 librespot-core = { version = "0.8.0", default-features = false, features = [
   "rustls-tls-native-roots",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ serde_json = "1.0"
 souvlaki = "0.8"
 sys-locale = "0.3"
 unic-langid = { version = "0.9", features = ["macros"] }
-ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "f771acf85e737b46922e32e7d4f5bc1164216ea5" }
+ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "4007cfe537b3c1d9a80550a8779ebe89fd401b2a" }
 
 librespot-core = { version = "0.8.0", default-features = false, features = [
   "rustls-tls-native-roots",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ serde_json = "1.0"
 souvlaki = "0.8"
 sys-locale = "0.3"
 unic-langid = { version = "0.9", features = ["macros"] }
-ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "89d62e25da6fad53eec796e1606e874e48b7a72c" }
+ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "3c8174afc1a6bbe1ea71a52a61ed3a92464b425f" }
 
 librespot-core = { version = "0.8.0", default-features = false, features = [
   "rustls-tls-native-roots",

--- a/assets/i18n/de/main.ftl
+++ b/assets/i18n/de/main.ftl
@@ -410,6 +410,7 @@ toast-queued-playlist = Playlist zur Warteschlange hinzugefügt
 toast-next-playlist = Playlist läuft als Nächstes
 toast-queue-failed = Das konnte nicht zur Warteschlange hinzugefügt werden
 toast-keys-refused = Spotify gibt diesem Konto keine Wiedergabeschlüssel
+toast-sign-in-to-play = { $name } streamt nur für angemeldete Hörer
 toast-track-unplayable = { $name } konnte nicht abgespielt werden
 
 # lyrics

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -420,6 +420,7 @@ toast-queued-playlist = Playlist added to the queue
 toast-next-playlist = Playlist plays next
 toast-queue-failed = That could not be added to the queue
 toast-keys-refused = Spotify is not granting this account playback keys
+toast-sign-in-to-play = { $name } only streams to a signed-in listener
 toast-track-unplayable = { $name } could not be played
 
 # lyrics

--- a/assets/i18n/fr/main.ftl
+++ b/assets/i18n/fr/main.ftl
@@ -410,6 +410,7 @@ toast-queued-playlist = Playlist ajoutée à la file d'attente
 toast-next-playlist = La playlist sera lue juste après
 toast-queue-failed = Impossible d'ajouter cela à la file d'attente
 toast-keys-refused = Spotify n'accorde pas de clés de lecture à ce compte
+toast-sign-in-to-play = { $name } ne diffuse qu'aux auditeurs connectés
 toast-track-unplayable = { $name } n'a pas pu être lu
 
 # lyrics

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -423,6 +423,7 @@ toast-queued-playlist = Playlistę dodano do kolejki
 toast-next-playlist = Playlista zabrzmi następna
 toast-queue-failed = Nie udało się dodać do kolejki
 toast-keys-refused = Spotify nie udziela temu kontu kluczy odtwarzania
+toast-sign-in-to-play = { $name } udostępnia muzykę tylko po zalogowaniu
 toast-track-unplayable = Nie udało się odtworzyć { $name }
 
 # lyrics

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -423,6 +423,7 @@ toast-queued-playlist = Плейлист добавлен в очередь
 toast-next-playlist = Плейлист прозвучит следующим
 toast-queue-failed = Не удалось добавить в очередь
 toast-keys-refused = Spotify не выдаёт этому аккаунту ключи воспроизведения
+toast-sign-in-to-play = { $name } отдаёт музыку только тем, кто вошёл в аккаунт
 toast-track-unplayable = Не удалось воспроизвести { $name }
 
 # lyrics

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -423,6 +423,7 @@ toast-queued-playlist = Плейлист додано до черги
 toast-next-playlist = Плейлист прозвучить наступним
 toast-queue-failed = Не вдалося додати до черги
 toast-keys-refused = Spotify не надає цьому обліковому запису ключі відтворення
+toast-sign-in-to-play = { $name } віддає музику лише тим, хто увійшов в акаунт
 toast-track-unplayable = Не вдалося відтворити { $name }
 
 # lyrics

--- a/crates/music/src/lib.rs
+++ b/crates/music/src/lib.rs
@@ -54,6 +54,10 @@ pub enum MediaKind {
 
 #[async_trait]
 pub trait MusicApi: Send + Sync {
+    fn alive(&self) -> bool {
+        true
+    }
+
     fn share_url(&self, kind: MediaKind, id: &str) -> Option<String>;
     async fn profile(&self) -> Result<UserProfile>;
     async fn artist(&self, artist_id: &str) -> Result<Artist>;

--- a/crates/music/src/lib.rs
+++ b/crates/music/src/lib.rs
@@ -137,6 +137,7 @@ pub enum PlaybackEvent {
     Ended,
     Unavailable,
     Refused,
+    Gated,
 }
 
 pub trait Player: Send + Sync {

--- a/crates/music/src/spotify/client.rs
+++ b/crates/music/src/spotify/client.rs
@@ -33,6 +33,10 @@ impl LibrespotClient {
 
 #[async_trait]
 impl MusicApi for LibrespotClient {
+    fn alive(&self) -> bool {
+        !self.session.is_invalid()
+    }
+
     fn share_url(&self, kind: MediaKind, id: &str) -> Option<String> {
         let kind = match kind {
             MediaKind::Track => "track",

--- a/crates/music/src/youtube/mod.rs
+++ b/crates/music/src/youtube/mod.rs
@@ -25,9 +25,9 @@ const GUEST_ID: &str = "youtube-guest";
 pub struct YouTubeProvider {
     cookies: PathBuf,
     authuser: PathBuf,
+    source: PathBuf,
     guest: PathBuf,
     resolved: PathBuf,
-    player: PathBuf,
 }
 
 impl YouTubeProvider {
@@ -39,9 +39,9 @@ impl YouTubeProvider {
         Self {
             cookies: cache.join("cookies.txt"),
             authuser: cache.join("authuser.txt"),
+            source: cache.join("browser.txt"),
             guest: cache.join("guest"),
             resolved: cache.join("resolved.json"),
-            player: cache.join("player.json"),
         }
     }
 
@@ -49,13 +49,12 @@ impl YouTubeProvider {
         Arc::new(
             YtMusic::with_cookies(cookies)
                 .as_user(authuser)
-                .cache_resolutions(self.resolved.clone())
-                .cache_player(self.player.clone()),
+                .cache_resolutions(self.resolved.clone()),
         )
     }
 
     fn guest_client(&self) -> Arc<YtMusic> {
-        Arc::new(YtMusic::anonymous().cache_player(self.player.clone()))
+        Arc::new(YtMusic::anonymous())
     }
 
     fn authenticated_session(&self, api: Arc<YtMusic>, profile: UserProfile) -> ProviderSession {
@@ -85,6 +84,7 @@ impl YouTubeProvider {
     async fn connect(
         &self,
         cookies: &str,
+        source: Option<&str>,
         prompt: &PromptSink,
         input: &mut InputSource,
     ) -> Result<ProviderSession> {
@@ -99,7 +99,7 @@ impl YouTubeProvider {
 
         let profile = wire::profile(account.profile.clone());
         let api = self.cookie_client(&cookies, account.index);
-        self.store_cookies(&cookies, account.index)?;
+        self.store_cookies(&cookies, account.index, source)?;
         log::debug!(
             "youtube: cookie sign-in succeeded for authuser {}",
             account.index
@@ -107,15 +107,75 @@ impl YouTubeProvider {
         Ok(self.authenticated_session(api, profile))
     }
 
-    fn store_cookies(&self, cookies: &str, authuser: usize) -> Result<()> {
+    fn store_cookies(&self, cookies: &str, authuser: usize, source: Option<&str>) -> Result<()> {
         if let Some(parent) = self.cookies.parent() {
             std::fs::create_dir_all(parent).context("cannot create youtube cache dir")?;
         }
         std::fs::write(&self.cookies, cookies).context("cannot store youtube cookies")?;
         std::fs::write(&self.authuser, authuser.to_string())
             .context("cannot store the youtube account")?;
+        match source {
+            Some(name) => std::fs::write(&self.source, name).context("cannot store the browser")?,
+            None => {
+                let _ = std::fs::remove_file(&self.source);
+            }
+        }
         let _ = std::fs::remove_file(&self.guest);
         Ok(())
+    }
+
+    async fn restore_cookies(&self) -> Option<ProviderSession> {
+        let remembered = self.remembered_browser();
+        let live = remembered
+            .as_deref()
+            .and_then(|name| self.live_cookies(name));
+        let cached = std::fs::read_to_string(&self.cookies)
+            .ok()
+            .map(|cookies| cookies.trim().to_string());
+        let authuser = self.stored_authuser();
+        for (fresh, cookies) in [(true, live), (false, cached)] {
+            let Some(cookies) = cookies.filter(|cookies| !cookies.is_empty()) else {
+                continue;
+            };
+            let api = self.cookie_client(&cookies, authuser);
+            match api.profile().await {
+                Ok(profile) => {
+                    if fresh {
+                        let _ = self.store_cookies(&cookies, authuser, remembered.as_deref());
+                    }
+                    log::debug!("youtube: restored the session for authuser {authuser}");
+                    return Some(self.authenticated_session(api, wire::profile(profile)));
+                }
+                Err(error) => log::warn!(
+                    "youtube: {} cookies are no longer usable: {error:#}",
+                    match fresh {
+                        true => "the browser",
+                        false => "the cached",
+                    }
+                ),
+            }
+        }
+        None
+    }
+
+    fn remembered_browser(&self) -> Option<String> {
+        let name = std::fs::read_to_string(&self.source).ok()?;
+        let name = name.trim().to_string();
+        (!name.is_empty()).then_some(name)
+    }
+
+    fn live_cookies(&self, name: &str) -> Option<String> {
+        let browser = self
+            .browsers()
+            .into_iter()
+            .find(|browser| browser.name == name)?;
+        match auth::cookies(&browser).and_then(|cookies| auth::header(&cookies)) {
+            Ok(cookies) => Some(cookies),
+            Err(error) => {
+                log::warn!("youtube: cannot read cookies from {name}: {error:#}");
+                None
+            }
+        }
     }
 
     fn stored_authuser(&self) -> usize {
@@ -230,20 +290,8 @@ impl MusicProvider for YouTubeProvider {
     }
 
     async fn restore(&self) -> Result<Option<ProviderSession>> {
-        if let Ok(cookies) = std::fs::read_to_string(&self.cookies) {
-            log::debug!("youtube: restoring authenticated session from cached cookies");
-            let api = self.cookie_client(cookies.trim(), self.stored_authuser());
-            let profile = api.profile().await;
-            match profile {
-                Ok(profile) => {
-                    return Ok(Some(
-                        self.authenticated_session(api, wire::profile(profile)),
-                    ));
-                }
-                Err(error) => {
-                    log::warn!("youtube: cached cookies are no longer usable: {error:#}");
-                }
-            }
+        if let Some(session) = self.restore_cookies().await {
+            return Ok(Some(session));
         }
         if self.guest.exists() {
             log::debug!("youtube: restoring guest session");
@@ -270,12 +318,13 @@ impl MusicProvider for YouTubeProvider {
                     .find(|browser| browser.name == name)
                     .with_context(|| format!("{name} is no longer available"))?;
                 let cookies = auth::cookies(&browser)?;
-                self.connect(&cookies, &prompt, &mut input).await
+                self.connect(&cookies, Some(browser.name), &prompt, &mut input)
+                    .await
             }
             SignIn::Secret => {
                 prompt(SignInPrompt::Secret);
                 let cookies = input.recv().await.context("sign-in was cancelled")?;
-                self.connect(&cookies, &prompt, &mut input).await
+                self.connect(&cookies, None, &prompt, &mut input).await
             }
             SignIn::Path(_) => Err(anyhow::anyhow!(
                 "youtube does not sign in with a folder path"
@@ -284,7 +333,7 @@ impl MusicProvider for YouTubeProvider {
     }
 
     fn sign_out(&self) {
-        for path in [&self.cookies, &self.authuser, &self.guest] {
+        for path in [&self.cookies, &self.authuser, &self.source, &self.guest] {
             if let Err(error) = std::fs::remove_file(path)
                 && error.kind() != std::io::ErrorKind::NotFound
             {

--- a/crates/music/src/youtube/mod.rs
+++ b/crates/music/src/youtube/mod.rs
@@ -28,6 +28,7 @@ pub struct YouTubeProvider {
     source: PathBuf,
     guest: PathBuf,
     resolved: PathBuf,
+    player: PathBuf,
 }
 
 impl YouTubeProvider {
@@ -42,6 +43,7 @@ impl YouTubeProvider {
             source: cache.join("browser.txt"),
             guest: cache.join("guest"),
             resolved: cache.join("resolved.json"),
+            player: cache.join("player.json"),
         }
     }
 
@@ -49,12 +51,13 @@ impl YouTubeProvider {
         Arc::new(
             YtMusic::with_cookies(cookies)
                 .as_user(authuser)
-                .cache_resolutions(self.resolved.clone()),
+                .cache_resolutions(self.resolved.clone())
+                .cache_player(self.player.clone()),
         )
     }
 
     fn guest_client(&self) -> Arc<YtMusic> {
-        Arc::new(YtMusic::anonymous())
+        Arc::new(YtMusic::anonymous().cache_player(self.player.clone()))
     }
 
     fn authenticated_session(&self, api: Arc<YtMusic>, profile: UserProfile) -> ProviderSession {

--- a/crates/music/src/youtube/playback.rs
+++ b/crates/music/src/youtube/playback.rs
@@ -318,7 +318,7 @@ async fn engine_loop(
                             }
                             Err(error) => {
                                 log::warn!("playback: cannot load {id}: {error:#}");
-                                events.send(PlaybackEvent::Unavailable).ok();
+                                events.send(refusal(&error)).ok();
                             }
                         }
                     }
@@ -469,6 +469,13 @@ fn announce(
         false => PlaybackEvent::Paused(position),
     };
     events.send(event).ok();
+}
+
+fn refusal(error: &anyhow::Error) -> PlaybackEvent {
+    match error.downcast_ref::<ytmusic::SignInRequired>().is_some() {
+        true => PlaybackEvent::Gated,
+        false => PlaybackEvent::Unavailable,
+    }
 }
 
 async fn fetch(api: &YtMusic, id: &str) -> Result<Loaded> {

--- a/crates/state/src/artist.rs
+++ b/crates/state/src/artist.rs
@@ -32,6 +32,7 @@ impl ArtistDetail {
                     cx.notify();
                 }
             }
+            SessionEvent::Reconnected => {}
             SessionEvent::LocalChanged => {
                 if let Some(id) = this.id.clone().filter(|id| music::is_local_id(id)) {
                     this.clear();

--- a/crates/state/src/cover.rs
+++ b/crates/state/src/cover.rs
@@ -25,7 +25,7 @@ impl Cover {
             .detach();
         cx.subscribe(&session, |this, _, event, cx| match event {
             SessionEvent::SignedOut => this.forget(cx),
-            SessionEvent::SignedIn | SessionEvent::LocalChanged => {}
+            SessionEvent::SignedIn | SessionEvent::Reconnected | SessionEvent::LocalChanged => {}
         })
         .detach();
 

--- a/crates/state/src/detail.rs
+++ b/crates/state/src/detail.rs
@@ -71,6 +71,7 @@ impl Detail {
                     }
                 }
             }
+            SessionEvent::Reconnected => {}
             SessionEvent::LocalChanged => {
                 if let (Some(kind), Some(id)) = (
                     this.kind,

--- a/crates/state/src/genre.rs
+++ b/crates/state/src/genre.rs
@@ -27,7 +27,7 @@ impl Genres {
                 this.error = None;
                 cx.notify();
             }
-            SessionEvent::LocalChanged => {}
+            SessionEvent::Reconnected | SessionEvent::LocalChanged => {}
         })
         .detach();
 
@@ -136,7 +136,7 @@ impl GenreDetails {
                 this.clear();
                 cx.notify();
             }
-            SessionEvent::LocalChanged => {}
+            SessionEvent::Reconnected | SessionEvent::LocalChanged => {}
         })
         .detach();
 

--- a/crates/state/src/home.rs
+++ b/crates/state/src/home.rs
@@ -40,7 +40,7 @@ impl Home {
                 this.feeding = false;
                 cx.notify();
             }
-            SessionEvent::LocalChanged => {}
+            SessionEvent::Reconnected | SessionEvent::LocalChanged => {}
         })
         .detach();
 

--- a/crates/state/src/library.rs
+++ b/crates/state/src/library.rs
@@ -129,6 +129,13 @@ impl Library {
                 this.state = LibraryState::Empty;
                 cx.notify();
             }
+            SessionEvent::Reconnected => {
+                if matches!(this.state, LibraryState::Failed(_))
+                    && let Some(client) = session.read(cx).client()
+                {
+                    this.load(client, cx);
+                }
+            }
             SessionEvent::LocalChanged => {
                 let client = session.read(cx).local_client();
                 match client {

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -13,6 +13,12 @@ use music::{
 type Fetch = Pin<Box<dyn Future<Output = Result<Vec<Track>>> + Send>>;
 
 #[derive(Clone, Copy, PartialEq)]
+enum Refusal {
+    Keys,
+    SignIn,
+}
+
+#[derive(Clone, Copy, PartialEq)]
 enum Start {
     Pick,
     Skip,
@@ -119,7 +125,7 @@ pub struct Playback {
     preloaded: Option<String>,
     skipped: Option<Instant>,
     blocked_until: Option<Instant>,
-    refused: bool,
+    refused: Option<Refusal>,
     armed: Option<Duration>,
     settle: Option<Duration>,
     held: bool,
@@ -193,7 +199,7 @@ impl Playback {
             preloaded: None,
             skipped: None,
             blocked_until: None,
-            refused: false,
+            refused: None,
             armed: None,
             settle: None,
             held: false,
@@ -253,8 +259,10 @@ impl Playback {
     }
 
     fn load_after(&mut self, track: &Track, start: Start, cx: &mut Context<Self>) {
-        if self.refused {
-            return self.refuse(cx);
+        match self.refused {
+            Some(Refusal::Keys) => return self.refuse(cx),
+            Some(Refusal::SignIn) => return self.gate(cx),
+            None => {}
         }
         let Some(id) = track.id.clone() else {
             return self.failed(format!("{} has no track id", track.name), cx);
@@ -1054,6 +1062,7 @@ impl Playback {
 
         self.listen(events, false, cx);
         self.engine = Some(engine);
+        self.refused = None;
         let local_active = self
             .track
             .as_ref()
@@ -1174,6 +1183,10 @@ impl Playback {
                 self.refuse(cx);
                 cx.emit(PlaybackEvent::EndedPlayback);
             }
+            BackendEvent::Gated => {
+                self.gate(cx);
+                cx.emit(PlaybackEvent::EndedPlayback);
+            }
         }
         cx.notify();
     }
@@ -1196,7 +1209,7 @@ impl Playback {
             self.preloaded = None;
             self.skipped = None;
             self.blocked_until = None;
-            self.refused = false;
+            self.refused = None;
             self.track = None;
             self.origin = None;
             self.state = PlaybackState::Idle;
@@ -1216,9 +1229,37 @@ impl Playback {
         cx.notify();
     }
 
+    fn gate(&mut self, cx: &mut Context<Self>) {
+        let first = self.refused.is_none();
+        self.refused = Some(Refusal::SignIn);
+        self.track = None;
+        self.blocked_until = None;
+        let provider = self
+            .session
+            .read(cx)
+            .provider_name()
+            .unwrap_or("this provider");
+        self.state = PlaybackState::Failed(format!(
+            "{provider} only streams to a signed-in listener; nothing will play until you sign in"
+        ));
+        if first {
+            log::warn!(
+                "playback: {provider} only streams to a signed-in listener, nothing will play \
+                 until you sign in"
+            );
+        }
+        Toasts::about(
+            Note::Failed,
+            "toast-sign-in-to-play",
+            provider.to_owned(),
+            cx,
+        );
+        cx.notify();
+    }
+
     fn refuse(&mut self, cx: &mut Context<Self>) {
-        let first = !self.refused;
-        self.refused = true;
+        let first = self.refused.is_none();
+        self.refused = Some(Refusal::Keys);
         self.track = None;
         self.blocked_until = None;
         self.state = PlaybackState::Failed(

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -123,6 +123,7 @@ pub struct Playback {
     armed: Option<Duration>,
     settle: Option<Duration>,
     held: bool,
+    mending: bool,
     stored: Duration,
 }
 
@@ -142,6 +143,12 @@ impl Playback {
                 };
                 this.start_engine(playback, cx);
                 this.adopt(cx);
+            }
+            SessionEvent::Reconnected => {
+                let Some(playback) = session.read(cx).playback() else {
+                    return;
+                };
+                this.rebind(playback, cx);
             }
             SessionEvent::SignedOut => this.teardown(cx),
             SessionEvent::LocalChanged => {
@@ -190,6 +197,7 @@ impl Playback {
             armed: None,
             settle: None,
             held: false,
+            mending: false,
             stored: Duration::ZERO,
         }
     }
@@ -1010,6 +1018,31 @@ impl Playback {
         cx.notify();
     }
 
+    fn mend(&mut self, cx: &mut Context<Self>) -> bool {
+        if self.track.is_none() {
+            return false;
+        }
+        self.mending = self.session.update(cx, |session, cx| session.heal(cx));
+        self.mending
+    }
+
+    fn rebind(&mut self, playback: Arc<dyn PlaybackFactory>, cx: &mut Context<Self>) {
+        let resume = self.state == PlaybackState::Playing || self.mending;
+        self.mending = false;
+        let at = self.position;
+        self.task = None;
+        self.engine = None;
+        self.preloaded = None;
+        self.blocked_until = None;
+        if self.track.is_some() {
+            self.armed = Some(at);
+        }
+        self.start_engine(playback, cx);
+        if resume {
+            self.resume(cx);
+        }
+    }
+
     fn start_engine(&mut self, playback: Arc<dyn PlaybackFactory>, cx: &mut Context<Self>) {
         let config = PlaybackConfig {
             normalisation: self.normalisation,
@@ -1120,6 +1153,10 @@ impl Playback {
                 cx.emit(PlaybackEvent::EndedPlayback);
                 self.advance(ended, cx);
             }
+            BackendEvent::Unavailable if self.mend(cx) => {
+                self.state = PlaybackState::Loading;
+                log::warn!("playback: the provider went stale, waiting for a reconnect");
+            }
             BackendEvent::Unavailable => {
                 let failed = self.track.take();
                 let name = failed.map_or_else(|| "?".to_owned(), |track| track.name);
@@ -1167,6 +1204,7 @@ impl Playback {
             self.armed = None;
             self.settle = None;
             self.held = false;
+            self.mending = false;
             self.stored = Duration::ZERO;
         }
         cx.notify();

--- a/crates/state/src/queue.rs
+++ b/crates/state/src/queue.rs
@@ -256,7 +256,7 @@ impl Queue {
     ) -> Self {
         cx.subscribe(&session, |this, _, event, cx| match event {
             SessionEvent::SignedOut => this.purge(cx),
-            SessionEvent::SignedIn | SessionEvent::LocalChanged => {}
+            SessionEvent::SignedIn | SessionEvent::Reconnected | SessionEvent::LocalChanged => {}
         })
         .detach();
 

--- a/crates/state/src/search.rs
+++ b/crates/state/src/search.rs
@@ -152,7 +152,7 @@ impl Search {
                 this.query.clear();
                 this.ask(&pending, cx);
             }
-            SessionEvent::LocalChanged => {}
+            SessionEvent::Reconnected | SessionEvent::LocalChanged => {}
         })
         .detach();
 

--- a/crates/state/src/session.rs
+++ b/crates/state/src/session.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Error;
 use gpui::{Context, Entity, EventEmitter, Task};
@@ -12,6 +13,15 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::catalog::CatalogSource;
 use crate::settings::AppSettings;
 use crate::{Io, join};
+
+const HEARTBEAT: Duration = Duration::from_secs(30);
+const BACKOFF: [Duration; 5] = [
+    Duration::ZERO,
+    Duration::from_secs(5),
+    Duration::from_secs(15),
+    Duration::from_secs(60),
+    Duration::from_secs(300),
+];
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Failure {
@@ -50,6 +60,7 @@ pub enum SessionState {
 pub enum SessionEvent {
     SignedIn,
     SignedOut,
+    Reconnected,
     LocalChanged,
 }
 
@@ -85,6 +96,10 @@ pub struct Session {
     local_catalog: Option<Arc<CatalogSource>>,
     local_playback: Option<Arc<dyn PlaybackFactory>>,
     local_task: Option<Task<()>>,
+    watch: Option<Task<()>>,
+    mend: Option<Task<()>>,
+    mending: bool,
+    attempt: usize,
 }
 
 impl EventEmitter<SessionEvent> for Session {}
@@ -123,6 +138,10 @@ impl Session {
             local_catalog: None,
             local_playback: None,
             local_task: None,
+            watch: None,
+            mend: None,
+            mending: false,
+            attempt: 0,
         };
         session.restore_local(cx);
         session
@@ -407,6 +426,10 @@ impl Session {
 
     fn release(&mut self, cx: &mut Context<Self>) {
         self.task = None;
+        self.watch = None;
+        self.mend = None;
+        self.mending = false;
+        self.attempt = 0;
         self.prompt_task = None;
         self.input = None;
         self.awaiting = None;
@@ -436,8 +459,76 @@ impl Session {
         self.authenticated = session.authenticated;
         self.playcounts = session.playcounts;
         self.state = SessionState::SignedIn(session.profile);
+        self.attempt = 0;
+        self.guard(cx);
         cx.notify();
         cx.emit(SessionEvent::SignedIn);
+    }
+
+    fn guard(&mut self, cx: &mut Context<Self>) {
+        self.watch = Some(cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor().timer(HEARTBEAT).await;
+                if this.update(cx, |this, cx| this.heal(cx)).is_err() {
+                    return;
+                }
+            }
+        }));
+    }
+
+    pub fn heal(&mut self, cx: &mut Context<Self>) -> bool {
+        if self.mending {
+            return true;
+        }
+        if !matches!(self.state, SessionState::SignedIn(_)) {
+            return false;
+        }
+        let Some(client) = &self.client else {
+            return false;
+        };
+        if client.alive() {
+            self.attempt = 0;
+            return false;
+        }
+        let Some(active) = self.active else {
+            return false;
+        };
+        let wait = BACKOFF[self.attempt.min(BACKOFF.len() - 1)];
+        self.attempt += 1;
+        self.mending = true;
+        log::warn!(
+            "session: the {} session went stale, reconnecting in {}s",
+            self.providers[active].name(),
+            wait.as_secs()
+        );
+        let provider = self.providers[active].clone();
+        let io = self.io.clone();
+        self.mend = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor().timer(wait).await;
+            let restored = join(io.spawn(async move { provider.restore().await })).await;
+            this.update(cx, |this, cx| {
+                this.mending = false;
+                match restored {
+                    Ok(Some(session)) => this.reconnected(session, cx),
+                    Ok(None) => log::warn!("session: nothing stored to reconnect with"),
+                    Err(error) => log::warn!("session: cannot reconnect: {error:#}"),
+                }
+            })
+            .ok();
+        }));
+        true
+    }
+
+    fn reconnected(&mut self, session: ProviderSession, cx: &mut Context<Self>) {
+        self.attempt = 0;
+        self.catalog = Some(Arc::new(CatalogSource::new(session.api.clone())));
+        self.client = Some(session.api);
+        self.playback = Some(session.playback);
+        self.authenticated = session.authenticated;
+        self.playcounts = session.playcounts;
+        log::debug!("session: reconnected");
+        cx.notify();
+        cx.emit(SessionEvent::Reconnected);
     }
 
     fn failed(&mut self, error: &Error, cx: &mut Context<Self>) {

--- a/crates/state/src/session.rs
+++ b/crates/state/src/session.rs
@@ -445,9 +445,15 @@ impl Session {
     }
 
     fn signed_in(&mut self, session: ProviderSession, index: usize, cx: &mut Context<Self>) {
+        let replaced = self
+            .resume
+            .take()
+            .is_some_and(|(held, profile)| held != index || profile.id != session.profile.id);
+        if replaced {
+            self.shed(cx);
+        }
         self.active = Some(index);
         self.awaiting = None;
-        self.resume = None;
         self.error = None;
         let slug = self.providers[index].slug();
         self.settings.update(cx, |settings, cx| {
@@ -463,6 +469,19 @@ impl Session {
         self.guard(cx);
         cx.notify();
         cx.emit(SessionEvent::SignedIn);
+    }
+
+    fn shed(&mut self, cx: &mut Context<Self>) {
+        self.client = None;
+        self.catalog = None;
+        self.playback = None;
+        self.authenticated = false;
+        self.playcounts = false;
+        self.watch = None;
+        self.mend = None;
+        self.mending = false;
+        self.attempt = 0;
+        cx.emit(SessionEvent::SignedOut);
     }
 
     fn guard(&mut self, cx: &mut Context<Self>) {

--- a/crates/state/src/song.rs
+++ b/crates/state/src/song.rs
@@ -32,6 +32,7 @@ impl SongDetail {
                 this.clear();
                 cx.notify();
             }
+            SessionEvent::Reconnected => {}
             SessionEvent::LocalChanged => {
                 if let Some(id) = this.id.clone().filter(|id| music::is_local_id(id)) {
                     this.clear();


### PR DESCRIPTION
## Summary

- stream youtube audio through the visionos client with a server-issued visitor id, so tracks stop being refused
- drop the ciphered player fallback, its quickjs deobfuscator and the player script cache
- read youtube cookies from the remembered browser on every restore instead of keeping the sign-in snapshot
- report whether a provider session is still alive and reconnect it quietly when it goes stale
- rebuild the playback engine on a reconnect, keeping the current track and resuming it where it stopped
- retry a failed load through a reconnect instead of reporting the track as unplayable