### PR TITLE
fix(toolbar):  window controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- The window buttons on Windows are handed to Windows itself, so the maximize button restores a
+  maximized window instead of maximizing it again, and hovering it opens the Snap Layouts flyout.
+- Double-clicking the title bar maximizes the window and restores it when it is already maximized.
+  Nothing happened on macOS before, because the first click started a window drag that swallowed
+  the second.
+
 ## [0.18.0] - 2026-08-25
 
 ### Added

--- a/crates/ui/src/controls.rs
+++ b/crates/ui/src/controls.rs
@@ -5,6 +5,7 @@ use gpui::{
 
 use crate::theme::ActiveTheme as _;
 
+const SYSTEM_ACTS: bool = cfg!(target_os = "windows");
 const BUTTON: Pixels = px(20.);
 const GLYPH: Pixels = px(16.);
 
@@ -93,7 +94,9 @@ impl RenderOnce for WindowControls {
             .flex_none()
             .items_center()
             .gap_2()
-            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+            .when(!SYSTEM_ACTS, |this| {
+                this.on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+            })
             .children(wanted.into_iter().map(move |control| {
                 let danger = control == Control::Close;
 
@@ -127,13 +130,15 @@ impl RenderOnce for WindowControls {
                                 })
                             }),
                     )
-                    .on_click(move |_, window, cx| {
-                        cx.stop_propagation();
-                        match control {
-                            Control::Minimize => window.minimize_window(),
-                            Control::Maximize | Control::Restore => window.zoom_window(),
-                            Control::Close => window.remove_window(),
-                        }
+                    .when(!SYSTEM_ACTS, |this| {
+                        this.on_click(move |_, window, cx| {
+                            cx.stop_propagation();
+                            match control {
+                                Control::Minimize => window.minimize_window(),
+                                Control::Maximize | Control::Restore => window.zoom_window(),
+                                Control::Close => window.remove_window(),
+                            }
+                        })
                     })
             }));
         controls.style().refine(&overrides);

--- a/crates/views/src/chrome/title_bar.rs
+++ b/crates/views/src/chrome/title_bar.rs
@@ -1,5 +1,8 @@
 use gpui::prelude::*;
-use gpui::{AnyView, Context, Entity, EventEmitter, MouseButton, Pixels, Render};
+use gpui::{
+    AnyView, Context, Entity, EventEmitter, MouseButton, MouseDownEvent, MouseMoveEvent,
+    MouseUpEvent, Pixels, Render,
+};
 use gpui::{Window, div, px};
 use ui::WindowControls;
 use ui::{ActiveTheme as _, Button};
@@ -7,6 +10,8 @@ use ui::{ActiveTheme as _, Button};
 use crate::chrome::SidebarRight;
 use router::Navigation;
 use state::{AppSettings, Sonora};
+
+const SYSTEM_ZOOMS: bool = cfg!(target_os = "windows");
 
 #[cfg(target_os = "macos")]
 const TITLE_BAR_LEFT_INSET: f32 = 74.;
@@ -45,6 +50,7 @@ pub(crate) struct TitleBar {
     navigation: Entity<Navigation>,
     settings: Entity<AppSettings>,
     options: TitleBarOptions,
+    grabbed: bool,
 }
 
 impl EventEmitter<TitleBarEvent> for TitleBar {}
@@ -60,6 +66,7 @@ impl TitleBar {
             navigation,
             settings,
             options: TitleBarOptions::default(),
+            grabbed: false,
         }
     }
 
@@ -193,9 +200,27 @@ impl Render for TitleBar {
                 this.border_b_1().border_color(theme.title_bar_border)
             })
             .window_control_area(gpui::WindowControlArea::Drag)
-            .on_mouse_down(MouseButton::Left, |_, window, _| {
-                window.start_window_move();
-            })
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(
+                    |this, event: &MouseDownEvent, window, _| match event.click_count {
+                        1 => this.grabbed = true,
+                        2 if !SYSTEM_ZOOMS => window.zoom_window(),
+                        _ => {}
+                    },
+                ),
+            )
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(|this, _: &MouseUpEvent, _, _| this.grabbed = false),
+            )
+            .on_mouse_down_out(cx.listener(|this, _: &MouseDownEvent, _, _| this.grabbed = false))
+            .on_mouse_move(cx.listener(|this, _: &MouseMoveEvent, window, _| {
+                if this.grabbed {
+                    this.grabbed = false;
+                    window.start_window_move();
+                }
+            }))
             .child(
                 div()
                     .flex()


### PR DESCRIPTION
## Summary

- hand the window buttons to Windows itself, so the maximize button restores a maximized window and Snap Layouts opens on hover
- zoom the window on a title bar double click, and start the window drag on the first move so macOS delivers that second click

Closes #229