### PR TITLE
fix(build): the windows build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1642,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2516,7 +2516,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2586,7 +2586,7 @@ dependencies = [
 [[package]]
 name = "gpui_apple"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "anyhow",
  "block",
@@ -2609,7 +2609,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2655,7 +2655,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -2701,7 +2701,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2712,7 +2712,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "gpui",
  "gpui_linux",
@@ -2723,7 +2723,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "schemars",
  "serde",
@@ -2733,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "anyhow",
  "log",
@@ -2743,7 +2743,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2769,7 +2769,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -3023,7 +3023,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4087,7 +4087,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -5037,7 +5037,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "collections",
  "serde",
@@ -5888,7 +5888,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "derive_refineable",
 ]
@@ -6320,7 +6320,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "async-task",
  "backtrace",
@@ -6984,7 +6984,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "heapless",
  "log",
@@ -8132,7 +8132,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "perf",
  "quote",
@@ -9690,7 +9690,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9707,7 +9707,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -9718,7 +9718,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=e8d6306158911ffa582bb94894528913e64c7e14#e8d6306158911ffa582bb94894528913e64c7e14"
+source = "git+https://github.com/nolight132/gpui?rev=2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b#2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,5 +110,5 @@ debug = false
 opt-level = 2
 
 [patch."https://github.com/nolight132/zed"]
-gpui = { git = "https://github.com/nolight132/gpui", rev = "e8d6306158911ffa582bb94894528913e64c7e14" }
-gpui_platform = { git = "https://github.com/nolight132/gpui", rev = "e8d6306158911ffa582bb94894528913e64c7e14" }
+gpui = { git = "https://github.com/nolight132/gpui", rev = "2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b" }
+gpui_platform = { git = "https://github.com/nolight132/gpui", rev = "2dfb3a17b201a53a2c32cbaedc8a2ba2d331e21b" }


### PR DESCRIPTION
## Summary

- point gpui at the fork commit that spells out the mask shader's transparent return, so `mask_fragment` compiles under HLSL again