### PR TITLE
fix(views): keep sidebar sections expanded across navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -494,10 +494,14 @@ library tab); it maps to a `Destination` through `Screen::destination` and is st
 `settings.json` as `startup`. `sonora/src/main.rs` resolves it at boot, and a link on the command
 line still wins over it.
 
-**Sidebar sections are derived, not remembered.** `SidebarLeft` expands Your Library or Settings from
-the current route (`expanded(&Destination)` in `sidebar_left.rs`), so every way of leaving — sidebar,
-a card, back/forward, an external `spotify:` link — collapses the group. A manual chevron toggle only
-survives until the next route change. Don't reintroduce per-event bookkeeping for this.
+**Sidebar sections only ever expand on their own.** `SidebarLeft` opens Your Library or Settings
+whenever the route enters one (`expanded(&Destination)` in `sidebar_left.rs`), but nothing collapses
+a group except the chevron — leaving through a card, back/forward or an external `spotify:` link
+keeps it open. Don't reintroduce route-driven collapsing.
+
+**The Your Library and Settings rows navigate nowhere.** They are expanders: a click toggles the
+group and nothing else, so a route change only ever comes from a tab underneath. That is also why an
+overlaid `SidebarLeft` survives opening a group — it dismisses on navigation, and there is none.
 
 **`LibraryTab::Local` is labelled "Imported".** The enum variant, the `local-songs`/`local-albums`
 settings keys and the `nav-local` i18n key all keep the old name so stored layouts survive; only the

--- a/crates/views/src/chrome/sidebar_left.rs
+++ b/crates/views/src/chrome/sidebar_left.rs
@@ -116,7 +116,9 @@ impl SidebarLeft {
             return;
         }
         self.at = current.clone();
-        (self.library_open, self.settings_open) = expanded(current);
+        let (library, settings) = expanded(current);
+        self.library_open |= library;
+        self.settings_open |= settings;
     }
 
     fn dismiss_menu(&mut self, cx: &mut Context<Self>) {
@@ -324,25 +326,14 @@ impl Render for SidebarLeft {
                 }
                 let inside = matches!(current, Destination::Library(_));
                 let text = if inside { foreground } else { muted };
-                let default_tab = if authenticated {
-                    LibraryTab::Songs
-                } else {
-                    LibraryTab::Local
-                };
-                let destination = destination.map(|_| Destination::Library(default_tab));
-                let link_destination = if inside { None } else { destination };
-                let target = link_destination.unwrap_or(current.clone());
 
                 rows.push(
                     nav_row(index, key, text, sidebar_accent)
                         .icon(icon)
                         .trailing(chevron(self.library_open))
-                        .on_click(cx.listener(move |this, _, _, cx| match inside {
-                            true => {
-                                this.library_open = !this.library_open;
-                                cx.notify();
-                            }
-                            false => navigate(target.clone(), cx),
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            this.library_open = !this.library_open;
+                            cx.notify();
                         }))
                         .into_any_element(),
                 );
@@ -370,19 +361,14 @@ impl Render for SidebarLeft {
             if matches!(destination, Some(Destination::Settings(_))) {
                 let inside = matches!(current, Destination::Settings(_));
                 let text = if inside { foreground } else { muted };
-                let link_destination = if inside { None } else { destination };
-                let target = link_destination.unwrap_or(current.clone());
 
                 rows.push(
                     nav_row(index, key, text, sidebar_accent)
                         .icon(icon)
                         .trailing(chevron(self.settings_open))
-                        .on_click(cx.listener(move |this, _, _, cx| match inside {
-                            true => {
-                                this.settings_open = !this.settings_open;
-                                cx.notify();
-                            }
-                            false => navigate(target.clone(), cx),
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            this.settings_open = !this.settings_open;
+                            cx.notify();
                         }))
                         .into_any_element(),
                 );
@@ -573,7 +559,7 @@ mod tests {
     }
 
     #[test]
-    fn leaving_through_content_collapses_both() {
+    fn content_belongs_to_neither_section() {
         let away = [
             Destination::Home,
             Destination::Search,


### PR DESCRIPTION
## Summary

- Preserve expanded Library and Settings sections when navigating.
- Make section headers toggle-only controls instead of navigation links.
- Update sidebar behavior documentation and tests.

## Testing

- Not run (documentation and sidebar behavior change only).