### PR TITLE
release 0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.16.2] - 2026-08-23
+
+### Added
+
+- Fullscreen controls fade away after a few seconds without mouse or keyboard activity, leaving
+  only the cover, the track title and artists, and the lyrics or queue panel; the cover grows into
+  the freed space. Any activity brings them back.
+
 ### Changed
 
 - Track tables start out with roomier title, artist and album columns, so a fresh install needs
   less dragging before it reads well.
+- In fullscreen, the cover column and the lyrics or queue panel now split the window evenly, with
+  the same spacing between them as around them.
 
 ## [0.16.1] - 2026-08-22
 
@@ -577,7 +587,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Initial release: a native Spotify client with playback, an interactive queue, the saved library,
 search, album, playlist, artist and song pages, context menus and adaptive theming.
 
-[unreleased]: https://github.com/nolight132/sonora/compare/v0.16.1...HEAD
+[unreleased]: https://github.com/nolight132/sonora/compare/v0.16.2...HEAD
+[0.16.2]: https://github.com/nolight132/sonora/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/nolight132/sonora/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/nolight132/sonora/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/nolight132/sonora/compare/v0.14.0...v0.15.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1642,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2518,22 +2518,13 @@ dependencies = [
  "async-task",
  "bindgen",
  "bitflags 2.13.1",
- "block",
- "cbindgen",
  "chrono",
- "cocoa 0.26.0",
- "cocoa-foundation 0.2.0",
  "collections",
- "core-foundation 0.10.0",
- "core-foundation-sys",
- "core-graphics 0.24.0",
- "core-text",
  "core-video",
  "ctor",
  "derive_more",
  "embed-resource",
  "etagere",
- "foreign-types 0.5.0",
  "futures",
  "futures-concurrency",
  "getrandom 0.3.4",
@@ -2547,14 +2538,9 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "lyon",
- "mach2 0.5.0",
- "media",
- "metal",
  "num_cpus",
- "objc",
  "parking",
  "parking_lot",
- "pathfinder_geometry",
  "pin-project",
  "pollster 0.4.0",
  "postage",
