### PR TITLE
fix(ui): make the window buttons work on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- The window buttons on Windows are handed to Windows itself, so the maximize button restores a
-  maximized window instead of maximizing it again, and hovering it opens the Snap Layouts flyout.
+- The minimize and close buttons work on Windows, where a click on either did nothing. Maximize is
+  still handed to Windows itself, which is what lets it restore a maximized window and open the
+  Snap Layouts flyout on hover.
 - Double-clicking the title bar maximizes the window and restores it when it is already maximized.
   Nothing happened on macOS before, because the first click started a window drag that swallowed
   the second.

--- a/crates/ui/src/controls.rs
+++ b/crates/ui/src/controls.rs
@@ -35,6 +35,10 @@ impl Control {
         }
     }
 
+    fn system(self) -> bool {
+        SYSTEM_ACTS && matches!(self, Self::Maximize | Self::Restore)
+    }
+
     fn area(self) -> WindowControlArea {
         match self {
             Self::Minimize => WindowControlArea::Min,
@@ -131,15 +135,16 @@ impl RenderOnce for WindowControls {
                                 })
                             }),
                     )
-                    .when(!SYSTEM_ACTS, |this| {
-                        this.on_click(move |_, window, cx| {
-                            cx.stop_propagation();
-                            match control {
-                                Control::Minimize => window.minimize_window(),
-                                Control::Maximize | Control::Restore => window.zoom_window(),
-                                Control::Close => window.remove_window(),
-                            }
-                        })
+                    .when(!control.system(), |this| {
+                        this.on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                            .on_click(move |_, window, cx| {
+                                cx.stop_propagation();
+                                match control {
+                                    Control::Minimize => window.minimize_window(),
+                                    Control::Maximize | Control::Restore => window.zoom_window(),
+                                    Control::Close => window.remove_window(),
+                                }
+                            })
                     })
             }));
         controls.style().refine(&overrides);

--- a/crates/ui/src/controls.rs
+++ b/crates/ui/src/controls.rs
@@ -110,6 +110,7 @@ impl RenderOnce for WindowControls {
                     .size(BUTTON)
                     .rounded(theme.radius)
                     .cursor_pointer()
+                    .occlude()
                     .window_control_area(control.area())
                     .hover(move |style| {
                         style.bg(match danger {


### PR DESCRIPTION
## Summary

- minimize and close from the title bar buttons on windows, where a click on either did nothing
- consume the button press so the platform cannot start a caption drag and swallow the click
- occlude each button so it wins the platform hit test over the title bar drag area
- leave maximize to windows, which owns restoring a maximized window and the snap layouts flyout