### PR TITLE
fix(views): hold the volume bubble while dragging and preview fullscreen seeks

### DIFF
--- a/crates/views/src/chrome/player_bar.rs
+++ b/crates/views/src/chrome/player_bar.rs
@@ -18,14 +18,13 @@ use ui::{
 
 use crate::chrome::SidebarRight;
 use crate::shared::menu::ItemMenu;
-use crate::shared::transport::{NOTCH, like, percent, transport, volume_icon};
+use crate::shared::transport::{NOTCH, like, moved, percent, transport, volume_icon};
 
 const SEEK_MAX: f32 = 560.;
 const VOLUME_WIDTH: f32 = 110.;
 const VOLUME_TIGHT: f32 = 72.;
 const CLOCK_SHORT: f32 = 3.4;
 const CLOCK_LONG: f32 = 5.4;
-const STEP: f32 = 0.004;
 
 pub(crate) struct PlayerBar {
     playback: Entity<Playback>,
@@ -38,6 +37,7 @@ pub(crate) struct PlayerBar {
     pending: Option<f32>,
     over_seek: Option<f32>,
     over_volume: Option<f32>,
+    volume_held: bool,
     muted: Option<f32>,
 }
 
@@ -63,6 +63,7 @@ impl PlayerBar {
             pending: None,
             over_seek: None,
             over_volume: None,
+            volume_held: false,
             muted: None,
         }
     }
@@ -124,7 +125,8 @@ impl PlayerBar {
         let theme = *cx.theme();
         let empty = theme.muted_foreground.opacity(0.3);
         let level = self.playback.read(cx).volume();
-        let bubble = self.over_volume.map(|_| (level, percent(level)));
+        let showing = self.over_volume.is_some() || self.volume_held;
+        let bubble = showing.then(|| (level, percent(level)));
         let restore = self.muted.unwrap_or(0.7);
 
         div()
@@ -163,9 +165,14 @@ impl PlayerBar {
                         .when_some(bubble, |this, (at, text)| this.bubble(at, text))
                         .on_move(cx.listener(|this, fraction: &f32, _, cx| {
                             let level = *fraction;
+                            this.volume_held = true;
                             this.muted = None;
                             this.playback
                                 .update(cx, |playback, cx| playback.set_volume(level, cx));
+                        }))
+                        .on_release(cx.listener(|this, _: &MouseUpEvent, _, cx| {
+                            this.volume_held = false;
+                            cx.notify();
                         })),
                 ),
             )
@@ -318,13 +325,6 @@ impl PlayerBar {
                         }),
                 )
             })
-    }
-}
-
-fn moved(before: Option<f32>, after: Option<f32>) -> bool {
-    match (before, after) {
-        (Some(before), Some(after)) => (before - after).abs() > STEP,
-        (before, after) => before.is_some() != after.is_some(),
     }
 }
 

--- a/crates/views/src/shared/transport.rs
+++ b/crates/views/src/shared/transport.rs
@@ -5,6 +5,7 @@ use state::{Playback, PlaybackState, Queue, Repeat, Sonora};
 use ui::{ActiveTheme as _, Button};
 
 pub(crate) const NOTCH: f32 = 0.05;
+const STEP: f32 = 0.004;
 
 pub(crate) fn volume_icon(level: f32) -> &'static str {
     match level {
@@ -161,4 +162,11 @@ fn next(playback: &Entity<Playback>, queue: &Entity<Queue>, cx: &App) -> Button 
         .on_click(move |_, _, cx| {
             playback.update(cx, |playback, cx| playback.next(cx));
         })
+}
+
+pub(crate) fn moved(before: Option<f32>, after: Option<f32>) -> bool {
+    match (before, after) {
+        (Some(before), Some(after)) => (before - after).abs() > STEP,
+        (before, after) => before.is_some() != after.is_some(),
+    }
 }

--- a/crates/views/src/shells/fullscreen.rs
+++ b/crates/views/src/shells/fullscreen.rs
@@ -18,7 +18,7 @@ use ui::{
 
 use crate::chrome::{Aside, TitleBarOptions};
 use crate::shared::menu::ItemMenu;
-use crate::shared::transport::{NOTCH, like, percent, transport, volume_icon};
+use crate::shared::transport::{NOTCH, like, moved, percent, transport, volume_icon};
 use crate::shells::Shell;
 
 const COVER_TALL: f32 = 0.46;
@@ -53,6 +53,7 @@ pub struct FullscreenView {
     panel: Option<SideTab>,
     seek: ScrubberState,
     pending: Option<f32>,
+    over_seek: Option<f32>,
     volume: ScrubberState,
     over_volume: bool,
     over_zone: bool,
@@ -91,6 +92,7 @@ impl FullscreenView {
             panel: Some(SideTab::Lyrics),
             seek: ScrubberState::new("fullscreen-seek"),
             pending: None,
+            over_seek: None,
             volume: ScrubberState::new("fullscreen-volume-slider"),
             over_volume: false,
             over_zone: false,
@@ -145,6 +147,16 @@ impl FullscreenView {
             })
             .ok();
         }));
+    }
+
+    fn hover(&mut self, event: &MouseMoveEvent, _: &mut Window, cx: &mut Context<Self>) {
+        let pad = cx.theme().metrics.pad;
+        let seek = self.seek.hovered(event.position, pad);
+        if moved(self.over_seek, seek) {
+            self.over_seek = seek;
+            cx.notify();
+        }
+        self.poke(cx);
     }
 
     fn poke(&mut self, cx: &mut Context<Self>) {
@@ -456,6 +468,11 @@ impl FullscreenView {
                 false => CLOCK_SHORT,
             };
 
+        let bubble = self
+            .over_seek
+            .or(self.pending)
+            .map(|at| (at, clock(total.mul_f32(at))));
+
         let label = move |value: Duration, align_end: bool| {
             div()
                 .child(clock(value))
@@ -478,6 +495,7 @@ impl FullscreenView {
                     Scrubber::new(&self.seek, progress)
                         .colors(theme.progress_bar, empty, theme.foreground)
                         .enabled(seekable)
+                        .when_some(bubble, |this, (at, text)| this.bubble(at, text))
                         .on_move(cx.listener(|this, fraction: &f32, _, cx| {
                             this.pending = Some(*fraction);
                             cx.notify();
@@ -603,7 +621,7 @@ impl FullscreenView {
         let empty = theme.muted_foreground.opacity(0.3);
         let restore = self.muted.unwrap_or(0.7);
         let span = theme.metrics.control_small + zone * 2.;
-        let bubble = self.over_panel.then(|| (level, percent(level)));
+        let bubble = (self.over_panel || self.volume_held).then(|| (level, percent(level)));
 
         div()
             .relative()
@@ -814,7 +832,7 @@ impl Render for FullscreenView {
             .px_8()
             .pb_6()
             .bg(theme.background)
-            .on_mouse_move(cx.listener(|this, _: &MouseMoveEvent, _, cx| this.poke(cx)))
+            .on_mouse_move(cx.listener(Self::hover))
             .on_any_mouse_down(cx.listener(|this, _: &MouseDownEvent, _, cx| this.poke(cx)))
             .on_scroll_wheel(cx.listener(|this, _: &ScrollWheelEvent, _, cx| this.poke(cx)))
             .on_key_down(cx.listener(|this, _: &KeyDownEvent, _, cx| this.poke(cx)))


### PR DESCRIPTION
## Summary

- keep the volume bubble visible for as long as the thumb is held, not just while hovered
- show a time bubble when hovering or dragging the fullscreen seek bar
- share the bubble hover threshold between the player bar and the fullscreen shell