@@ -2592,9 +2578,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpui_apple"
+version = "0.1.0"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
+dependencies = [
+ "anyhow",
+ "block",
+ "cbindgen",
+ "cocoa 0.26.0",
+ "collections",
+ "core-foundation 0.10.0",
+ "core-video",
+ "derive_more",
+ "etagere",
+ "foreign-types 0.5.0",
+ "gpui",
+ "image",
+ "log",
+ "metal",
+ "objc",
+ "parking_lot",
+]
+
+[[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2612,22 +2621,16 @@ dependencies = [
  "gpui_util",
  "gpui_wgpu",
  "http_client",
- "image",
- "itertools 0.14.0",
  "libc",
  "log",
  "notify-rust",
  "oo7",
  "open",
  "parking_lot",
- "pathfinder_geometry",
- "pollster 0.4.0",
- "profiling",
  "raw-window-handle",
  "smallvec",
  "smol",
  "strum",
- "swash",
  "url",
  "uuid",
  "wayland-backend",
@@ -2646,7 +2649,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -2654,21 +2657,18 @@ dependencies = [
  "async-task",
  "block",
  "block2 0.6.2",
- "cbindgen",
  "cocoa 0.26.0",
  "collections",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "core-graphics 0.24.0",
  "core-text",
- "core-video",
  "ctor",
- "derive_more",
  "dispatch2",
- "etagere",
  "foreign-types 0.5.0",
  "futures",
  "gpui",
+ "gpui_apple",
  "gpui_util",
  "image",
  "itertools 0.14.0",
@@ -2695,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2706,7 +2706,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "gpui",
  "gpui_linux",
@@ -2717,7 +2717,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "schemars",
  "serde",
@@ -2727,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "anyhow",
  "log",
@@ -2737,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2747,18 +2747,14 @@ dependencies = [
  "gpui",
  "gpui_util",
  "itertools 0.14.0",
- "js-sys",
  "log",
  "parking_lot",
- "pollster 0.4.0",
  "profiling",
  "raw-window-handle",
  "smallvec",
  "swash",
  "unicode-bidi",
  "unicode-segmentation",
- "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
  "wgpu",
  "zed-font-kit",
@@ -2767,7 +2763,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -3021,7 +3017,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4073,13 +4069,12 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "anyhow",
  "bindgen",
  "core-foundation 0.10.0",
  "core-video",
- "ctor",
  "foreign-types 0.5.0",
  "metal",
  "objc",
@@ -5017,7 +5012,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "collections",
  "serde",
@@ -5826,7 +5821,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "derive_refineable",
 ]
@@ -6258,7 +6253,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "async-task",
  "backtrace",
@@ -6909,7 +6904,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "heapless",
  "log",
@@ -8042,7 +8037,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "perf",
  "quote",
@@ -9600,7 +9595,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9617,7 +9612,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -9628,7 +9623,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=cfacee48b397de9a318ac1825833cedab7c6341a#cfacee48b397de9a318ac1825833cedab7c6341a"
+source = "git+https://github.com/nolight132/gpui?rev=878cf2458e7a18579d79ccafa8f1d3beecefd7da#878cf2458e7a18579d79ccafa8f1d3beecefd7da"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "i18n"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "fluent-bundle",
  "gpui",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "input"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "gpui",
  "ui",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "music"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "router"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "gpui",
  "ui",
@@ -6704,7 +6704,7 @@ dependencies = [
 
 [[package]]
 name = "sonora"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "dirs",
@@ -6833,7 +6833,7 @@ dependencies = [
 
 [[package]]
 name = "state"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7852,7 +7852,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "gpui",
  "i18n",
@@ -8162,7 +8162,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "views"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "gpui",
  "i18n",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,5 +103,5 @@ debug = false
 opt-level = 2
 
 [patch."https://github.com/nolight132/zed"]
-gpui = { git = "https://github.com/nolight132/gpui", rev = "cfacee48b397de9a318ac1825833cedab7c6341a" }
-gpui_platform = { git = "https://github.com/nolight132/gpui", rev = "cfacee48b397de9a318ac1825833cedab7c6341a" }
+gpui = { git = "https://github.com/nolight132/gpui", rev = "878cf2458e7a18579d79ccafa8f1d3beecefd7da" }
+gpui_platform = { git = "https://github.com/nolight132/gpui", rev = "878cf2458e7a18579d79ccafa8f1d3beecefd7da" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.16.1"
+version = "0.16.2"
 edition = "2024"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/nolight132/sonora"

--- a/crates/ui/src/artwork.rs
+++ b/crates/ui/src/artwork.rs
@@ -220,16 +220,6 @@ impl ImageCache for ArtworkCache {
         };
 
         self.pending.remove(resource);
-        let value = match value {
-            Ok(image) => Ok(match squared(&image) {
-                Some(square) => {
-                    cx.remove_asset::<ImgResourceLoader>(resource);
-                    square
-                }
-                None => image,
-            }),
-            Err(error) => Err(error),
-        };
         self.insert(resource.clone(), value.clone(), window, cx);
         Some(value)
     }
@@ -254,37 +244,6 @@ fn blurred(image: &RenderImage) -> Option<Arc<RenderImage>> {
         .collect();
     if frames.len() != image.frame_count() {
         log::warn!("artwork: cannot soften an image");
-        return None;
-    }
-
-    Some(Arc::new(RenderImage::new(frames)))
-}
-
-fn squared(image: &RenderImage) -> Option<Arc<RenderImage>> {
-    let widest = (0..image.frame_count())
-        .map(|frame| image.size(frame))
-        .max_by_key(|size| (size.width.0 - size.height.0).abs())?;
-    if widest.width == widest.height {
-        return None;
-    }
-
-    let frames: Vec<Frame> = (0..image.frame_count())
-        .filter_map(|index| {
-            let size = image.size(index);
-            let width = size.width.0.max(0) as u32;
-            let height = size.height.0.max(0) as u32;
-            let side = width.min(height);
-            let bytes = image.as_bytes(index)?.to_vec();
-            let whole = RgbaImage::from_raw(width, height, bytes)?;
-            let cropped =
-                imageops::crop_imm(&whole, (width - side) / 2, (height - side) / 2, side, side)
-                    .to_image();
-
-            Some(Frame::from_parts(cropped, 0, 0, image.delay(index)))
-        })
-        .collect();
-    if frames.len() != image.frame_count() {
-        log::warn!("artwork: cannot crop an image to a square");
         return None;
     }
 

--- a/crates/ui/src/scrubber.rs
+++ b/crates/ui/src/scrubber.rs
@@ -67,6 +67,16 @@ impl ScrubberState {
         }
         ((x - bounds.origin.x - pin / 2.) / travel).clamp(0., 1.)
     }
+
+    fn climb_at(&self, y: Pixels, pad: Pixels) -> f32 {
+        let bounds = self.bounds.get();
+        let pin = thumb(pad);
+        let travel = bounds.size.height - pin;
+        if travel <= px(0.) {
+            return 0.;
+        }
+        1. - ((y - bounds.origin.y - pin / 2.) / travel).clamp(0., 1.)
+    }
 }
 
 #[derive(IntoElement)]
@@ -78,6 +88,7 @@ pub struct Scrubber {
     empty: Hsla,
     thumb: Hsla,
     enabled: bool,
+    vertical: bool,
     bubble: Option<(f32, SharedString)>,
     lift: Pixels,
     on_move: Option<Slide>,
@@ -94,6 +105,7 @@ impl Scrubber {
             empty: gpui::black(),
             thumb: gpui::white(),
             enabled: true,
+            vertical: false,
             bubble: None,
             lift: px(12.),
             on_move: None,
@@ -120,6 +132,11 @@ impl Scrubber {
 
     pub fn enabled(mut self, enabled: bool) -> Self {
         self.enabled = enabled;
+        self
+    }
+
+    pub fn vertical(mut self) -> Self {
+        self.vertical = true;
         self
     }
 
@@ -157,6 +174,7 @@ impl RenderOnce for Scrubber {
             empty,
             thumb,
             enabled,
+            vertical,
             bubble,
             lift,
             on_move,
@@ -170,12 +188,17 @@ impl RenderOnce for Scrubber {
         let on_move = on_move.map(Rc::new);
         let on_release = on_release.map(Rc::new);
 
+        let at = move |state: &ScrubberState, position: Point<Pixels>| match vertical {
+            true => state.climb_at(position.y, pad),
+            false => state.fraction_at(position.x, pad),
+        };
+
         let down = {
             let state = state.clone();
             let on_move = on_move.clone();
             move |event: &MouseDownEvent, window: &mut Window, cx: &mut App| {
                 if let Some(handler) = on_move.as_ref() {
-                    handler(&state.fraction_at(event.position.x, pad), window, cx);
+                    handler(&at(&state, event.position), window, cx);
                 }
             }
         };
@@ -189,7 +212,7 @@ impl RenderOnce for Scrubber {
                     return;
                 }
                 if let Some(handler) = on_move.as_ref() {
-                    handler(&state.fraction_at(event.event.position.x, pad), window, cx);
+                    handler(&at(&state, event.event.position), window, cx);
                 }
             }
         };
@@ -200,17 +223,155 @@ impl RenderOnce for Scrubber {
             }
         };
 
-        let width = bounds.get().size.width;
-        let travel = (width - pin).max(Pixels::ZERO);
-        let centered = enabled && width > Pixels::ZERO;
+        let extent = match vertical {
+            true => bounds.get().size.height,
+            false => bounds.get().size.width,
+        };
+        let travel = (extent - pin).max(Pixels::ZERO);
+        let centered = enabled && extent > Pixels::ZERO;
+        let measured = extent > Pixels::ZERO;
+
+        let bar = match vertical {
+            true => div()
+                .relative()
+                .h_full()
+                .w(line)
+                .rounded_full()
+                .bg(empty)
+                .child(
+                    div()
+                        .absolute()
+                        .bottom_0()
+                        .left_0()
+                        .w_full()
+                        .rounded_full()
+                        .bg(filled)
+                        .map(|this| match centered {
+                            true => this.h(pin / 2. + travel * fraction),
+                            false => this.h(relative(fraction)),
+                        }),
+                )
+                .when(enabled, |this| {
+                    this.child(
+                        div()
+                            .absolute()
+                            .left((line - pin) / 2.)
+                            .map(|this| match measured {
+                                true => this.bottom(travel * fraction),
+                                false => {
+                                    this.bottom(relative(fraction)).mb(Pixels::ZERO - pin / 2.)
+                                }
+                            })
+                            .size(pin)
+                            .rounded_full()
+                            .bg(thumb),
+                    )
+                })
+                .when_some(bubble, |this, (at, text)| {
+                    this.child(
+                        div()
+                            .absolute()
+                            .map(|this| {
+                                if lift >= Pixels::ZERO {
+                                    this.right(line + lift)
+                                } else {
+                                    this.left(line - lift)
+                                }
+                            })
+                            .map(|this| match centered {
+                                true => this.bottom(travel * at),
+                                false => this.bottom(relative(at)).mb(Pixels::ZERO - pin / 2.),
+                            })
+                            .h(pin)
+                            .flex()
+                            .items_center()
+                            .child(
+                                div()
+                                    .px_1p5()
+                                    .rounded_md()
+                                    .bg(popover)
+                                    .border_1()
+                                    .border_color(popover_border)
+                                    .text_color(popover_text)
+                                    .text_size(text_size)
+                                    .whitespace_nowrap()
+                                    .child(text),
+                            ),
+                    )
+                }),
+            false => div()
+                .relative()
+                .w_full()
+                .h(line)
+                .rounded_full()
+                .bg(empty)
+                .child(
+                    div()
+                        .h_full()
+                        .rounded_full()
+                        .bg(filled)
+                        .map(|this| match centered {
+                            true => this.w(pin / 2. + travel * fraction),
+                            false => this.w(relative(fraction)),
+                        }),
+                )
+                .when(enabled, |this| {
+                    this.child(
+                        div()
+                            .absolute()
+                            .top((line - pin) / 2.)
+                            .map(|this| match measured {
+                                true => this.left(travel * fraction),
+                                false => this.left(relative(fraction)).ml(Pixels::ZERO - pin / 2.),
+                            })
+                            .size(pin)
+                            .rounded_full()
+                            .bg(thumb),
+                    )
+                })
+                .when_some(bubble, |this, (at, text)| {
+                    this.child(
+                        div()
+                            .absolute()
+                            .map(|this| {
+                                if lift >= Pixels::ZERO {
+                                    this.bottom(lift)
+                                } else {
+                                    this.top(Pixels::ZERO - lift)
+                                }
+                            })
+                            .map(|this| match centered {
+                                true => this.left(pin / 2. + travel * at),
+                                false => this.left(relative(at)),
+                            })
+                            .ml(Pixels::ZERO - bubble_width / 2.)
+                            .w(bubble_width)
+                            .flex()
+                            .justify_center()
+                            .child(
+                                div()
+                                    .px_1p5()
+                                    .rounded_md()
+                                    .bg(popover)
+                                    .border_1()
+                                    .border_color(popover_border)
+                                    .text_color(popover_text)
+                                    .text_size(text_size)
+                                    .child(text),
+                            ),
+                    )
+                }),
+        };
 
         div()
             .id(gpui::ElementId::Name(id.clone()))
             .relative()
             .flex()
-            .items_center()
-            .w_full()
-            .h(reach)
+            .when_else(
+                vertical,
+                |this| this.justify_center().h_full().w(reach),
+                |this| this.items_center().w_full().h(reach),
+            )
             .child(
                 canvas(move |b, _, _| bounds.set(b), |_, _, _, _| {})
                     .absolute()
@@ -224,72 +385,7 @@ impl RenderOnce for Scrubber {
                     .on_mouse_up(MouseButton::Left, released.clone())
                     .on_mouse_up_out(MouseButton::Left, released)
             })
-            .child(
-                div()
-                    .relative()
-                    .w_full()
-                    .h(line)
-                    .rounded_full()
-                    .bg(empty)
-                    .child(
-                        div()
-                            .h_full()
-                            .rounded_full()
-                            .bg(filled)
-                            .map(|this| match centered {
-                                true => this.w(pin / 2. + travel * fraction),
-                                false => this.w(relative(fraction)),
-                            }),
-                    )
-                    .when(enabled, |this| {
-                        this.child(
-                            div()
-                                .absolute()
-                                .top((line - pin) / 2.)
-                                .map(|this| match width > Pixels::ZERO {
-                                    true => this.left(travel * fraction),
-                                    false => {
-                                        this.left(relative(fraction)).ml(Pixels::ZERO - pin / 2.)
-                                    }
-                                })
-                                .size(pin)
-                                .rounded_full()
-                                .bg(thumb),
-                        )
-                    })
-                    .when_some(bubble, |this, (at, text)| {
-                        this.child(
-                            div()
-                                .absolute()
-                                .map(|this| {
-                                    if lift >= Pixels::ZERO {
-                                        this.bottom(lift)
-                                    } else {
-                                        this.top(Pixels::ZERO - lift)
-                                    }
-                                })
-                                .map(|this| match centered {
-                                    true => this.left(pin / 2. + travel * at),
-                                    false => this.left(relative(at)),
-                                })
-                                .ml(Pixels::ZERO - bubble_width / 2.)
-                                .w(bubble_width)
-                                .flex()
-                                .justify_center()
-                                .child(
-                                    div()
-                                        .px_1p5()
-                                        .rounded_md()
-                                        .bg(popover)
-                                        .border_1()
-                                        .border_color(popover_border)
-                                        .text_color(popover_text)
-                                        .text_size(text_size)
-                                        .child(text),
-                                ),
-                        )
-                    }),
-            )
+            .child(bar)
     }
 }
 

--- a/crates/views/src/chrome/player_bar.rs
+++ b/crates/views/src/chrome/player_bar.rs
@@ -18,7 +18,7 @@ use ui::{
 
 use crate::chrome::SidebarRight;
 use crate::shared::menu::ItemMenu;
-use crate::shared::transport::{like, transport};
+use crate::shared::transport::{NOTCH, like, percent, transport, volume_icon};
 
 const SEEK_MAX: f32 = 560.;
 const VOLUME_WIDTH: f32 = 110.;
@@ -26,7 +26,6 @@ const VOLUME_TIGHT: f32 = 72.;
 const CLOCK_SHORT: f32 = 3.4;
 const CLOCK_LONG: f32 = 5.4;
 const STEP: f32 = 0.004;
-const NOTCH: f32 = 0.05;
 
 pub(crate) struct PlayerBar {
     playback: Entity<Playback>,
@@ -327,19 +326,6 @@ fn moved(before: Option<f32>, after: Option<f32>) -> bool {
         (Some(before), Some(after)) => (before - after).abs() > STEP,
         (before, after) => before.is_some() != after.is_some(),
     }
-}
-
-fn volume_icon(level: f32) -> &'static str {
-    match level {
-        level if level <= 0.0001 => "icons/volume-x.svg",
-        level if level < 0.25 => "icons/volume.svg",
-        level if level < 0.5 => "icons/volume-1.svg",
-        _ => "icons/volume-2.svg",
-    }
-}
-
-fn percent(fraction: f32) -> SharedString {
-    t!("player-percent", value = (fraction * 100.).round())
 }
 
 impl Render for PlayerBar {

--- a/crates/views/src/shared/transport.rs
+++ b/crates/views/src/shared/transport.rs
@@ -1,7 +1,23 @@
 use gpui::prelude::*;
-use gpui::{App, Entity, div};
+use gpui::{App, Entity, SharedString, div};
+use i18n::t;
 use state::{Playback, PlaybackState, Queue, Repeat, Sonora};
 use ui::{ActiveTheme as _, Button};
+
+pub(crate) const NOTCH: f32 = 0.05;
+
+pub(crate) fn volume_icon(level: f32) -> &'static str {
+    match level {
+        level if level <= 0.0001 => "icons/volume-x.svg",
+        level if level < 0.25 => "icons/volume.svg",
+        level if level < 0.5 => "icons/volume-1.svg",
+        _ => "icons/volume-2.svg",
+    }
+}
+
+pub(crate) fn percent(fraction: f32) -> SharedString {
+    t!("player-percent", value = (fraction * 100.).round())
+}
 
 pub(crate) fn like(track: Option<music::Track>, cx: &App) -> Button {
     let theme = *cx.theme();

--- a/crates/views/src/shells/fullscreen.rs
+++ b/crates/views/src/shells/fullscreen.rs
@@ -3,9 +3,9 @@ use std::time::{Duration, Instant};
 use gpui::prelude::*;
 use gpui::{
     AnyView, App, Context, Entity, FocusHandle, MouseButton, MouseDownEvent, MouseMoveEvent,
-    MouseUpEvent, Pixels, Point, Render, SharedString, Task,
+    MouseUpEvent, Pixels, Point, Render, ScrollWheelEvent, SharedString, Task,
 };
-use gpui::{Window, div, px};
+use gpui::{Window, div, px, relative};
 use i18n::t;
 use input::{ToggleFullscreen, WORKSPACE_CONTEXT};
 use router::{Destination, navigate};
@@ -17,7 +17,7 @@ use ui::{
 
 use crate::chrome::{Aside, TitleBarOptions};
 use crate::shared::menu::ItemMenu;
-use crate::shared::transport::{like, transport};
+use crate::shared::transport::{NOTCH, like, percent, transport, volume_icon};
 use crate::shells::Shell;
 
 const COVER_TALL: f32 = 0.46;
@@ -32,6 +32,8 @@ const PILL_GAP: f32 = 2.;
 const FROST: f32 = 16.;
 const FROSTED: f32 = 0.5;
 const SEEK_MAX: f32 = 420.;
+const VOLUME_RISE: f32 = 132.;
+const VOLUME_ZONE: f32 = 14.;
 const CLOCK_SHORT: f32 = 3.4;
 const CLOCK_LONG: f32 = 5.4;
 const REST: Duration = Duration::from_secs(3);
@@ -45,6 +47,12 @@ pub struct FullscreenView {
     panel: Option<SideTab>,
     seek: ScrubberState,
     pending: Option<f32>,
+    volume: ScrubberState,
+    over_volume: bool,
+    over_zone: bool,
+    over_panel: bool,
+    volume_held: bool,
+    muted: Option<f32>,
     large: Option<SharedString>,
     revision: usize,
     track_menu: ItemMenu,
@@ -75,6 +83,12 @@ impl FullscreenView {
             panel: Some(SideTab::Lyrics),
             seek: ScrubberState::new("fullscreen-seek"),
             pending: None,
+            volume: ScrubberState::new("fullscreen-volume-slider"),
+            over_volume: false,
+            over_zone: false,
+            over_panel: false,
+            volume_held: false,
+            muted: None,
             large: None,
             revision: 0,
             track_menu: ItemMenu::new(playlist_scrollbar),
@@ -122,6 +136,32 @@ impl FullscreenView {
             return;
         }
         self.stir(cx);
+    }
+
+    fn volume_open(&self) -> bool {
+        self.over_volume || self.over_zone || self.over_panel || self.volume_held
+    }
+
+    fn turn_volume(
+        &mut self,
+        event: &ScrollWheelEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let delta = event.delta.pixel_delta(window.line_height()).y;
+        if delta == Pixels::ZERO {
+            return;
+        }
+        cx.stop_propagation();
+
+        let notch = match delta > Pixels::ZERO {
+            true => NOTCH,
+            false => -NOTCH,
+        };
+        let level = (self.playback.read(cx).volume() + notch).clamp(0., 1.);
+        self.muted = None;
+        self.playback
+            .update(cx, |playback, cx| playback.set_volume(level, cx));
     }
 
     fn commit_seek(&mut self, cx: &mut Context<Self>) {
@@ -370,7 +410,24 @@ impl FullscreenView {
             .flex_none()
             .when(inline, |this| this.child(self.pill(false, cx)))
             .child(self.seek(cx))
-            .child(transport(&self.playback, &self.queue, true, cx))
+            .child(
+                div()
+                    .relative()
+                    .w_full()
+                    .flex()
+                    .justify_center()
+                    .child(transport(&self.playback, &self.queue, true, cx))
+                    .child(
+                        div()
+                            .absolute()
+                            .right_0()
+                            .top_0()
+                            .bottom_0()
+                            .flex()
+                            .items_center()
+                            .child(self.sound(cx)),
+                    ),
+            )
     }
 
     fn pill(&self, fading: bool, cx: &mut Context<Self>) -> impl IntoElement {
@@ -380,7 +437,6 @@ impl FullscreenView {
             true => (0., 1.),
             false => (1., 0.),
         };
-
         let tab = move |id: &'static str, icon: &'static str, hint: &'static str, panel| {
             let showing = self.panel == panel;
 
@@ -432,6 +488,115 @@ impl FullscreenView {
                 Motion::Base,
                 move |pill, t| pill.opacity(from + (to - from) * t),
             )
+    }
+
+    fn sound(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = *cx.theme();
+        let zone = px(VOLUME_ZONE);
+        let level = self.playback.read(cx).volume();
+        let empty = theme.muted_foreground.opacity(0.3);
+        let restore = self.muted.unwrap_or(0.7);
+        let span = theme.metrics.control_small + zone * 2.;
+        let bubble = self.over_panel.then(|| (level, percent(level)));
+
+        div()
+            .relative()
+            .flex()
+            .flex_none()
+            .on_scroll_wheel(cx.listener(Self::turn_volume))
+            .child(
+                div()
+                    .id("fullscreen-volume-hover")
+                    .on_hover(cx.listener(|this, hovering: &bool, _, cx| {
+                        this.over_volume = *hovering;
+                        cx.notify();
+                    }))
+                    .child(
+                        Button::new("fullscreen-volume")
+                            .ghost()
+                            .small()
+                            .icon(volume_icon(level))
+                            .tint(match self.volume_open() {
+                                true => theme.foreground,
+                                false => theme.muted_foreground,
+                            })
+                            .on_click(cx.listener(move |this, _, _, cx| {
+                                let wanted = match level <= 0.001 {
+                                    true => restore,
+                                    false => 0.,
+                                };
+                                this.muted = match wanted {
+                                    0. => Some(level),
+                                    _ => None,
+                                };
+                                this.playback
+                                    .update(cx, |playback, cx| playback.set_volume(wanted, cx));
+                            })),
+                    ),
+            )
+            .when(self.volume_open(), |this| {
+                this.child(
+                    div()
+                        .id("fullscreen-volume-zone")
+                        .absolute()
+                        .bottom_0()
+                        .left(relative(0.5))
+                        .ml(Pixels::ZERO - span / 2.)
+                        .w(span)
+                        .pt(zone)
+                        .pb(theme.metrics.control_small + px(PILL_GAP) * 2.)
+                        .flex()
+                        .justify_center()
+                        .on_scroll_wheel(cx.listener(Self::turn_volume))
+                        .on_hover(cx.listener(|this, hovering: &bool, _, cx| {
+                            this.over_zone = *hovering;
+                            cx.notify();
+                        }))
+                        .child(
+                            div()
+                                .id("fullscreen-volume-panel")
+                                .occlude()
+                                .flex()
+                                .justify_center()
+                                .p_1()
+                                .py_2()
+                                .rounded(theme.radius)
+                                .border_1()
+                                .border_color(theme.border)
+                                .backdrop_blur(px(FROST))
+                                .bg(theme.popover.opacity(FROSTED))
+                                .on_scroll_wheel(cx.listener(Self::turn_volume))
+                                .on_hover(cx.listener(|this, hovering: &bool, _, cx| {
+                                    this.over_panel = *hovering;
+                                    cx.notify();
+                                }))
+                                .child(
+                                    div().h(px(VOLUME_RISE)).flex().child(
+                                        Scrubber::new(&self.volume, level)
+                                            .vertical()
+                                            .colors(theme.progress_bar, empty, theme.foreground)
+                                            .when_some(bubble, |this, (at, text)| {
+                                                this.bubble(at, text)
+                                            })
+                                            .on_move(cx.listener(|this, fraction: &f32, _, cx| {
+                                                let level = *fraction;
+                                                this.volume_held = true;
+                                                this.muted = None;
+                                                this.playback.update(cx, |playback, cx| {
+                                                    playback.set_volume(level, cx)
+                                                });
+                                            }))
+                                            .on_release(cx.listener(
+                                                |this, _: &MouseUpEvent, _, cx| {
+                                                    this.volume_held = false;
+                                                    cx.notify();
+                                                },
+                                            )),
+                                    ),
+                                ),
+                        ),
+                )
+            })
     }
 
     fn floating(&self, cx: &mut Context<Self>) -> impl IntoElement {

--- a/crates/views/src/shells/fullscreen.rs
+++ b/crates/views/src/shells/fullscreen.rs
@@ -2,8 +2,9 @@ use std::time::{Duration, Instant};
 
 use gpui::prelude::*;
 use gpui::{
-    AnyView, App, Context, Entity, FocusHandle, MouseButton, MouseDownEvent, MouseMoveEvent,
-    MouseUpEvent, Pixels, Point, Render, ScrollWheelEvent, SharedString, Task,
+    AnyView, App, Context, Entity, FocusHandle, KeyDownEvent, MouseButton, MouseDownEvent,
+    MouseMoveEvent, MouseUpEvent, Pixels, Point, Render, ScrollWheelEvent, SharedString, Task,
+    ease_in_out,
 };
 use gpui::{Window, div, px, relative};
 use i18n::t;
@@ -24,10 +25,17 @@ const COVER_TALL: f32 = 0.46;
 const COVER_WIDE: f32 = 0.34;
 const COVER_TALL_TIGHT: f32 = 0.6;
 const COVER_WIDE_TIGHT: f32 = 0.86;
+const COVER_TALL_REST: f32 = 0.56;
+const COVER_WIDE_REST: f32 = 0.4;
+const COVER_TALL_TIGHT_REST: f32 = 0.72;
 const COVER_MIN: f32 = 96.;
 const COVER_MAX: f32 = 520.;
+const COVER_MAX_REST: f32 = 560.;
 const RESERVE: f32 = 2.9;
-const PANEL: f32 = 460.;
+const RESERVE_REST: f32 = 1.3;
+const DOCK: f32 = 1.15;
+const DOCK_FULL: f32 = 1.7;
+const SINK: f32 = 24.;
 const PILL_GAP: f32 = 2.;
 const FROST: f32 = 16.;
 const FROSTED: f32 = 0.5;
@@ -36,7 +44,7 @@ const VOLUME_RISE: f32 = 132.;
 const VOLUME_ZONE: f32 = 14.;
 const CLOCK_SHORT: f32 = 3.4;
 const CLOCK_LONG: f32 = 5.4;
-const REST: Duration = Duration::from_secs(3);
+const REST: Duration = Duration::from_millis(1500);
 const WAKE_DEBOUNCE: Duration = Duration::from_millis(400);
 
 pub struct FullscreenView {
@@ -59,6 +67,8 @@ pub struct FullscreenView {
     context_menu: Option<(music::Track, Point<Pixels>)>,
     last_moved: Instant,
     awake: bool,
+    hidden_from: f32,
+    turned: Instant,
     rest: Option<Task<()>>,
     focus: FocusHandle,
 }
@@ -75,7 +85,7 @@ impl FullscreenView {
         cx.observe(&aside, |_, _, cx| cx.notify()).detach();
         let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
 
-        Self {
+        let mut this = Self {
             playback,
             queue,
             cover,
@@ -95,9 +105,13 @@ impl FullscreenView {
             context_menu: None,
             last_moved: Instant::now(),
             awake: true,
+            hidden_from: 0.,
+            turned: Instant::now(),
             rest: None,
             focus: cx.focus_handle(),
-        }
+        };
+        this.stir(cx);
+        this
     }
 
     pub fn focus(&self, window: &mut Window, cx: &mut App) {
@@ -114,7 +128,7 @@ impl FullscreenView {
 
     fn stir(&mut self, cx: &mut Context<Self>) {
         if !self.awake {
-            self.awake = true;
+            self.flip(true);
             cx.notify();
         }
         self.last_moved = Instant::now();
@@ -124,18 +138,61 @@ impl FullscreenView {
                 if this.last_moved.elapsed() < REST {
                     return;
                 }
-                this.awake = false;
+                if this.busy() {
+                    this.stir(cx);
+                    return;
+                }
+                this.flip(false);
                 cx.notify();
             })
             .ok();
         }));
     }
 
-    fn on_mouse_move(&mut self, _: &MouseMoveEvent, _: &mut Window, cx: &mut Context<Self>) {
+    fn poke(&mut self, cx: &mut Context<Self>) {
         if self.awake && self.last_moved.elapsed() < WAKE_DEBOUNCE {
             return;
         }
         self.stir(cx);
+    }
+
+    fn busy(&self) -> bool {
+        self.volume_open() || self.pending.is_some() || self.context_menu.is_some()
+    }
+
+    fn flip(&mut self, awake: bool) {
+        if self.awake == awake {
+            return;
+        }
+        self.hidden_from = self.hidden_now();
+        self.awake = awake;
+        self.turned = Instant::now();
+    }
+
+    fn hidden_now(&self) -> f32 {
+        let span = Motion::Slow.span().as_secs_f32().max(f32::EPSILON);
+        let progress = (self.turned.elapsed().as_secs_f32() / span).clamp(0., 1.);
+        let target = match self.awake {
+            true => 0.,
+            false => 1.,
+        };
+
+        self.hidden_from + (target - self.hidden_from) * ease_in_out(progress)
+    }
+
+    fn hidden(&self, window: &mut Window, cx: &App) -> f32 {
+        let target = match self.awake {
+            true => 0.,
+            false => 1.,
+        };
+        if cx.reduce_motion() {
+            return target;
+        }
+        let span = Motion::Slow.span().as_secs_f32().max(f32::EPSILON);
+        if self.hidden_from != target && self.turned.elapsed().as_secs_f32() < span {
+            window.request_animation_frame();
+        }
+        self.hidden_now()
     }
 
     fn volume_open(&self) -> bool {
@@ -220,7 +277,7 @@ impl FullscreenView {
             })
     }
 
-    fn meta(&self, cx: &mut Context<Self>) -> impl IntoElement {
+    fn meta(&self, hide: f32, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = *cx.theme();
         let track = self.playback.read(cx).track().cloned();
         let title = match &track {
@@ -272,7 +329,18 @@ impl FullscreenView {
                             )
                             .child(title),
                     )
-                    .child(like(track.clone(), cx)),
+                    .child(match hide < 1. {
+                        true => div()
+                            .flex()
+                            .flex_none()
+                            .opacity(1. - hide)
+                            .child(like(track.clone(), cx))
+                            .into_any_element(),
+                        false => div()
+                            .w(theme.metrics.control_small)
+                            .flex_none()
+                            .into_any_element(),
+                    }),
             )
             .when_some(track, |this, track| {
                 this.child(
@@ -293,7 +361,7 @@ impl FullscreenView {
             })
     }
 
-    fn strip(&self, window: &Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn strip(&self, hide: f32, window: &Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = *cx.theme();
         let cover = ui::snapped(theme.metrics.row, window);
         let track = self.playback.read(cx).track().cloned();
@@ -343,7 +411,15 @@ impl FullscreenView {
                                     })
                                     .child(title),
                             )
-                            .child(like(track.clone(), cx)),
+                            .when(hide < 1., |this| {
+                                this.child(
+                                    div()
+                                        .flex()
+                                        .flex_none()
+                                        .opacity(1. - hide)
+                                        .child(like(track.clone(), cx)),
+                                )
+                            }),
                     )
                     .when_some(track, |this, track| {
                         this.child(
@@ -427,7 +503,7 @@ impl FullscreenView {
             .w_full()
             .max_w(px(SEEK_MAX))
             .flex_none()
-            .when(inline, |this| this.child(self.pill(false, cx)))
+            .when(inline, |this| this.child(self.pill(cx)))
             .child(self.seek(cx))
             .child(
                 div()
@@ -449,13 +525,32 @@ impl FullscreenView {
             )
     }
 
-    fn pill(&self, fading: bool, cx: &mut Context<Self>) -> impl IntoElement {
+    fn dock(&self, cap: Pixels, hide: f32, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .flex()
+            .flex_none()
+            .w_full()
+            .justify_center()
+            .when(hide > 0., |this| {
+                this.max_h(cap * (1. - hide))
+                    .overflow_hidden()
+                    .opacity(1. - hide)
+            })
+            .when(hide < 1., |this| {
+                this.child(
+                    div()
+                        .w_full()
+                        .flex()
+                        .justify_center()
+                        .top(px(SINK) * hide)
+                        .child(self.controls(cx)),
+                )
+            })
+    }
+
+    fn pill(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = *cx.theme();
         let gap = px(PILL_GAP);
-        let (from, to) = match self.awake || !fading {
-            true => (0., 1.),
-            false => (1., 0.),
-        };
         let tab = move |id: &'static str, icon: &'static str, hint: &'static str, panel| {
             let showing = self.panel == panel;
 
@@ -502,11 +597,6 @@ impl FullscreenView {
                 "queue-title",
                 Some(SideTab::Queue),
             ))
-            .motion(
-                ("pill", usize::from(self.awake || !fading)),
-                Motion::Base,
-                move |pill, t| pill.opacity(from + (to - from) * t),
-            )
     }
 
     fn sound(&self, cx: &mut Context<Self>) -> impl IntoElement {
@@ -618,7 +708,7 @@ impl FullscreenView {
             })
     }
 
-    fn floating(&self, cx: &mut Context<Self>) -> impl IntoElement {
+    fn floating(&self, hide: f32, cx: &mut Context<Self>) -> impl IntoElement {
         div()
             .absolute()
             .bottom_3()
@@ -630,7 +720,9 @@ impl FullscreenView {
                     .flex()
                     .flex_none()
                     .block_mouse_except_scroll()
-                    .child(self.pill(true, cx)),
+                    .opacity(1. - hide)
+                    .top(px(SINK) * hide)
+                    .child(self.pill(cx)),
             )
     }
 
@@ -679,19 +771,37 @@ impl Render for FullscreenView {
         let viewport = window.viewport_size();
         let room = Room::of(viewport.width);
         let split = room.fits(Room::Wide) && self.panel.is_some();
-        let reserve = theme.metrics.title_bar + theme.metrics.player_bar * RESERVE;
-        let (tall, wide, ceiling) = match room.fits(Room::Wide) {
-            true => (COVER_TALL, COVER_WIDE, px(COVER_MAX)),
-            false => (COVER_TALL_TIGHT, COVER_WIDE_TIGHT, viewport.width),
+        let hide = self.hidden(window, cx);
+        let shown = hide < 1.;
+        let (tall, wide, ceiling, tall_rest, wide_rest, ceiling_rest) = match room.fits(Room::Wide)
+        {
+            true => (
+                COVER_TALL,
+                COVER_WIDE,
+                px(COVER_MAX),
+                COVER_TALL_REST,
+                COVER_WIDE_REST,
+                px(COVER_MAX_REST),
+            ),
+            false => (
+                COVER_TALL_TIGHT,
+                COVER_WIDE_TIGHT,
+                viewport.width,
+                COVER_TALL_TIGHT_REST,
+                COVER_WIDE_TIGHT,
+                viewport.width,
+            ),
         };
-        let side = snapped(
+        let fit = |tall: f32, wide: f32, reserve: f32, ceiling: Pixels| {
             (viewport.height * tall)
-                .min(viewport.height - reserve)
+                .min(viewport.height - theme.metrics.title_bar - theme.metrics.player_bar * reserve)
                 .min(viewport.width * wide)
                 .min(ceiling)
-                .max(px(COVER_MIN)),
-            window,
-        );
+                .max(px(COVER_MIN))
+        };
+        let near = fit(tall, wide, RESERVE, ceiling);
+        let far = fit(tall_rest, wide_rest, RESERVE_REST, ceiling_rest);
+        let side = snapped(near + (far - near) * hide, window);
         let staged = self.panel.is_none() || split;
 
         div()
@@ -708,7 +818,10 @@ impl Render for FullscreenView {
             .px_8()
             .pb_6()
             .bg(theme.background)
-            .on_mouse_move(cx.listener(Self::on_mouse_move))
+            .on_mouse_move(cx.listener(|this, _: &MouseMoveEvent, _, cx| this.poke(cx)))
+            .on_any_mouse_down(cx.listener(|this, _: &MouseDownEvent, _, cx| this.poke(cx)))
+            .on_scroll_wheel(cx.listener(|this, _: &ScrollWheelEvent, _, cx| this.poke(cx)))
+            .on_key_down(cx.listener(|this, _: &KeyDownEvent, _, cx| this.poke(cx)))
             .child(
                 div()
                     .relative()
@@ -717,7 +830,7 @@ impl Render for FullscreenView {
                     .min_h_0()
                     .w_full()
                     .items_center()
-                    .justify_center()
+                    .justify_between()
                     .gap_8()
                     .when(staged, |this| {
                         this.child(
@@ -734,8 +847,10 @@ impl Render for FullscreenView {
                                     |this| this.w_full(),
                                 )
                                 .child(self.artwork(side, cx))
-                                .child(self.meta(cx))
-                                .when(split, |this| this.child(self.controls(cx))),
+                                .child(self.meta(hide, cx))
+                                .when(split, |this| {
+                                    this.child(self.dock(theme.metrics.player_bar * DOCK, hide, cx))
+                                }),
                         )
                     })
                     .when(self.panel.is_some(), |this| {
@@ -748,25 +863,27 @@ impl Render for FullscreenView {
                                 .min_w_0()
                                 .min_h_0()
                                 .h_full()
-                                .when(split, |this| this.max_w(px(PANEL)))
                                 .child(self.aside.clone())
-                                .child(self.floating(cx)),
+                                .when(shown, |this| this.child(self.floating(hide, cx))),
                         )
                     }),
             )
             .when(!split && self.panel.is_some(), |this| {
-                this.child(self.strip(window, cx))
+                this.child(self.strip(hide, window, cx))
             })
             .when(!split, |this| {
+                this.child(self.dock(theme.metrics.player_bar * DOCK_FULL, hide, cx))
+            })
+            .when(shown, |this| {
                 this.child(
                     div()
-                        .flex()
-                        .w_full()
-                        .justify_center()
-                        .child(self.controls(cx)),
+                        .absolute()
+                        .top(px(SINK) * -hide)
+                        .right_3()
+                        .opacity(1. - hide)
+                        .child(self.leave()),
                 )
             })
-            .child(div().absolute().top_0().right_3().child(self.leave()))
             .children(self.menu(cx))
     }
 }

--- a/crates/views/src/shells/fullscreen.rs
+++ b/crates/views/src/shells/fullscreen.rs
@@ -253,7 +253,8 @@ impl FullscreenView {
                             .truncate()
                             .text_size(theme.text(Text::Title))
                             .when_some(album, |this, album| {
-                                this.hover(|style| style.underline())
+                                this.cursor_pointer()
+                                    .hover(|style| style.underline())
                                     .on_click(move |_, _, cx| open_album(&album, cx))
                             })
                             .on_mouse_down(
@@ -324,8 +325,27 @@ impl FullscreenView {
                     .justify_center()
                     .flex_1()
                     .min_w_0()
-                    .child(div().min_w_0().truncate().child(title))
-                    .when_some(track.clone(), |this, track| {
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .gap_2()
+                            .min_w_0()
+                            .child(
+                                div()
+                                    .id("strip-title")
+                                    .min_w_0()
+                                    .truncate()
+                                    .when_some(album, |this, album| {
+                                        this.cursor_pointer()
+                                            .hover(|style| style.underline())
+                                            .on_click(move |_, _, cx| open_album(&album, cx))
+                                    })
+                                    .child(title),
+                            )
+                            .child(like(track.clone(), cx)),
+                    )
+                    .when_some(track, |this, track| {
                         this.child(
                             InlineLinks::new(
                                 "strip-artists",
@@ -341,7 +361,6 @@ impl FullscreenView {
                         )
                     }),
             )
-            .child(like(track, cx))
     }
 
     fn seek(&self, cx: &mut Context<Self>) -> impl IntoElement {


### PR DESCRIPTION
## Summary

- fade fullscreen controls away after inactivity, growing the cover into the freed space
- split the fullscreen columns evenly with matching spacing
- start track tables with roomier title, artist and album columns