### PR TITLE
feat: remember the window and change the first-launch defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   a monitor cannot leave the window off screen. Wayland does not hand a window its position, so
   there only the size and the maximized state come back.
 
+### Changed
+
+- New installs start with different defaults. Album art tints the theme, corners are rounded rather
+  than subtle, volume normalisation is off, and lyrics are romanized for Japanese, Chinese and
+  Korean only. Albums, playlists and artists open as cards, an artist's own page as a list, and both
+  sidebars are a little narrower. Anything you have already set is left alone.
+
 ### Fixed
 
 - The window buttons on Windows are handed to Windows itself, so the maximize button restores a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Sonora reopens at the size and position it had when you closed it, and maximized if you left it
+  that way. A saved position that no longer lands on a connected display is dropped, so unplugging
+  a monitor cannot leave the window off screen. Wayland does not hand a window its position, so
+  there only the size and the maximized state come back.
+
 ### Fixed
 
 - The window buttons on Windows are handed to Windows itself, so the maximize button restores a

--- a/crates/sonora/src/main.rs
+++ b/crates/sonora/src/main.rs
@@ -10,14 +10,17 @@ mod single;
 use std::sync::Arc;
 
 use gpui::{
-    App, AppContext as _, Bounds, Entity, TitlebarOptions, WindowBackgroundAppearance,
-    WindowBounds, WindowOptions, point, px, size,
+    App, AppContext as _, Bounds, Entity, Pixels, Size, TitlebarOptions,
+    WindowBackgroundAppearance, WindowBounds, WindowOptions, point, px, size,
 };
 use music::LyricsProvider;
 use router::Screen;
 use state::{Library, Playback, Queue, Session, Sonora};
 use ui::ActiveTheme as _;
 use views::Root;
