### PR TITLE
fix(playback): restart the current track before stepping back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Previous restarts the track you are on once you are more than three seconds into it, and only
+  steps back a track if you press it near the start. There is also nothing to step back to on the
+  first track of a queue, so there it always restarts.
 - New installs start with different defaults. Album art tints the theme, corners are rounded rather
   than subtle, volume normalisation is off, and lyrics are romanized for Japanese, Chinese and
   Korean only. Albums, playlists and artists open as cards, an artist's own page as a list, and both

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use gpui::{Context, Entity, EventEmitter, Task};
+use gpui::{App, Context, Entity, EventEmitter, Task};
 use music::{
     MusicApi, PlaybackConfig, PlaybackEvent as BackendEvent, PlaybackEvents, PlaybackFactory,
     Player, Track,
@@ -50,6 +50,7 @@ const POSITION_INTERVAL: Duration = Duration::from_millis(500);
 const CLOCK_SETTLE: Duration = Duration::from_secs(1);
 const PRELOAD_BEFORE_END: Duration = Duration::from_secs(10);
 const SKIP_DEBOUNCE: Duration = Duration::from_millis(250);
+const RESTART_WINDOW: Duration = Duration::from_secs(3);
 const KEY_COOLDOWN: Duration = Duration::from_secs(6);
 const RESUME_STEP: Duration = Duration::from_secs(5);
 const TAPER_DB: f32 = 50.;
@@ -822,7 +823,19 @@ impl Playback {
         self.load_after(&track, start, cx);
     }
 
+    pub fn has_previous(&self, cx: &App) -> bool {
+        self.track.is_some() || self.queue.read(cx).has_previous()
+    }
+
+    fn restarts(&self, cx: &App) -> bool {
+        self.track.is_some()
+            && (self.live_position() > RESTART_WINDOW || !self.queue.read(cx).has_previous())
+    }
+
     pub fn previous(&mut self, cx: &mut Context<Self>) {
+        if self.restarts(cx) {
+            return self.seek(Duration::ZERO, cx);
+        }
         self.fetch = None;
         let start = self.burst();
         let Some(track) = self.queue.update(cx, |queue, cx| queue.previous(cx)) else {

--- a/crates/views/src/shared/transport.rs
+++ b/crates/views/src/shared/transport.rs
@@ -61,7 +61,7 @@ pub(crate) fn transport(
         .items_center()
         .gap_2()
         .child(shuffle(queue, cx))
-        .child(previous(playback, queue, cx))
+        .child(previous(playback, cx))
         .child(toggle(playback, big, cx))
         .child(next(playback, queue, cx))
         .child(repeat(playback, cx))
@@ -134,8 +134,8 @@ fn repeat(playback: &Entity<Playback>, cx: &App) -> Button {
         })
 }
 
-fn previous(playback: &Entity<Playback>, queue: &Entity<Queue>, cx: &App) -> Button {
-    let enabled = queue.read(cx).has_previous();
+fn previous(playback: &Entity<Playback>, cx: &App) -> Button {
+    let enabled = playback.read(cx).has_previous(cx);
     let playback = playback.clone();
 
     Button::new("previous")


### PR DESCRIPTION
## Summary

- restart the current track when previous is pressed more than three seconds in, and step back only near the start
- restart on the first track of a queue, where there is nothing to step back to
- keep the previous button enabled whenever a track is loaded, not only when the queue has history
