### PR TITLE
feat(views): fullscreen volume slider

### DIFF
--- a/crates/ui/src/scrubber.rs
+++ b/crates/ui/src/scrubber.rs
@@ -67,6 +67,16 @@ impl ScrubberState {
         }
         ((x - bounds.origin.x - pin / 2.) / travel).clamp(0., 1.)
     }
+
+    fn climb_at(&self, y: Pixels, pad: Pixels) -> f32 {
+        let bounds = self.bounds.get();
+        let pin = thumb(pad);
+        let travel = bounds.size.height - pin;
+        if travel <= px(0.) {
+            return 0.;
+        }
+        1. - ((y - bounds.origin.y - pin / 2.) / travel).clamp(0., 1.)
+    }
 }
 
 #[derive(IntoElement)]
@@ -78,6 +88,7 @@ pub struct Scrubber {
     empty: Hsla,
     thumb: Hsla,
     enabled: bool,
+    vertical: bool,
     bubble: Option<(f32, SharedString)>,
     lift: Pixels,
     on_move: Option<Slide>,
@@ -94,6 +105,7 @@ impl Scrubber {
             empty: gpui::black(),
             thumb: gpui::white(),
             enabled: true,
+            vertical: false,
             bubble: None,
             lift: px(12.),
             on_move: None,
@@ -120,6 +132,11 @@ impl Scrubber {
 
     pub fn enabled(mut self, enabled: bool) -> Self {
         self.enabled = enabled;
+        self
+    }
+
+    pub fn vertical(mut self) -> Self {
+        self.vertical = true;
         self
     }
 
@@ -157,6 +174,7 @@ impl RenderOnce for Scrubber {
             empty,
             thumb,
             enabled,
+            vertical,
             bubble,
             lift,
             on_move,
@@ -170,12 +188,17 @@ impl RenderOnce for Scrubber {
         let on_move = on_move.map(Rc::new);
         let on_release = on_release.map(Rc::new);
 
+        let at = move |state: &ScrubberState, position: Point<Pixels>| match vertical {
+            true => state.climb_at(position.y, pad),
+            false => state.fraction_at(position.x, pad),
+        };
+
         let down = {
             let state = state.clone();
             let on_move = on_move.clone();
             move |event: &MouseDownEvent, window: &mut Window, cx: &mut App| {
                 if let Some(handler) = on_move.as_ref() {
-                    handler(&state.fraction_at(event.position.x, pad), window, cx);
+                    handler(&at(&state, event.position), window, cx);
                 }
             }
         };
@@ -189,7 +212,7 @@ impl RenderOnce for Scrubber {
                     return;
                 }
                 if let Some(handler) = on_move.as_ref() {
-                    handler(&state.fraction_at(event.event.position.x, pad), window, cx);
+                    handler(&at(&state, event.event.position), window, cx);
                 }
             }
         };
@@ -200,17 +223,155 @@ impl RenderOnce for Scrubber {
             }
         };
 
-        let width = bounds.get().size.width;
-        let travel = (width - pin).max(Pixels::ZERO);
-        let centered = enabled && width > Pixels::ZERO;
+        let extent = match vertical {
+            true => bounds.get().size.height,
+            false => bounds.get().size.width,
+        };
+        let travel = (extent - pin).max(Pixels::ZERO);
+        let centered = enabled && extent > Pixels::ZERO;
+        let measured = extent > Pixels::ZERO;
+
+        let bar = match vertical {
+            true => div()
+                .relative()
+                .h_full()
+                .w(line)
+                .rounded_full()
+                .bg(empty)
+                .child(
+                    div()
+                        .absolute()
+                        .bottom_0()
+                        .left_0()
+                        .w_full()
+                        .rounded_full()
+                        .bg(filled)
+                        .map(|this| match centered {
+                            true => this.h(pin / 2. + travel * fraction),
+                            false => this.h(relative(fraction)),
+                        }),
+                )
+                .when(enabled, |this| {
+                    this.child(
+                        div()
+                            .absolute()
+                            .left((line - pin) / 2.)
+                            .map(|this| match measured {
+                                true => this.bottom(travel * fraction),
+                                false => {
+                                    this.bottom(relative(fraction)).mb(Pixels::ZERO - pin / 2.)
+                                }
+                            })
+                            .size(pin)
+                            .rounded_full()
+                            .bg(thumb),
+                    )
+                })
+                .when_some(bubble, |this, (at, text)| {
+                    this.child(
+                        div()
+                            .absolute()
+                            .map(|this| {
+                                if lift >= Pixels::ZERO {
+                                    this.right(line + lift)
+                                } else {
+                                    this.left(line - lift)
+                                }
+                            })
+                            .map(|this| match centered {
+                                true => this.bottom(travel * at),
+                                false => this.bottom(relative(at)).mb(Pixels::ZERO - pin / 2.),
+                            })
+                            .h(pin)
+                            .flex()
+                            .items_center()
+                            .child(
+                                div()
+                                    .px_1p5()
+                                    .rounded_md()
+                                    .bg(popover)
+                                    .border_1()
+                                    .border_color(popover_border)
+                                    .text_color(popover_text)
+                                    .text_size(text_size)
+                                    .whitespace_nowrap()
+                                    .child(text),
+                            ),
+                    )
+                }),
+            false => div()
+                .relative()
+                .w_full()
+                .h(line)
+                .rounded_full()
+                .bg(empty)
+                .child(
+                    div()
+                        .h_full()
+                        .rounded_full()
+                        .bg(filled)
+                        .map(|this| match centered {
+                            true => this.w(pin / 2. + travel * fraction),
+                            false => this.w(relative(fraction)),
+                        }),
+                )
+                .when(enabled, |this| {
+                    this.child(
+                        div()
+                            .absolute()
+                            .top((line - pin) / 2.)
+                            .map(|this| match measured {
+                                true => this.left(travel * fraction),
+                                false => this.left(relative(fraction)).ml(Pixels::ZERO - pin / 2.),
+                            })
+                            .size(pin)
+                            .rounded_full()
+                            .bg(thumb),
+                    )
+                })
+                .when_some(bubble, |this, (at, text)| {
+                    this.child(
+                        div()
+                            .absolute()
+                            .map(|this| {
+                                if lift >= Pixels::ZERO {
+                                    this.bottom(lift)
+                                } else {
+                                    this.top(Pixels::ZERO - lift)
+                                }
+                            })
+                            .map(|this| match centered {
+                                true => this.left(pin / 2. + travel * at),
+                                false => this.left(relative(at)),
+                            })
+                            .ml(Pixels::ZERO - bubble_width / 2.)
+                            .w(bubble_width)
+                            .flex()
+                            .justify_center()
+                            .child(
+                                div()
+                                    .px_1p5()
+                                    .rounded_md()
+                                    .bg(popover)
+                                    .border_1()
+                                    .border_color(popover_border)
+                                    .text_color(popover_text)
+                                    .text_size(text_size)
+                                    .child(text),
+                            ),
+                    )
+                }),
+        };
 
         div()
             .id(gpui::ElementId::Name(id.clone()))
             .relative()
             .flex()
-            .items_center()
-            .w_full()
-            .h(reach)
+            .when_else(
+                vertical,
+                |this| this.justify_center().h_full().w(reach),
+                |this| this.items_center().w_full().h(reach),
+            )
             .child(
                 canvas(move |b, _, _| bounds.set(b), |_, _, _, _| {})
                     .absolute()
@@ -224,72 +385,7 @@ impl RenderOnce for Scrubber {
                     .on_mouse_up(MouseButton::Left, released.clone())
                     .on_mouse_up_out(MouseButton::Left, released)
             })
-            .child(
-                div()
-                    .relative()
-                    .w_full()
-                    .h(line)
-                    .rounded_full()
-                    .bg(empty)
-                    .child(
-                        div()
-                            .h_full()
-                            .rounded_full()
-                            .bg(filled)
-                            .map(|this| match centered {
-                                true => this.w(pin / 2. + travel * fraction),
-                                false => this.w(relative(fraction)),
-                            }),
-                    )
-                    .when(enabled, |this| {
-                        this.child(
-                            div()
-                                .absolute()
-                                .top((line - pin) / 2.)
-                                .map(|this| match width > Pixels::ZERO {
-                                    true => this.left(travel * fraction),
-                                    false => {
-                                        this.left(relative(fraction)).ml(Pixels::ZERO - pin / 2.)
-                                    }
-                                })
-                                .size(pin)
-                                .rounded_full()
-                                .bg(thumb),
-                        )
-                    })
-                    .when_some(bubble, |this, (at, text)| {
-                        this.child(
-                            div()
-                                .absolute()
-                                .map(|this| {
-                                    if lift >= Pixels::ZERO {
-                                        this.bottom(lift)
-                                    } else {
-                                        this.top(Pixels::ZERO - lift)
-                                    }
-                                })
-                                .map(|this| match centered {
-                                    true => this.left(pin / 2. + travel * at),
-                                    false => this.left(relative(at)),
-                                })
-                                .ml(Pixels::ZERO - bubble_width / 2.)
-                                .w(bubble_width)
-                                .flex()
-                                .justify_center()
-                                .child(
-                                    div()
-                                        .px_1p5()
-                                        .rounded_md()
-                                        .bg(popover)
-                                        .border_1()
-                                        .border_color(popover_border)
-                                        .text_color(popover_text)
-                                        .text_size(text_size)
-                                        .child(text),
-                                ),
-                        )
-                    }),
-            )
+            .child(bar)
     }
 }
 