+
+const LEAST_SIZE: Size<Pixels> = size(px(480.), px(400.));
+const FIRST_SIZE: Size<Pixels> = size(px(920.), px(640.));
 
 fn main() {
     logging::init();
@@ -137,10 +140,11 @@ fn open_window(
     queue: Entity<Queue>,
     cx: &mut App,
 ) {
-    let bounds = Bounds::centered(None, size(px(920.), px(640.)), cx);
+    let placement = state::window_placement(LEAST_SIZE, cx)
+        .unwrap_or_else(|| WindowBounds::Windowed(Bounds::centered(None, FIRST_SIZE, cx)));
     cx.open_window(
         WindowOptions {
-            window_bounds: Some(WindowBounds::Windowed(bounds)),
+            window_bounds: Some(placement),
             window_background: WindowBackgroundAppearance::Transparent,
             titlebar: Some(TitlebarOptions {
                 title: Some("Sonora".into()),
@@ -151,12 +155,13 @@ fn open_window(
             is_movable: true,
             is_resizable: true,
             app_id: Some("sonora".into()),
-            window_min_size: Some(size(px(480.), px(400.))),
+            window_min_size: Some(LEAST_SIZE),
             ..Default::default()
         },
         |window, cx| {
             window.set_rem_size(cx.theme().font_size);
             state::attach_remote(window_handle(window), cx);
+            state::remember_window(window, cx);
             cx.new(|cx| Root::new(session, library, playback, queue, window, cx))
         },
     )

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -29,7 +29,7 @@ pub use queue::{Named, Queue, Resume, Stub};
 pub use remote::{Remote, attach as attach_remote};
 pub use search::{AlbumHit, ArtistHit, Hit, Kind, PlaylistHit, Search};
 pub use session::{Failure, ProviderInfo, Session, SessionEvent, SessionState};
-pub use settings::{AppSettings, RomanizationScripts, SideTab};
+pub use settings::{AppSettings, RomanizationScripts, SideTab, remember_window, window_placement};
 pub use song::SongDetail;
 pub use toast::{Outcome, Toast, Toasts};
 

--- a/crates/state/src/settings.rs
+++ b/crates/state/src/settings.rs
@@ -3,15 +3,17 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use gpui::{Context, Task};
+use gpui::{
+    App, Bounds, Context, Pixels, Size, Subscription, Task, Window, WindowBounds, point, px, size,
+};
 use music::WritingSystem;
 use serde::{Deserialize, Serialize};
 use ui::{
     Layout, Look, Mode, Pace, Pin, Rounding, Sorting, Stillness, Sweep, ThemeKind, ThemeOverrides,
 };
 
-use crate::Repeat;
 use crate::queue::{Resume, gap_target};
+use crate::{Repeat, Sonora};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -73,6 +75,52 @@ impl Default for RomanizationScripts {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+struct Frame {
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+    maximized: bool,
+}
+
+impl Frame {
+    fn of(window: &Window) -> Self {
+        let placement = window.window_bounds();
+        let bounds = placement.get_bounds();
+        Self {
+            x: bounds.origin.x / px(1.),
+            y: bounds.origin.y / px(1.),
+            width: bounds.size.width / px(1.),
+            height: bounds.size.height / px(1.),
+            maximized: matches!(placement, WindowBounds::Maximized(_)),
+        }
+    }
+
+    fn sane(self) -> bool {
+        [self.x, self.y, self.width, self.height]
+            .iter()
+            .all(|it| it.is_finite())
+            && self.width > 0.
+            && self.height > 0.
+    }
+
+    fn placement(self, least: Size<Pixels>) -> WindowBounds {
+        let bounds = Bounds {
+            origin: point(px(self.x), px(self.y)),
+            size: size(
+                px(self.width).max(least.width),
+                px(self.height).max(least.height),
+            ),
+        };
+        match self.maximized {
+            true => WindowBounds::Maximized(bounds),
+            false => WindowBounds::Windowed(bounds),
+        }
+    }
+}
+
 const SAVE_DELAY: Duration = Duration::from_millis(300);
 const DEFAULT_VOLUME: f32 = 0.7;
 const DEFAULT_SIDEBAR_WIDTH: f32 = 220.;
@@ -112,6 +160,8 @@ struct Values {
     pins: Pins,
     #[serde(skip_serializing_if = "Option::is_none")]
     resume: Option<Resume>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    window: Option<Frame>,
     appearance: Appearance,
 }
 
@@ -159,6 +209,7 @@ impl Default for Values {
             views: HashMap::new(),
             pins: Pins::new(),
             resume: None,
+            window: None,
             appearance: Appearance::default(),
         }
     }
@@ -197,6 +248,7 @@ pub struct AppSettings {
     values: Values,
     path: PathBuf,
     save: Option<Task<()>>,
+    watch: Option<Subscription>,
 }
 
 impl AppSettings {
@@ -219,6 +271,7 @@ impl AppSettings {
             values,
             path,
             save: None,
+            watch: None,
         }
     }
 
@@ -618,6 +671,22 @@ impl AppSettings {
         self.schedule_save(cx);
     }
 
+    pub fn watch_window(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.keep_frame(window, cx);
+        self.watch = Some(cx.observe_window_bounds(window, |this, window, cx| {
+            this.keep_frame(window, cx);
+        }));
+    }
+
+    fn keep_frame(&mut self, window: &Window, cx: &mut Context<Self>) {
+        let frame = Frame::of(window);
+        if !frame.sane() || self.values.window == Some(frame) {
+            return;
+        }
+        self.values.window = Some(frame);
+        self.schedule_save(cx);
+    }
+
     fn schedule_save(&mut self, cx: &mut Context<Self>) {
         cx.notify();
         self.save = Some(cx.spawn(async move |this, cx| {
@@ -646,6 +715,25 @@ impl AppSettings {
             log::error!("settings: cannot write {}: {error}", self.path.display());
         }
     }
+}
+
+pub fn window_placement(least: Size<Pixels>, cx: &App) -> Option<WindowBounds> {
+    let frame = Sonora::global(cx).settings.read(cx).values.window?;
+    if !frame.sane() {
+        return None;
+    }
+
+    let placement = frame.placement(least);
+    let bounds = placement.get_bounds();
+    cx.displays()
+        .iter()
+        .any(|display| display.bounds().intersects(&bounds))
+        .then_some(placement)
+}
+
+pub fn remember_window(window: &mut Window, cx: &mut App) {
+    let settings = Sonora::global(cx).settings.clone();
+    settings.update(cx, |settings, cx| settings.watch_window(window, cx));
 }
 
 fn settings_path() -> PathBuf {

--- a/crates/state/src/settings.rs
+++ b/crates/state/src/settings.rs
@@ -67,10 +67,10 @@ impl Default for RomanizationScripts {
             japanese: true,
             chinese: true,
             korean: true,
-            cyrillic: true,
-            greek: true,
-            arabic: true,
-            other: true,
+            cyrillic: false,
+            greek: false,
+            arabic: false,
+            other: false,
         }
     }
 }
@@ -123,8 +123,8 @@ impl Frame {
 
 const SAVE_DELAY: Duration = Duration::from_millis(300);
 const DEFAULT_VOLUME: f32 = 0.7;
-const DEFAULT_SIDEBAR_WIDTH: f32 = 220.;
-const DEFAULT_SIDEBAR_RIGHT_WIDTH: f32 = 380.;
+const DEFAULT_SIDEBAR_WIDTH: f32 = 195.;
+const DEFAULT_SIDEBAR_RIGHT_WIDTH: f32 = 254.;
 const DEFAULT_FONT_SIZE: f32 = 14.;
 const DEFAULT_STARTUP: &str = "home";
 
@@ -186,11 +186,11 @@ impl Default for Values {
         Self {
             version: 1,
             volume: DEFAULT_VOLUME,
-            normalisation: true,
+            normalisation: false,
             gapless: true,
             karaoke_lyrics: true,
             karaoke_sweep: Sweep::default().id().to_owned(),
-            romanized_lyrics: false,
+            romanized_lyrics: true,
             romanization_scripts: RomanizationScripts::default(),
             adaptive_menu: false,
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
@@ -230,8 +230,8 @@ impl Default for Appearance {
     fn default() -> Self {
         Self {
             theme: "dark".to_owned(),
-            adaptive_theme: false,
-            rounding: "subtle".to_owned(),
+            adaptive_theme: true,
+            rounding: Rounding::Rounded.id().to_owned(),
             font_size: DEFAULT_FONT_SIZE,
             transparent: false,
             transparency: 0.15,
@@ -475,10 +475,6 @@ impl AppSettings {
         }
         self.values.tables.insert(table.to_owned(), layout);
         self.schedule_save(cx);
-    }
-
-    pub fn view(&self, table: &str) -> Mode {
-        self.values.views.get(table).copied().unwrap_or_default()
     }
 
     pub fn view_or(&self, table: &str, fallback: Mode) -> Mode {
@@ -821,16 +817,22 @@ mod tests {
     }
 
     #[test]
-    fn new_lyric_preferences_have_backward_compatible_defaults() {
+    fn lyrics_start_karaoke_and_romanize_only_cjk() {
         let values: Values = serde_json::from_str("{}").expect("empty settings use defaults");
 
         assert!(values.karaoke_lyrics);
-        assert!(!values.romanized_lyrics);
-        assert!(
-            WritingSystem::ALL
-                .into_iter()
-                .all(|system| values.romanization_scripts.contains(system))
-        );
+        assert!(values.romanized_lyrics);
+        let romanized = [
+            WritingSystem::Japanese,
+            WritingSystem::Chinese,
+            WritingSystem::Korean,
+        ];
+        for system in WritingSystem::ALL {
+            assert_eq!(
+                values.romanization_scripts.contains(system),
+                romanized.contains(&system)
+            );
+        }
     }
 
     #[test]
@@ -848,7 +850,7 @@ mod tests {
                 .contains(WritingSystem::Japanese)
         );
         assert!(values.romanization_scripts.contains(WritingSystem::Chinese));
-        assert!(values.romanization_scripts.contains(WritingSystem::Other));
+        assert!(!values.romanization_scripts.contains(WritingSystem::Other));
     }
 
     #[test]

--- a/crates/views/src/screens/artist.rs
+++ b/crates/views/src/screens/artist.rs
@@ -128,7 +128,7 @@ impl ArtistView {
         let settings = Sonora::global(cx).settings.clone();
         let saved = settings.read(cx).table(SECTION);
         let sorting = settings.read(cx).sorting(SECTION);
-        let mode = settings.read(cx).view_or(SECTION, Mode::Cards);
+        let mode = settings.read(cx).view_or(SECTION, Mode::List);
         let columns =
             crate::shared::tracks::artist_columns(Sonora::global(cx).session.read(cx).playcounts());
         let scroll = scrollbar.read(cx).scroll().clone();

--- a/crates/views/src/screens/library/mod.rs
+++ b/crates/views/src/screens/library/mod.rs
@@ -105,6 +105,13 @@ impl Section {
         }
     }
 
+    fn mode(self) -> Mode {
+        match self {
+            Section::Tracks => Mode::List,
+            Section::Albums | Section::Playlists | Section::Artists => Mode::Cards,
+        }
+    }
+
     fn slot(self) -> usize {
         match self {
             Section::Tracks => 0,
@@ -190,7 +197,8 @@ impl LibraryView {
                 settings.sorting(section.key()),
             )
         };
-        let viewed = |section: Section, cx: &App| settings.read(cx).view(section.key());
+        let viewed =
+            |section: Section, cx: &App| settings.read(cx).view_or(section.key(), section.mode());
         let views = Section::ALL.map(|section| viewed(section, cx));
 
         let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()));


### PR DESCRIPTION
## Summary

- remember the window size, position and maximized state, and reopen there next launch
- drop a saved position that no longer lands on a connected display, so the window cannot open off screen
- start a fresh install with the adaptive theme on, rounded corners and volume normalisation off
- romanize lyrics by default, for japanese, chinese and korean only
- open albums, playlists and artists as cards, and an artist page as a list
- narrow the default width of both sidebars