### PR TITLE
fix(playback): use device output config

### DIFF
--- a/crates/music/src/audio.rs
+++ b/crates/music/src/audio.rs
@@ -50,26 +50,30 @@ impl Output {
             device.name().unwrap_or_else(|_| "unknown".to_owned())
         );
 
-        let mut builder = OutputStreamBuilder::default().with_device(device.clone());
-        if let Some(wanted) = wanted {
-            let default = device
-                .default_output_config()
-                .map_err(|error| anyhow::anyhow!("cannot read the output config: {error}"))?;
-            let config = device
-                .supported_output_configs()
-                .map_err(|error| anyhow::anyhow!("cannot list the output configs: {error}"))?
-                .find(|config| config.channels() == wanted.channels)
-                .and_then(|config| {
-                    config
-                        .try_with_sample_rate(cpal::SampleRate(wanted.sample_rate))
-                        .or_else(|| config.try_with_sample_rate(default.sample_rate()))
-                })
-                .unwrap_or(default);
-            let format = (wanted.format)(config.sample_format());
-            builder = builder
-                .with_config(&config.config())
-                .with_sample_format(format);
-        }
+        let default = device
+            .default_output_config()
+            .map_err(|error| anyhow::anyhow!("cannot read the output config: {error}"))?;
+        let (config, format) = match wanted {
+            Some(wanted) => {
+                let config = device
+                    .supported_output_configs()
+                    .map_err(|error| anyhow::anyhow!("cannot list the output configs: {error}"))?
+                    .find(|config| config.channels() == wanted.channels)
+                    .and_then(|config| {
+                        config
+                            .try_with_sample_rate(cpal::SampleRate(wanted.sample_rate))
+                            .or_else(|| config.try_with_sample_rate(default.sample_rate()))
+                    })
+                    .unwrap_or(default);
+                let format = (wanted.format)(config.sample_format());
+                (config.config(), format)
+            }
+            None => (default.config(), default.sample_format()),
+        };
+        let builder = OutputStreamBuilder::default()
+            .with_device(device)
+            .with_config(&config)
+            .with_sample_format(format);
         let mut stream = builder
             .open_stream()
             .map_err(|error| anyhow::anyhow!("cannot open the audio output: {error}"))?;


### PR DESCRIPTION
## Summary

- use the audio device's default stream configuration for YouTube and local playback
- preserve provider-specific output selection while falling back to supported device settings
- prevent unsupported WASAPI stream configurations on Windows