--- a/crates/views/src/chrome/player_bar.rs
+++ b/crates/views/src/chrome/player_bar.rs
@@ -18,7 +18,7 @@ use ui::{
 
 use crate::chrome::SidebarRight;
 use crate::shared::menu::ItemMenu;
-use crate::shared::transport::{like, transport};
+use crate::shared::transport::{NOTCH, like, percent, transport, volume_icon};
 
 const SEEK_MAX: f32 = 560.;
 const VOLUME_WIDTH: f32 = 110.;
@@ -26,7 +26,6 @@ const VOLUME_TIGHT: f32 = 72.;
 const CLOCK_SHORT: f32 = 3.4;
 const CLOCK_LONG: f32 = 5.4;
 const STEP: f32 = 0.004;
-const NOTCH: f32 = 0.05;
 
 pub(crate) struct PlayerBar {
     playback: Entity<Playback>,
@@ -327,19 +326,6 @@ fn moved(before: Option<f32>, after: Option<f32>) -> bool {
         (Some(before), Some(after)) => (before - after).abs() > STEP,
         (before, after) => before.is_some() != after.is_some(),
     }
-}
-
-fn volume_icon(level: f32) -> &'static str {
-    match level {
-        level if level <= 0.0001 => "icons/volume-x.svg",
-        level if level < 0.25 => "icons/volume.svg",
-        level if level < 0.5 => "icons/volume-1.svg",
-        _ => "icons/volume-2.svg",
-    }
-}
-
-fn percent(fraction: f32) -> SharedString {
-    t!("player-percent", value = (fraction * 100.).round())
 }
 
 impl Render for PlayerBar {

--- a/crates/views/src/shared/transport.rs
+++ b/crates/views/src/shared/transport.rs
@@ -1,7 +1,23 @@
 use gpui::prelude::*;
-use gpui::{App, Entity, div};
+use gpui::{App, Entity, SharedString, div};
+use i18n::t;
 use state::{Playback, PlaybackState, Queue, Repeat, Sonora};
 use ui::{ActiveTheme as _, Button};
+
+pub(crate) const NOTCH: f32 = 0.05;
+
+pub(crate) fn volume_icon(level: f32) -> &'static str {
+    match level {
+        level if level <= 0.0001 => "icons/volume-x.svg",
+        level if level < 0.25 => "icons/volume.svg",
+        level if level < 0.5 => "icons/volume-1.svg",
+        _ => "icons/volume-2.svg",
+    }
+}
+
+pub(crate) fn percent(fraction: f32) -> SharedString {
+    t!("player-percent", value = (fraction * 100.).round())
+}
 
 pub(crate) fn like(track: Option<music::Track>, cx: &App) -> Button {
     let theme = *cx.theme();

--- a/crates/views/src/shells/fullscreen.rs
+++ b/crates/views/src/shells/fullscreen.rs
@@ -3,9 +3,9 @@ use std::time::{Duration, Instant};
 use gpui::prelude::*;
 use gpui::{
     AnyView, App, Context, Entity, FocusHandle, MouseButton, MouseDownEvent, MouseMoveEvent,
-    MouseUpEvent, Pixels, Point, Render, SharedString, Task,
+    MouseUpEvent, Pixels, Point, Render, ScrollWheelEvent, SharedString, Task,
 };
-use gpui::{Window, div, px};
+use gpui::{Window, div, px, relative};
 use i18n::t;
 use input::{ToggleFullscreen, WORKSPACE_CONTEXT};
 use router::{Destination, navigate};
@@ -17,7 +17,7 @@ use ui::{
 
 use crate::chrome::{Aside, TitleBarOptions};
 use crate::shared::menu::ItemMenu;
-use crate::shared::transport::{like, transport};
+use crate::shared::transport::{NOTCH, like, percent, transport, volume_icon};
 use crate::shells::Shell;
 
 const COVER_TALL: f32 = 0.46;
@@ -32,6 +32,8 @@ const PILL_GAP: f32 = 2.;
 const FROST: f32 = 16.;
 const FROSTED: f32 = 0.5;
 const SEEK_MAX: f32 = 420.;
+const VOLUME_RISE: f32 = 132.;
+const VOLUME_ZONE: f32 = 14.;
 const CLOCK_SHORT: f32 = 3.4;
 const CLOCK_LONG: f32 = 5.4;
 const REST: Duration = Duration::from_secs(3);
@@ -45,6 +47,12 @@ pub struct FullscreenView {
     panel: Option<SideTab>,
     seek: ScrubberState,
     pending: Option<f32>,
+    volume: ScrubberState,
+    over_volume: bool,
+    over_zone: bool,
+    over_panel: bool,
+    volume_held: bool,
+    muted: Option<f32>,
     large: Option<SharedString>,
     revision: usize,
     track_menu: ItemMenu,
@@ -75,6 +83,12 @@ impl FullscreenView {
             panel: Some(SideTab::Lyrics),
             seek: ScrubberState::new("fullscreen-seek"),
             pending: None,
+            volume: ScrubberState::new("fullscreen-volume-slider"),
+            over_volume: false,
+            over_zone: false,
+            over_panel: false,
+            volume_held: false,
+            muted: None,
             large: None,
             revision: 0,
             track_menu: ItemMenu::new(playlist_scrollbar),
@@ -122,6 +136,32 @@ impl FullscreenView {
             return;
         }
         self.stir(cx);
+    }
+
+    fn volume_open(&self) -> bool {
+        self.over_volume || self.over_zone || self.over_panel || self.volume_held
+    }
+
+    fn turn_volume(
+        &mut self,
+        event: &ScrollWheelEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let delta = event.delta.pixel_delta(window.line_height()).y;
+        if delta == Pixels::ZERO {
+            return;
+        }
+        cx.stop_propagation();
+
+        let notch = match delta > Pixels::ZERO {
+            true => NOTCH,
+            false => -NOTCH,
+        };
+        let level = (self.playback.read(cx).volume() + notch).clamp(0., 1.);
+        self.muted = None;
+        self.playback
+            .update(cx, |playback, cx| playback.set_volume(level, cx));
     }
 
     fn commit_seek(&mut self, cx: &mut Context<Self>) {
@@ -370,7 +410,24 @@ impl FullscreenView {
             .flex_none()
             .when(inline, |this| this.child(self.pill(false, cx)))
             .child(self.seek(cx))
-            .child(transport(&self.playback, &self.queue, true, cx))
+            .child(
+                div()
+                    .relative()
+                    .w_full()
+                    .flex()
+                    .justify_center()
+                    .child(transport(&self.playback, &self.queue, true, cx))
+                    .child(
+                        div()
+                            .absolute()
+                            .right_0()
+                            .top_0()
+                            .bottom_0()
+                            .flex()
+                            .items_center()
+                            .child(self.sound(cx)),
+                    ),
+            )
     }
 
     fn pill(&self, fading: bool, cx: &mut Context<Self>) -> impl IntoElement {
@@ -380,7 +437,6 @@ impl FullscreenView {
             true => (0., 1.),
             false => (1., 0.),
         };
-
         let tab = move |id: &'static str, icon: &'static str, hint: &'static str, panel| {
             let showing = self.panel == panel;
 
@@ -432,6 +488,115 @@ impl FullscreenView {
                 Motion::Base,
                 move |pill, t| pill.opacity(from + (to - from) * t),
             )
+    }
+
+    fn sound(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = *cx.theme();
+        let zone = px(VOLUME_ZONE);
+        let level = self.playback.read(cx).volume();
+        let empty = theme.muted_foreground.opacity(0.3);
+        let restore = self.muted.unwrap_or(0.7);
+        let span = theme.metrics.control_small + zone * 2.;
+        let bubble = self.over_panel.then(|| (level, percent(level)));
+
+        div()
+            .relative()
+            .flex()
+            .flex_none()
+            .on_scroll_wheel(cx.listener(Self::turn_volume))
+            .child(
+                div()
+                    .id("fullscreen-volume-hover")
+                    .on_hover(cx.listener(|this, hovering: &bool, _, cx| {
+                        this.over_volume = *hovering;
+                        cx.notify();
+                    }))
+                    .child(
+                        Button::new("fullscreen-volume")
+                            .ghost()
+                            .small()
+                            .icon(volume_icon(level))
+                            .tint(match self.volume_open() {
+                                true => theme.foreground,
+                                false => theme.muted_foreground,
+                            })
+                            .on_click(cx.listener(move |this, _, _, cx| {
+                                let wanted = match level <= 0.001 {
+                                    true => restore,
+                                    false => 0.,
+                                };
+                                this.muted = match wanted {
+                                    0. => Some(level),
+                                    _ => None,
+                                };
+                                this.playback
+                                    .update(cx, |playback, cx| playback.set_volume(wanted, cx));
+                            })),
+                    ),
+            )
+            .when(self.volume_open(), |this| {
+                this.child(
+                    div()
+                        .id("fullscreen-volume-zone")
+                        .absolute()
+                        .bottom_0()
+                        .left(relative(0.5))
+                        .ml(Pixels::ZERO - span / 2.)
+                        .w(span)
+                        .pt(zone)
+                        .pb(theme.metrics.control_small + px(PILL_GAP) * 2.)
+                        .flex()
+                        .justify_center()
+                        .on_scroll_wheel(cx.listener(Self::turn_volume))
+                        .on_hover(cx.listener(|this, hovering: &bool, _, cx| {
+                            this.over_zone = *hovering;
+                            cx.notify();
+                        }))
+                        .child(
+                            div()
+                                .id("fullscreen-volume-panel")
+                                .occlude()
+                                .flex()
+                                .justify_center()
+                                .p_1()
+                                .py_2()
+                                .rounded(theme.radius)
+                                .border_1()
+                                .border_color(theme.border)
+                                .backdrop_blur(px(FROST))
+                                .bg(theme.popover.opacity(FROSTED))
+                                .on_scroll_wheel(cx.listener(Self::turn_volume))
+                                .on_hover(cx.listener(|this, hovering: &bool, _, cx| {
+                                    this.over_panel = *hovering;
+                                    cx.notify();
+                                }))
+                                .child(
+                                    div().h(px(VOLUME_RISE)).flex().child(
+                                        Scrubber::new(&self.volume, level)
+                                            .vertical()
+                                            .colors(theme.progress_bar, empty, theme.foreground)
+                                            .when_some(bubble, |this, (at, text)| {
+                                                this.bubble(at, text)
+                                            })
+                                            .on_move(cx.listener(|this, fraction: &f32, _, cx| {
+                                                let level = *fraction;
+                                                this.volume_held = true;
+                                                this.muted = None;
+                                                this.playback.update(cx, |playback, cx| {
+                                                    playback.set_volume(level, cx)
+                                                });
+                                            }))
+                                            .on_release(cx.listener(
+                                                |this, _: &MouseUpEvent, _, cx| {
+                                                    this.volume_held = false;
+                                                    cx.notify();
+                                                },
+                                            )),
+                                    ),
+                                ),
+                        ),
+                )
+            })
     }
 
     fn floating(&self, cx: &mut Context<Self>) -> impl IntoElement {

--- a/crates/views/src/shells/fullscreen.rs
+++ b/crates/views/src/shells/fullscreen.rs
@@ -253,7 +253,8 @@ impl FullscreenView {
                             .truncate()
                             .text_size(theme.text(Text::Title))
                             .when_some(album, |this, album| {
-                                this.hover(|style| style.underline())
+                                this.cursor_pointer()
+                                    .hover(|style| style.underline())
                                     .on_click(move |_, _, cx| open_album(&album, cx))
                             })
                             .on_mouse_down(
@@ -324,8 +325,27 @@ impl FullscreenView {
                     .justify_center()
                     .flex_1()
                     .min_w_0()
-                    .child(div().min_w_0().truncate().child(title))
-                    .when_some(track.clone(), |this, track| {
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .gap_2()
+                            .min_w_0()
+                            .child(
+                                div()
+                                    .id("strip-title")
+                                    .min_w_0()
+                                    .truncate()
+                                    .when_some(album, |this, album| {
+                                        this.cursor_pointer()
+                                            .hover(|style| style.underline())
+                                            .on_click(move |_, _, cx| open_album(&album, cx))
+                                    })
+                                    .child(title),
+                            )
+                            .child(like(track.clone(), cx)),
+                    )
+                    .when_some(track, |this, track| {
                         this.child(
                             InlineLinks::new(
                                 "strip-artists",
@@ -341,7 +361,6 @@ impl FullscreenView {
                         )
                     }),
             )
-            .child(like(track, cx))
     }
 
     fn seek(&self, cx: &mut Context<Self>) -> impl IntoElement {


### PR DESCRIPTION
## Summary

- add a hover-revealed vertical volume slider beside the fullscreen transport, with scroll-wheel nudging, mute toggle, and a side percent bubble
- add a vertical orientation with a side bubble to the ui scrubber
- move the volume helpers into shared transport for reuse across player bar and fullscreen
- link the fullscreen strip title to its album and keep the like button beside it