### PR TITLE
feat: drag list rows and fix the context menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Right-clicking an artist now offers Play artist, Play next, Add artist to queue, Follow and Copy
+  link, wherever the artist appears. It only ever offered Copy link before.
+- Albums and playlists on Home and on a genre page answer a right-click with the same menu they
+  have in Your Library, so a card and a row no longer disagree about what you can do with an item.
+- The song page and the now-playing artwork in the player bar answer a right-click with the track
+  menu. The song page had no context menu at all, and the artwork ignored the click even though the
+  title beside it did not.
 - Songs, albums, playlists and artists can be dropped straight onto the queue. Drop between two
   queued songs to slot them in there, or anywhere else in the pane to add them at the end.
 - Sonora tells you when a newer version is out. On Windows it asks GitHub once at startup and, if

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Songs, albums, playlists and artists can be dropped straight onto the queue. Drop between two
+  queued songs to slot them in there, or anywhere else in the pane to add them at the end.
 - Sonora tells you when a newer version is out. On Windows it asks GitHub once at startup and, if
   a release is newer than the running build, floats a card in the top-left corner with the new
   version number, a link to what changed, and a choice between Later and Update. Update downloads
@@ -34,6 +36,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Rows in the list view of Albums, Playlists and Artists can be dragged by their name. The name
+  column swallowed the press, so the only place a row could be picked up from was its cover.
+- Dropping something in the space between two pinned items in the sidebar, or between two queued
+  songs, puts it there instead of at the end.
 - The minimize and close buttons work on Windows, where a click on either did nothing. Maximize is
   still handed to Windows itself, which is what lets it restore a maximized window and open the
   Snap Layouts flyout on hover.

--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ partial translation is welcome — pick a language below and fill in what it lac
 
 | Language | Translated | Coverage |
 | --- | --- | --- |
-| English (`en-US`) | 395/395 | 100% |
-| Deutsch (`de`) | 364/395 | 92% |
-| Français (`fr`) | 364/395 | 92% |
-| Русский (`ru`) | 383/395 | 97% |
-| Українська (`uk`) | 383/395 | 97% |
-| Polski (`pl`) | 383/395 | 97% |
+| English (`en-US`) | 399/399 | 100% |
+| Deutsch (`de`) | 368/399 | 92% |
+| Français (`fr`) | 368/399 | 92% |
+| Русский (`ru`) | 387/399 | 97% |
+| Українська (`uk`) | 387/399 | 97% |
+| Polski (`pl`) | 387/399 | 97% |
 
 <!-- i18n:end -->
 

--- a/assets/i18n/de/main.ftl
+++ b/assets/i18n/de/main.ftl
@@ -92,6 +92,8 @@ menu-make-playlist-private = Privat machen
 menu-open-album = Album öffnen
 menu-play-album = Album abspielen
 menu-add-album-to-queue = Album zur Warteschlange hinzufügen
+menu-play-artist = Künstler abspielen
+menu-add-artist-to-queue = Künstler zur Warteschlange hinzufügen
 
 # playlist editor
 playlist-name-placeholder = Name der Playlist
@@ -412,6 +414,8 @@ toast-queued-album = Album zur Warteschlange hinzugefügt
 toast-next-album = Album läuft als Nächstes
 toast-queued-playlist = Playlist zur Warteschlange hinzugefügt
 toast-next-playlist = Playlist läuft als Nächstes
+toast-queued-artist = Künstler zur Warteschlange hinzugefügt
+toast-next-artist = Künstler läuft als Nächstes
 toast-queue-failed = Das konnte nicht zur Warteschlange hinzugefügt werden
 toast-keys-refused = Spotify gibt diesem Konto keine Wiedergabeschlüssel
 toast-sign-in-to-play = { $name } streamt nur für angemeldete Hörer

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -92,6 +92,8 @@ menu-make-playlist-private = Make private
 menu-open-album = Open album
 menu-play-album = Play album
 menu-add-album-to-queue = Add album to queue
+menu-play-artist = Play artist
+menu-add-artist-to-queue = Add artist to queue
 
 # playlist editor
 playlist-name-placeholder = Playlist name
@@ -434,6 +436,8 @@ toast-queued-album = Album added to the queue
 toast-next-album = Album plays next
 toast-queued-playlist = Playlist added to the queue
 toast-next-playlist = Playlist plays next
+toast-queued-artist = Artist added to the queue
+toast-next-artist = Artist plays next
 toast-queue-failed = That could not be added to the queue
 toast-keys-refused = Spotify is not granting this account playback keys
 toast-sign-in-to-play = { $name } only streams to a signed-in listener

--- a/assets/i18n/fr/main.ftl
+++ b/assets/i18n/fr/main.ftl
@@ -92,6 +92,8 @@ menu-make-playlist-private = Rendre privée
 menu-open-album = Ouvrir l'album
 menu-play-album = Lire l'album
 menu-add-album-to-queue = Ajouter l'album à la file d'attente
+menu-play-artist = Lire l'artiste
+menu-add-artist-to-queue = Ajouter l'artiste à la file d'attente
 
 # playlist editor
 playlist-name-placeholder = Nom de la playlist
@@ -412,6 +414,8 @@ toast-queued-album = Album ajouté à la file d'attente
 toast-next-album = L'album sera lu juste après
 toast-queued-playlist = Playlist ajoutée à la file d'attente
 toast-next-playlist = La playlist sera lue juste après
+toast-queued-artist = Artiste ajouté à la file d'attente
+toast-next-artist = L'artiste sera lu juste après
 toast-queue-failed = Impossible d'ajouter cela à la file d'attente
 toast-keys-refused = Spotify n'accorde pas de clés de lecture à ce compte
 toast-sign-in-to-play = { $name } ne diffuse qu'aux auditeurs connectés

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -92,6 +92,8 @@ menu-make-playlist-private = Ustaw jako prywatną
 menu-open-album = Otwórz album
 menu-play-album = Odtwórz album
 menu-add-album-to-queue = Dodaj album do kolejki
+menu-play-artist = Odtwórz wykonawcę
+menu-add-artist-to-queue = Dodaj wykonawcę do kolejki
 
 # playlist editor
 playlist-name-placeholder = Nazwa playlisty
@@ -425,6 +427,8 @@ toast-queued-album = Album dodano do kolejki
 toast-next-album = Album zabrzmi następny
 toast-queued-playlist = Playlistę dodano do kolejki
 toast-next-playlist = Playlista zabrzmi następna
+toast-queued-artist = Wykonawcę dodano do kolejki
+toast-next-artist = Wykonawca zabrzmi następny
 toast-queue-failed = Nie udało się dodać do kolejki
 toast-keys-refused = Spotify nie udziela temu kontu kluczy odtwarzania
 toast-sign-in-to-play = { $name } udostępnia muzykę tylko po zalogowaniu

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -92,6 +92,8 @@ menu-make-playlist-private = Сделать приватным
 menu-open-album = Открыть альбом
 menu-play-album = Воспроизвести альбом
 menu-add-album-to-queue = Добавить альбом в очередь
+menu-play-artist = Воспроизвести исполнителя
+menu-add-artist-to-queue = Добавить исполнителя в очередь
 
 # playlist editor
 playlist-name-placeholder = Название плейлиста
@@ -425,6 +427,8 @@ toast-queued-album = Альбом добавлен в очередь
 toast-next-album = Альбом прозвучит следующим
 toast-queued-playlist = Плейлист добавлен в очередь
 toast-next-playlist = Плейлист прозвучит следующим
+toast-queued-artist = Исполнитель добавлен в очередь
+toast-next-artist = Исполнитель прозвучит следующим
 toast-queue-failed = Не удалось добавить в очередь
 toast-keys-refused = Spotify не выдаёт этому аккаунту ключи воспроизведения
 toast-sign-in-to-play = { $name } отдаёт музыку только тем, кто вошёл в аккаунт

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -92,6 +92,8 @@ menu-make-playlist-private = Зробити приватним
 menu-open-album = Відкрити альбом
 menu-play-album = Відтворити альбом
 menu-add-album-to-queue = Додати альбом до черги
+menu-play-artist = Відтворити виконавця
+menu-add-artist-to-queue = Додати виконавця до черги
 
 # playlist editor
 playlist-name-placeholder = Назва плейлиста
@@ -425,6 +427,8 @@ toast-queued-album = Альбом додано до черги
 toast-next-album = Альбом прозвучить наступним
 toast-queued-playlist = Плейлист додано до черги
 toast-next-playlist = Плейлист прозвучить наступним
+toast-queued-artist = Виконавця додано до черги
+toast-next-artist = Виконавець прозвучить наступним
 toast-queue-failed = Не вдалося додати до черги
 toast-keys-refused = Spotify не надає цьому обліковому запису ключі відтворення
 toast-sign-in-to-play = { $name } віддає музику лише тим, хто увійшов в акаунт

--- a/crates/router/src/link.rs
+++ b/crates/router/src/link.rs
@@ -1,5 +1,5 @@
 use gpui::prelude::*;
-use gpui::{Div, MouseButton, Stateful};
+use gpui::{Div, Stateful};
 
 use crate::{Destination, navigate};
 
@@ -9,8 +9,9 @@ pub trait Link: Sized {
 
 impl Link for Stateful<Div> {
     fn link(self, to: Destination) -> Self {
-        self.cursor_pointer()
-            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
-            .on_click(move |_, _, cx| navigate(to.clone(), cx))
+        self.cursor_pointer().on_click(move |_, _, cx| {
+            cx.stop_propagation();
+            navigate(to.clone(), cx);
+        })
     }
 }

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -1,5 +1,4 @@
 use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -9,8 +8,9 @@ use music::{
     MusicApi, PlaybackConfig, PlaybackEvent as BackendEvent, PlaybackEvents, PlaybackFactory,
     Player, Track,
 };
+use ui::{Pin, PinKind};
 
-type Fetch = Pin<Box<dyn Future<Output = Result<Vec<Track>>> + Send>>;
+type Fetch = std::pin::Pin<Box<dyn Future<Output = Result<Vec<Track>>> + Send>>;
 
 #[derive(Clone, Copy, PartialEq)]
 enum Refusal {
@@ -39,6 +39,17 @@ impl Start {
 enum QueuePlacement {
     Next,
     End,
+    Gap(usize),
+}
+
+impl QueuePlacement {
+    fn toast(self, source: &str) -> Option<String> {
+        match self {
+            Self::Next => Some(format!("toast-next-{source}")),
+            Self::End => Some(format!("toast-queued-{source}")),
+            Self::Gap(_) => None,
+        }
+    }
 }
 
 use crate::queue::Queue;
@@ -456,6 +467,52 @@ impl Playback {
             .update(cx, |queue, cx| queue.prepend_all(tracks, cx));
     }
 
+    pub fn insert_all(&mut self, tracks: Vec<Track>, gap: usize, cx: &mut Context<Self>) {
+        if tracks.is_empty() {
+            return;
+        }
+        if self.queue.read(cx).current().is_none() {
+            self.begin(tracks, 0, None, cx);
+            return;
+        }
+        self.queue
+            .update(cx, |queue, cx| queue.insert_upcoming(gap, tracks, cx));
+    }
+
+    pub fn enqueue_pin(&mut self, pin: &Pin, gap: Option<usize>, cx: &mut Context<Self>) {
+        let placement = QueuePlacement::Gap(gap.unwrap_or(usize::MAX));
+        let id = pin.id.clone();
+
+        match pin.kind {
+            PinKind::Song => {
+                let track = id.clone();
+                self.enqueue_from("track", &id, placement, cx, move |client| {
+                    Box::pin(async move { client.track(&track).await.map(|track| vec![track]) })
+                });
+            }
+            PinKind::Album => {
+                let album = id.clone();
+                self.enqueue_from("album", &id, placement, cx, move |client| {
+                    Box::pin(async move { client.album_tracks(&album).await })
+                });
+            }
+            PinKind::Playlist => {
+                let playlist = id.clone();
+                self.enqueue_from("playlist", &id, placement, cx, move |client| {
+                    Box::pin(async move { client.playlist_tracks(&playlist).await })
+                });
+            }
+            PinKind::Artist => {
+                let artist = id.clone();
+                self.enqueue_from("artist", &id, placement, cx, move |client| {
+                    Box::pin(
+                        async move { client.artist(&artist).await.map(|found| found.top_tracks) },
+                    )
+                });
+            }
+        }
+    }
+
     pub fn enqueue_album(&mut self, album: &str, cx: &mut Context<Self>) {
         let id = album.to_owned();
         let album = album.to_owned();
@@ -547,12 +604,9 @@ impl Playback {
                         match placement {
                             QueuePlacement::Next => this.play_next_all(tracks, cx),
                             QueuePlacement::End => this.enqueue_all(tracks, cx),
+                            QueuePlacement::Gap(gap) => this.insert_all(tracks, gap, cx),
                         }
-                        if queued {
-                            let key = match placement {
-                                QueuePlacement::Next => format!("toast-next-{source}"),
-                                QueuePlacement::End => format!("toast-queued-{source}"),
-                            };
+                        if queued && let Some(key) = placement.toast(source) {
                             Toasts::show(Outcome::Done, key, cx);
                         }
                     }

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -545,6 +545,22 @@ impl Playback {
         });
     }
 
+    pub fn play_artist_next(&mut self, artist: &str, cx: &mut Context<Self>) {
+        let id = artist.to_owned();
+        let artist = artist.to_owned();
+        self.enqueue_from("artist", &id, QueuePlacement::Next, cx, move |client| {
+            Box::pin(async move { client.artist(&artist).await.map(|found| found.top_tracks) })
+        });
+    }
+
+    pub fn enqueue_artist(&mut self, artist: &str, cx: &mut Context<Self>) {
+        let id = artist.to_owned();
+        let artist = artist.to_owned();
+        self.enqueue_from("artist", &id, QueuePlacement::End, cx, move |client| {
+            Box::pin(async move { client.artist(&artist).await.map(|found| found.top_tracks) })
+        });
+    }
+
     pub fn enqueue_playlist(&mut self, playlist: &str, cx: &mut Context<Self>) {
         let id = playlist.to_owned();
         let playlist = playlist.to_owned();

--- a/crates/state/src/queue.rs
+++ b/crates/state/src/queue.rs
@@ -494,7 +494,16 @@ impl Queue {
     }
 
     pub fn append_all(&mut self, tracks: impl IntoIterator<Item = Track>, cx: &mut Context<Self>) {
-        let at = self.queued();
+        self.insert_upcoming(self.queued(), tracks, cx);
+    }
+
+    pub fn insert_upcoming(
+        &mut self,
+        gap: usize,
+        tracks: impl IntoIterator<Item = Track>,
+        cx: &mut Context<Self>,
+    ) {
+        let at = gap.min(self.queued());
         for (offset, track) in tracks.into_iter().enumerate() {
             self.upcoming.insert(at + offset, track);
         }

--- a/crates/ui/src/drag.rs
+++ b/crates/ui/src/drag.rs
@@ -8,6 +8,7 @@ const CHIP: Pixels = px(240.);
 const NUDGE: Pixels = px(8.);
 const ART: Pixels = px(20.);
 const MARKER: Pixels = px(2.);
+const SLACK: Pixels = px(10.);
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Edge {
@@ -16,7 +17,8 @@ pub enum Edge {
 }
 
 pub fn drop_gap(bounds: Bounds<Pixels>, position: Point<Pixels>, index: usize) -> Option<usize> {
-    if !bounds.contains(&position) {
+    let slack = SLACK.min(bounds.size.height / 2.);
+    if !bounds.dilate(slack).contains(&position) {
         return None;
     }
 

--- a/crates/ui/src/inline_links.rs
+++ b/crates/ui/src/inline_links.rs
@@ -1,9 +1,7 @@
 use std::rc::Rc;
 
 use gpui::prelude::*;
-use gpui::{
-    App, Div, ElementId, Hsla, MouseButton, Pixels, SharedString, StyleRefinement, Window, div,
-};
+use gpui::{App, Div, ElementId, Hsla, Pixels, SharedString, StyleRefinement, Window, div};
 
 const RAMP: f32 = 6.;
 const DEPTH: usize = 5;
@@ -122,9 +120,11 @@ impl RenderOnce for InlineLinks {
                             let handler = on_click.clone();
                             item.hover(|style| style.underline())
                                 .cursor_pointer()
-                                .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
                                 .when_some(handler, |this, handler| {
-                                    this.on_click(move |_, _, cx| handler(value.clone(), cx))
+                                    this.on_click(move |_, _, cx| {
+                                        cx.stop_propagation();
+                                        handler(value.clone(), cx);
+                                    })
                                 })
                                 .child(label)
                         }

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -14,14 +14,15 @@ use state::{
     Sonora,
 };
 use ui::{
-    ActiveTheme as _, Button, Card, DraggedPin, Edge, Motion, Motioned as _, Pin, PinKind,
-    Pinnable as _, Popup, Scrollbar, Scroller, Spot, Text, drop_gap, drop_marker, ease_out_cubic,
-    eyebrow, mix, snapped, vacant,
+    ActiveTheme as _, Button, Card, DraggedPin, Edge, Motion, Motioned as _, Pin, Pinnable as _,
+    Popup, Scrollbar, Scroller, Spot, Text, drop_gap, drop_marker, ease_out_cubic, eyebrow, mix,
+    snapped, vacant,
 };
 
 use crate::chrome::{Chrome, section_label};
 use crate::shared::effects;
 use crate::shared::menu::ItemMenu;
+use crate::shared::pins::Pinned as _;
 
 const QUEUE: &str = "queue";
 const FADE: f32 = 96.;
@@ -377,6 +378,11 @@ impl Aside {
         }));
     }
 
+    fn enqueue(&mut self, pin: &Pin, gap: Option<usize>, cx: &mut Context<Self>) {
+        self.playback
+            .update(cx, |playback, cx| playback.enqueue_pin(pin, gap, cx));
+    }
+
     fn dismiss_menu(&mut self, cx: &mut Context<Self>) {
         self.track_menu.reset(cx);
         self.context_menu = None;
@@ -401,10 +407,7 @@ impl Aside {
             QueuePosition::Current => theme.primary,
             QueuePosition::Upcoming(_) | QueuePosition::Similar(_) => theme.foreground,
         };
-        let pin = track
-            .id
-            .clone()
-            .map(|id| Pin::new(PinKind::Song, id, track.name.clone()).cover(track.cover.clone()));
+        let pin = track.pin();
         let menu_track = track.clone();
 
         let card = Card::new(
@@ -484,10 +487,10 @@ impl Aside {
                     let Some(gap) = drop_gap(event.bounds, event.event.position, target) else {
                         return;
                     };
-                    let Some(held) = event.drag(cx).spot(QUEUE) else {
-                        return;
+                    let gap = match event.drag(cx).spot(QUEUE) {
+                        Some(held) => (gap != held.index && gap != held.index + 1).then_some(gap),
+                        None => Some(gap),
                     };
-                    let gap = (gap != held.index && gap != held.index + 1).then_some(gap);
                     if this.drop_gap != gap {
                         this.drop_gap = gap;
                         cx.notify();
@@ -495,16 +498,20 @@ impl Aside {
                 }),
             )
             .on_drop(cx.listener(move |this, dragged: &DraggedPin, _, cx| {
-                let Some(held) = dragged.spot(QUEUE) else {
-                    return;
-                };
-                if let Some(gap) = this.drop_gap.take() {
-                    this.queue.update(cx, |queue, cx| {
-                        if queue.revision() == held.revision {
-                            queue.move_upcoming_to_gap(held.index, gap, cx);
+                let gap = this.drop_gap.take();
+                match dragged.spot(QUEUE) {
+                    Some(held) => {
+                        if let Some(gap) = gap {
+                            this.queue.update(cx, |queue, cx| {
+                                if queue.revision() == held.revision {
+                                    queue.move_upcoming_to_gap(held.index, gap, cx);
+                                }
+                            });
                         }
-                    });
+                    }
+                    None => this.enqueue(&dragged.pin, gap, cx),
                 }
+                cx.notify();
             }))
         })
         .when_some(similar_index, |this, target| {
@@ -1181,11 +1188,21 @@ impl Render for Aside {
             .child(self.header(sections, cx))
             .child(
                 div()
+                    .id("queue-drop")
                     .relative()
                     .flex()
                     .flex_col()
                     .flex_1()
                     .min_h_0()
+                    .when(self.tab == SideTab::Queue, |this| {
+                        this.on_drop(cx.listener(|this, dragged: &DraggedPin, _, cx| {
+                            let gap = this.drop_gap.take();
+                            if dragged.spot(QUEUE).is_none() {
+                                this.enqueue(&dragged.pin, gap, cx);
+                            }
+                            cx.notify();
+                        }))
+                    })
                     .when(self.tab == SideTab::Lyrics, |this| {
                         this.child(self.verses(window, cx))
                     })

--- a/crates/views/src/chrome/player_bar.rs
+++ b/crates/views/src/chrome/player_bar.rs
@@ -257,6 +257,15 @@ impl PlayerBar {
                         track.as_ref().and_then(|track| track.album_id.clone()),
                         |this, album| this.link(Destination::Album(album.into())),
                     )
+                    .when_some(track.clone(), |this, context| {
+                        this.on_mouse_down(
+                            MouseButton::Right,
+                            cx.listener(move |this, event: &MouseDownEvent, window, cx| {
+                                window.prevent_default();
+                                this.open_context_menu(context.clone(), event.position, cx);
+                            }),
+                        )
+                    })
                     .child(Artwork::new(cover).size(artwork)),
             )
             .when(room, |this| {

--- a/crates/views/src/screens/artist.rs
+++ b/crates/views/src/screens/artist.rs
@@ -270,12 +270,12 @@ impl ArtistView {
                 let value = cells::count(count);
                 t!("artist-monthly-listeners", count = count, value = &value)
             });
-        let overflow = self.detail.read(cx).id().map(|id| {
+        let overflow = self.saved_artist(cx).map(|artist| {
             Picker::icon("artist-overflow", &self.popovers, "icons/ellipsis.svg")
                 .tooltip("common-more")
                 .large()
                 .left()
-                .menu(artist_menu(id.to_owned()))
+                .menu(artist_menu(artist, self.playback.clone(), true, cx))
         });
         let actions = div()
             .flex()
@@ -309,22 +309,26 @@ impl ArtistView {
             .into_any_element()
     }
 
-    fn follow_button(&self, cx: &App) -> Option<Button> {
-        let theme = *cx.theme();
-        let library = Sonora::global(cx).library.clone();
+    fn saved_artist(&self, cx: &App) -> Option<SavedArtist> {
         let detail = self.detail.read(cx);
-        let id = detail.id()?.to_owned();
-        if music::is_local_id(&id) {
-            return None;
-        }
         let artist = detail.artist()?;
-        let followed = library.read(cx).saved_artist(&id);
-        let target = SavedArtist {
-            id,
+
+        Some(SavedArtist {
+            id: detail.id()?.to_owned(),
             name: artist.name.clone(),
             cover: artist.cover_large.clone(),
             added_at: None,
-        };
+        })
+    }
+
+    fn follow_button(&self, cx: &App) -> Option<Button> {
+        let theme = *cx.theme();
+        let library = Sonora::global(cx).library.clone();
+        let target = self.saved_artist(cx)?;
+        if music::is_local_id(&target.id) {
+            return None;
+        }
+        let followed = library.read(cx).saved_artist(&target.id);
 
         let heart = Button::new("artist-toggle-library")
             .outline()

--- a/crates/views/src/screens/library/albums.rs
+++ b/crates/views/src/screens/library/albums.rs
@@ -8,10 +8,11 @@ use music::Album;
 use router::Destination;
 use state::{Library, LibraryState, Origin, Playback};
 use ui::rank::{HANDY, NICE, SPARE, USEFUL};
-use ui::{Cell, ColumnSpec, GridSource, Menu, Pin, PinKind, Width};
+use ui::{Cell, ColumnSpec, GridSource, Menu, Pin, Width};
 
 use crate::shared::cells::{self, DATE, NUMBER, TRAILING, YEAR};
 use crate::shared::menu::album_menu;
+use crate::shared::pins::Pinned as _;
 use crate::shared::text::{folded, holds};
 use crate::shared::tracks::initial;
 
@@ -224,12 +225,7 @@ impl GridSource for AlbumSource {
     }
 
     fn pin(&self, row: usize, cx: &App) -> Option<Pin> {
-        let album = self.albums(cx).get(row)?;
-
-        Some(
-            Pin::new(PinKind::Album, album.id.clone(), album.name.clone())
-                .cover(album.cover.clone()),
-        )
+        self.albums(cx).get(row)?.pin()
     }
 
     fn context_menu(&self, row: usize, _visible: &[AlbumField], cx: &App) -> Option<Menu> {

--- a/crates/views/src/screens/library/artists.rs
+++ b/crates/views/src/screens/library/artists.rs
@@ -6,10 +6,11 @@ use music::SavedArtist;
 use router::Destination;
 use state::{Library, LibraryState, Origin, Playback};
 use ui::rank::{ESSENTIAL, HANDY};
-use ui::{Cell, ColumnSpec, GridSource, Menu, Pin, PinKind, Width};
+use ui::{Cell, ColumnSpec, GridSource, Menu, Pin, Width};
 
 use crate::shared::cells::{self, DATE, NUMBER};
 use crate::shared::menu::artist_menu;
+use crate::shared::pins::Pinned as _;
 use crate::shared::text::{folded, holds};
 use crate::shared::tracks::initial;
 
@@ -107,12 +108,7 @@ impl GridSource for ArtistSource {
     }
 
     fn pin(&self, row: usize, cx: &App) -> Option<Pin> {
-        let artist = self.artists(cx).get(row)?;
-
-        Some(
-            Pin::new(PinKind::Artist, artist.id.clone(), artist.name.clone())
-                .cover(artist.cover.clone()),
-        )
+        self.artists(cx).get(row)?.pin()
     }
 
     fn context_menu(&self, row: usize, _visible: &[ArtistField], cx: &App) -> Option<Menu> {

--- a/crates/views/src/screens/library/artists.rs
+++ b/crates/views/src/screens/library/artists.rs
@@ -112,7 +112,12 @@ impl GridSource for ArtistSource {
     }
 
     fn context_menu(&self, row: usize, _visible: &[ArtistField], cx: &App) -> Option<Menu> {
-        Some(artist_menu(self.at(row, cx)?.id))
+        Some(artist_menu(
+            self.at(row, cx)?,
+            self.playback.clone(),
+            false,
+            cx,
+        ))
     }
 
     fn cell(&self, cell: Cell<ArtistField>, cx: &mut App) -> AnyElement {

--- a/crates/views/src/screens/library/mod.rs
+++ b/crates/views/src/screens/library/mod.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 
 use crate::chrome::tools::{self, Sift, Sliders};
 use crate::chrome::{Chrome, Searchable, Toolbar, Tooled};
-use crate::shared::menu::{album_menu, artist_menu, playlist_menu};
+use crate::shared::menu::Item;
 use crate::shared::playlist_editor::{Edit, PlaylistEditor};
 
 use gpui::prelude::*;
@@ -18,7 +18,7 @@ use gpui::{
     SharedString, WeakEntity, Window, div, point, px, relative,
 };
 use i18n::t;
-use music::{Album, Playlist, Track};
+use music::Track;
 use router::{Destination, LibraryTab, navigate};
 use state::{AppSettings, Library, LibraryPart, LibraryState, Playback, PlaybackState, Sonora};
 use ui::{
@@ -77,9 +77,8 @@ const RECENT: Sort = Sort::Descending;
 #[derive(Clone)]
 enum LibraryMenu {
     Background,
-    Album(Album),
-    Playlist(Playlist),
-    Artist(String),
+    Item(Item),
+    Track(Track),
 }
 
 #[derive(Clone)]
@@ -696,6 +695,8 @@ impl LibraryView {
         .truncate();
 
         let pin = track.pin();
+        let context = track.clone();
+        let view = self.me.clone();
 
         Some(
             Card::new(("library-track", display), SharedString::from(track.name))
@@ -707,6 +708,17 @@ impl LibraryView {
                 .underline()
                 .when(track.explicit, Card::explicit)
                 .bare_meta(artists)
+                .menu(move |event, _, cx| {
+                    let Some(view) = view.upgrade() else {
+                        return;
+                    };
+                    view.update(cx, |this, cx| {
+                        this.tracks.read(cx).delegate().source().menu().reset(cx);
+                        this.context_menu =
+                            Some((LibraryMenu::Track(context.clone()), event.position));
+                        cx.notify();
+                    });
+                })
                 .when(playable, move |card| {
                     card.play(playing, move |_, _, cx| match &state {
                         Some(PlaybackState::Playing) => {
@@ -740,7 +752,8 @@ impl LibraryView {
                     return;
                 };
                 view.update(cx, |this, cx| {
-                    this.context_menu = Some((LibraryMenu::Album(album.clone()), position));
+                    this.context_menu =
+                        Some((LibraryMenu::Item(Item::Album(album.clone())), position));
                     cx.notify();
                 });
             },
@@ -766,8 +779,10 @@ impl LibraryView {
                         return;
                     };
                     view.update(cx, |this, cx| {
-                        this.context_menu =
-                            Some((LibraryMenu::Playlist(playlist.clone()), event.position));
+                        this.context_menu = Some((
+                            LibraryMenu::Item(Item::Playlist(playlist.clone())),
+                            event.position,
+                        ));
                         cx.notify();
                     });
                 })
@@ -783,7 +798,7 @@ impl LibraryView {
         cx: &App,
     ) -> Option<AnyElement> {
         let artist = self.artists.read(cx).delegate().source().at(row, cx)?;
-        let context = artist.id.clone();
+        let context = artist.clone();
         let view = self.me.clone();
 
         Some(
@@ -795,8 +810,10 @@ impl LibraryView {
                         return;
                     };
                     view.update(cx, |this, cx| {
-                        this.context_menu =
-                            Some((LibraryMenu::Artist(context.clone()), event.position));
+                        this.context_menu = Some((
+                            LibraryMenu::Item(Item::Artist(context.clone())),
+                            event.position,
+                        ));
                         cx.notify();
                     });
                 })
@@ -823,11 +840,14 @@ impl Render for LibraryView {
 
         let context_menu = self.context_menu.clone().map(|(target, position)| {
             let menu = match target {
-                LibraryMenu::Album(album) => album_menu(album, self.playback.clone(), false, cx),
-                LibraryMenu::Playlist(playlist) => {
-                    playlist_menu(playlist, self.playback.clone(), false, cx)
-                }
-                LibraryMenu::Artist(id) => artist_menu(id),
+                LibraryMenu::Item(item) => item.menu(self.playback.clone(), false, cx),
+                LibraryMenu::Track(track) => self
+                    .tracks
+                    .read(cx)
+                    .delegate()
+                    .source()
+                    .menu()
+                    .for_track(&track, cx),
                 LibraryMenu::Background => Menu::new("playlist-background-menu").item(
                     MenuItem::new("create-playlist", t!("menu-new-playlist"))
                         .icon("icons/plus.svg")

--- a/crates/views/src/screens/library/mod.rs
+++ b/crates/views/src/screens/library/mod.rs
@@ -23,13 +23,14 @@ use router::{Destination, LibraryTab, navigate};
 use state::{AppSettings, Library, LibraryPart, LibraryState, Playback, PlaybackState, Sonora};
 use ui::{
     ActiveTheme as _, Button, Card, Deck, FlagAxis, GridDelegate, GridEvent, GridSource, GridState,
-    LEADING, Menu, MenuItem, Mode, Pin, PinKind, Pinnable, Popovers, Popup, RangeAxis, Scrollbar,
-    Scroller, Sort, SortAxis, Text, Toggle, Unit, Viewport, clock, grid, heading, quantize,
-    scrolled, snapped, vacant,
+    LEADING, Menu, MenuItem, Mode, Pinnable, Popovers, Popup, RangeAxis, Scrollbar, Scroller, Sort,
+    SortAxis, Text, Toggle, Unit, Viewport, clock, grid, heading, quantize, scrolled, snapped,
+    vacant,
 };
 
 use crate::shared::album_grid::{AlbumGrid, CardGrid};
 use crate::shared::hero::{HeroMetaStrip, HeroPlayButton, PageHero};
+use crate::shared::pins::Pinned as _;
 use crate::shared::tracks::{
     self, LIBRARY_COLUMNS, PlaybackStatus, TrackField, TrackSieve, TrackSource, Tracks,
     playback_status,
@@ -694,10 +695,7 @@ impl LibraryView {
         .text_size(theme.text(Text::Small))
         .truncate();
 
-        let pin = track
-            .id
-            .clone()
-            .map(|id| Pin::new(PinKind::Song, id, track.name.clone()).cover(track.cover.clone()));
+        let pin = track.pin();
 
         Some(
             Card::new(("library-track", display), SharedString::from(track.name))

--- a/crates/views/src/screens/library/playlists.rs
+++ b/crates/views/src/screens/library/playlists.rs
@@ -6,10 +6,11 @@ use music::Playlist;
 use router::Destination;
 use state::{Library, LibraryState, Origin, Playback};
 use ui::rank::{ESSENTIAL, HANDY, NICE, SPARE};
-use ui::{Cell, ColumnSpec, GridSource, Menu, Pin, PinKind, Width};
+use ui::{Cell, ColumnSpec, GridSource, Menu, Pin, Width};
 
 use crate::shared::cells::{self, DATE, NUMBER, TRAILING};
 use crate::shared::menu::playlist_menu;
+use crate::shared::pins::Pinned as _;
 use crate::shared::text::{folded, holds};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -130,16 +131,7 @@ impl GridSource for PlaylistSource {
     }
 
     fn pin(&self, row: usize, cx: &App) -> Option<Pin> {
-        let playlist = self.playlists(cx).get(row)?;
-
-        Some(
-            Pin::new(
-                PinKind::Playlist,
-                playlist.id.clone(),
-                playlist.name.clone(),
-            )
-            .cover(playlist.cover.clone()),
-        )
+        self.playlists(cx).get(row)?.pin()
     }
 
     fn context_menu(&self, row: usize, _visible: &[PlaylistField], cx: &App) -> Option<Menu> {

--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -13,11 +13,12 @@ use crate::shared::menu::{ItemMenu, item_menu};
 use state::{Genres, Hit, Kind, Playback, Search};
 use ui::ActiveTheme as _;
 use ui::{
-    Card, Deck, Pin, PinKind, Pinnable, Popup, Room, Scrollbar, Scroller, Separator, Text, Theme,
-    VAST, Viewport, clock, eyebrow, scrolled, snapped, vacant,
+    Card, Deck, Pin, Pinnable, Popup, Room, Scrollbar, Scroller, Separator, Text, Theme, VAST,
+    Viewport, clock, eyebrow, scrolled, snapped, vacant,
 };
 
 use crate::shared::cells;
+use crate::shared::pins::Pinned as _;
 use crate::shared::shelves;
 
 const RAIL: Pixels = gpui::px(12.);
@@ -44,7 +45,7 @@ impl HitMenu {
     fn of(hit: &Hit) -> Option<Self> {
         match hit {
             Hit::Song(track) => Some(Self::Song(Box::new(track.clone()))),
-            Hit::Artist(_) | Hit::Album(_) | Hit::Playlist(_) => pin(hit).map(Self::Item),
+            Hit::Artist(_) | Hit::Album(_) | Hit::Playlist(_) => hit.pin().map(Self::Item),
         }
     }
 }
@@ -284,7 +285,7 @@ impl SearchView {
             }
         };
 
-        card.when_some(pin(hit), Pinnable::pin)
+        card.when_some(hit.pin(), Pinnable::pin)
             .when_some(HitMenu::of(hit), |card, target| card.menu(menu(target, me)))
             .into_any_element()
     }
@@ -341,7 +342,7 @@ impl SearchView {
             .gap_4()
             .p_3()
             .bg(theme.secondary)
-            .when_some(pin(hit), Pinnable::pin)
+            .when_some(hit.pin(), Pinnable::pin)
             .when_some(target, |card, target| card.press(pressed(target, &me)))
             .when_some(HitMenu::of(hit), |card, target| {
                 card.on_mouse_down(MouseButton::Right, menu(target, &me))
@@ -576,17 +577,6 @@ fn cover(hit: &Hit) -> Option<String> {
         Hit::Album(album) => album.cover.clone(),
         Hit::Playlist(list) => list.cover.clone(),
     }
-}
-
-fn pin(hit: &Hit) -> Option<Pin> {
-    let (kind, id, name) = match hit {
-        Hit::Song(track) => (PinKind::Song, track.id.clone()?, track.name.clone()),
-        Hit::Artist(artist) => (PinKind::Artist, artist.id.clone()?, artist.name.clone()),
-        Hit::Album(album) => (PinKind::Album, album.id.clone(), album.name.clone()),
-        Hit::Playlist(list) => (PinKind::Playlist, list.id.clone(), list.name.clone()),
-    };
-
-    Some(Pin::new(kind, id, name).cover(cover(hit)))
 }
 
 fn meta(hit: &Hit, compact: bool) -> SharedString {

--- a/crates/views/src/screens/song.rs
+++ b/crates/views/src/screens/song.rs
@@ -7,13 +7,14 @@ use music::{Credit, Track};
 use router::{Destination, Link as _};
 use state::{Playback, SongDetail};
 use ui::{
-    ActiveTheme as _, Avatar, Button, Fact, InfoCard, Initials, Pin, PinKind, Scrollbar, Scroller,
-    Skeleton, Text, clock,
+    ActiveTheme as _, Avatar, Button, Fact, InfoCard, Initials, Scrollbar, Scroller, Skeleton,
+    Text, clock,
 };
 
 use crate::shared::about::{AboutArtist, about_modal};
 use crate::shared::cells;
 use crate::shared::hero::{HeroMetaStrip, HeroPlayButton, PageHero, release_date_label};
+use crate::shared::pins::Pinned as _;
 
 const PANEL: Pixels = px(300.);
 const TITLE_SKELETON: Pixels = px(240.);
@@ -120,10 +121,7 @@ impl SongView {
                 )
             });
 
-        let pin = track
-            .id
-            .clone()
-            .map(|id| Pin::new(PinKind::Song, id, track.name.clone()).cover(cover.clone()));
+        let pin = track.pin().map(|pin| pin.cover(cover.clone()));
 
         PageHero::new("song-hero", track.name.clone())
             .pin(pin)

--- a/crates/views/src/screens/song.rs
+++ b/crates/views/src/screens/song.rs
@@ -1,19 +1,21 @@
 use gpui::prelude::*;
 use gpui::{
-    AnyElement, Context, Entity, FontWeight, Pixels, Render, SharedString, Window, div, px,
+    AnyElement, Context, Entity, FontWeight, Pixels, Point, Render, SharedString, WeakEntity,
+    Window, div, px,
 };
 use i18n::t;
 use music::{Credit, Track};
 use router::{Destination, Link as _};
 use state::{Playback, SongDetail};
 use ui::{
-    ActiveTheme as _, Avatar, Button, Fact, InfoCard, Initials, Scrollbar, Scroller, Skeleton,
-    Text, clock,
+    ActiveTheme as _, Avatar, Button, Fact, InfoCard, Initials, Popup, Scrollbar, Scroller,
+    Skeleton, Text, clock,
 };
 
 use crate::shared::about::{AboutArtist, about_modal};
 use crate::shared::cells;
 use crate::shared::hero::{HeroMetaStrip, HeroPlayButton, PageHero, release_date_label};
+use crate::shared::menu::ItemMenu;
 use crate::shared::pins::Pinned as _;
 
 const PANEL: Pixels = px(300.);
@@ -28,6 +30,9 @@ pub(crate) struct SongView {
     scrollbar: Entity<Scrollbar>,
     about_bar: Entity<Scrollbar>,
     about_open: bool,
+    track_menu: ItemMenu,
+    context_menu: Option<Point<Pixels>>,
+    me: WeakEntity<Self>,
 }
 
 impl SongView {
@@ -67,12 +72,17 @@ impl SongView {
         })
         .detach();
         cx.observe(&playback, |_, _, cx| cx.notify()).detach();
+        let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+
         Self {
             detail,
             playback,
             scrollbar: cx.new(|_| Scrollbar::new(gpui::ScrollHandle::new())),
             about_bar: cx.new(|_| Scrollbar::new(gpui::ScrollHandle::new())),
             about_open: false,
+            track_menu: ItemMenu::new(playlist_scrollbar),
+            context_menu: None,
+            me: cx.weak_entity(),
         }
     }
 
@@ -122,6 +132,7 @@ impl SongView {
             });
 
         let pin = track.pin().map(|pin| pin.cover(cover.clone()));
+        let view = self.me.clone();
 
         PageHero::new("song-hero", track.name.clone())
             .pin(pin)
@@ -130,7 +141,30 @@ impl SongView {
             .meta(meta)
             .actions(actions)
             .explicit(track.explicit)
+            .drag_start(move |event, window, cx| {
+                window.prevent_default();
+                view.update(cx, |this, cx| {
+                    this.track_menu.reset(cx);
+                    this.context_menu = Some(event.position);
+                    cx.notify();
+                })
+                .ok();
+            })
             .into_any_element()
+    }
+
+    fn menu(&self, cx: &mut Context<Self>) -> Option<Popup> {
+        let position = self.context_menu?;
+        let track = self.detail.read(cx).track().cloned()?;
+
+        Some(
+            Popup::new(position, self.track_menu.for_track(&track, cx)).on_close(cx.listener(
+                |this, _, _, cx| {
+                    this.context_menu = None;
+                    cx.notify();
+                },
+            )),
+        )
     }
 
     fn overview(&self, track: &Track, cx: &Context<Self>) -> AnyElement {
@@ -520,6 +554,7 @@ impl Render for SongView {
                             )
                     }),
             )
+            .children(self.menu(cx))
             .children(self.about_dialog(cx))
     }
 }

--- a/crates/views/src/shared/cards.rs
+++ b/crates/views/src/shared/cards.rs
@@ -1,10 +1,12 @@
+use gpui::prelude::FluentBuilder as _;
 use gpui::{App, ElementId, Entity, FontWeight, SharedString};
 use music::{Album, Playlist, SavedArtist};
 use router::{Destination, navigate};
 use state::{Origin, Playback, PlaybackState};
-use ui::{ActiveTheme as _, Card, Pin, PinKind, Pinnable as _, Text};
+use ui::{ActiveTheme as _, Card, Pinnable, Text};
 
 use crate::shared::cells;
+use crate::shared::pins::Pinned as _;
 
 pub(crate) fn album_card(
     id: impl Into<ElementId>,
@@ -19,7 +21,7 @@ pub(crate) fn album_card(
         playback.read(cx).playing_from(&origin),
         Some(PlaybackState::Playing)
     );
-    let pin = Pin::new(PinKind::Album, album.id.clone(), album.name.clone()).cover(cover.clone());
+    let pin = album.pin();
     let opened = SharedString::from(album.id.clone());
     let toggled = playback.clone();
     let artists = cells::artist_links(
@@ -40,7 +42,7 @@ pub(crate) fn album_card(
             toggled.update(cx, |playback, cx| playback.toggle_origin(&origin, cx));
         })
         .press(move |_, _, cx| navigate(Destination::Album(opened.clone()), cx))
-        .pin(pin)
+        .when_some(pin, Pinnable::pin)
 }
 
 pub(crate) fn playlist_card(
@@ -54,12 +56,7 @@ pub(crate) fn playlist_card(
         playback.read(cx).playing_from(&origin),
         Some(PlaybackState::Playing)
     );
-    let pin = Pin::new(
-        PinKind::Playlist,
-        playlist.id.clone(),
-        playlist.name.clone(),
-    )
-    .cover(playlist.cover.clone());
+    let pin = playlist.pin();
     let opened = SharedString::from(playlist.id.clone());
     let toggled = playback.clone();
 
@@ -72,12 +69,11 @@ pub(crate) fn playlist_card(
             toggled.update(cx, |playback, cx| playback.toggle_origin(&origin, cx));
         })
         .press(move |_, _, cx| navigate(Destination::Playlist(opened.clone()), cx))
-        .pin(pin)
+        .when_some(pin, Pinnable::pin)
 }
 
 pub(crate) fn artist_card(id: impl Into<ElementId>, artist: &SavedArtist) -> Card {
-    let pin = Pin::new(PinKind::Artist, artist.id.clone(), artist.name.clone())
-        .cover(artist.cover.clone());
+    let pin = artist.pin();
     let opened = SharedString::from(artist.id.clone());
 
     Card::new(id, SharedString::from(artist.name.clone()))
@@ -87,5 +83,5 @@ pub(crate) fn artist_card(id: impl Into<ElementId>, artist: &SavedArtist) -> Car
         .underline()
         .meta(i18n::lookup("artist-eyebrow", None))
         .press(move |_, _, cx| navigate(Destination::Artist(opened.clone()), cx))
-        .pin(pin)
+        .when_some(pin, Pinnable::pin)
 }

--- a/crates/views/src/shared/menu.rs
+++ b/crates/views/src/shared/menu.rs
@@ -1,11 +1,28 @@
 use gpui::{App, ClipboardItem, Entity, Styled as _};
 use i18n::t;
-use music::{Album, MediaKind, Playlist, Track};
+use music::{Album, MediaKind, Playlist, SavedArtist, Track};
 use router::{Destination, navigate};
 use state::{Detail, LibraryState, Playback, Sonora};
 use ui::{Menu, MenuItem, Pin, PinKind, Scrollbar, SubmenuState};
 
 use crate::shared::playlist_editor::{Edit, PlaylistEditor};
+
+#[derive(Clone)]
+pub(crate) enum Item {
+    Album(Album),
+    Playlist(Playlist),
+    Artist(SavedArtist),
+}
+
+impl Item {
+    pub(crate) fn menu(&self, playback: Entity<Playback>, opened_here: bool, cx: &App) -> Menu {
+        match self {
+            Self::Album(album) => album_menu(album.clone(), playback, opened_here, cx),
+            Self::Playlist(playlist) => playlist_menu(playlist.clone(), playback, opened_here, cx),
+            Self::Artist(artist) => artist_menu(artist.clone(), playback, opened_here, cx),
+        }
+    }
+}
 
 #[derive(Clone, Copy, Default)]
 pub(crate) struct TrackColumns {
@@ -400,12 +417,86 @@ fn album_library_item(album: Album, cx: &App) -> MenuItem {
     }
 }
 
-pub(crate) fn artist_menu(artist_id: String) -> Menu {
-    Menu::new("artist-context-menu").item(
-        MenuItem::new("copy-artist-link", t!("menu-copy-link"))
-            .icon("icons/link.svg")
-            .on_click(move |_, _, cx| copy_link(MediaKind::Artist, &artist_id, cx)),
+pub(crate) fn artist_menu(
+    artist: SavedArtist,
+    playback: Entity<Playback>,
+    opened_here: bool,
+    cx: &App,
+) -> Menu {
+    let artist_id = artist.id.clone();
+    let opened = artist_id.clone();
+    let played = artist_id.clone();
+    let next = artist_id.clone();
+    let queued = artist_id.clone();
+    let copied = artist_id.clone();
+    let playing = playback.clone();
+    let nexting = playback.clone();
+    let queueing = playback;
+
+    let open = match opened_here {
+        true => Vec::new(),
+        false => vec![
+            MenuItem::new("open-artist", t!("menu-go-to-artist"))
+                .icon("icons/info.svg")
+                .on_click(move |_, _, cx| navigate(Destination::Artist(opened.clone().into()), cx)),
+        ],
+    };
+
+    sections(
+        Menu::new("artist-context-menu"),
+        vec![
+            open,
+            vec![
+                MenuItem::new("play-artist", t!("menu-play-artist"))
+                    .icon("icons/play.svg")
+                    .on_click(move |_, _, cx| {
+                        playing.update(cx, |playback, cx| playback.play_artist(&played, cx));
+                    }),
+                MenuItem::new("play-artist-next", t!("menu-play-next"))
+                    .icon("icons/list-plus.svg")
+                    .on_click(move |_, _, cx| {
+                        nexting.update(cx, |playback, cx| playback.play_artist_next(&next, cx));
+                    }),
+                MenuItem::new("enqueue-artist", t!("menu-add-artist-to-queue"))
+                    .icon("icons/list-end.svg")
+                    .on_click(move |_, _, cx| {
+                        queueing.update(cx, |playback, cx| playback.enqueue_artist(&queued, cx));
+                    }),
+            ],
+            artist_library_item(artist, cx).into_iter().collect(),
+            vec![
+                MenuItem::new("copy-artist-link", t!("menu-copy-link"))
+                    .icon("icons/link.svg")
+                    .on_click(move |_, _, cx| copy_link(MediaKind::Artist, &copied, cx)),
+            ],
+        ],
     )
+}
+
+fn artist_library_item(artist: SavedArtist, cx: &App) -> Option<MenuItem> {
+    if music::is_local_id(&artist.id) {
+        return None;
+    }
+    let library = Sonora::global(cx).library.clone();
+    let followed = library.read(cx).saved_artist(&artist.id);
+    let item = MenuItem::new(
+        "toggle-artist-library",
+        match followed {
+            true => t!("artist-unfollow"),
+            false => t!("artist-follow"),
+        },
+    )
+    .icon(match followed {
+        true => "icons/heart-off.svg",
+        false => "icons/heart.svg",
+    });
+
+    Some(match library.read(cx).pending_artist(&artist.id) {
+        true => item.disabled(),
+        false => item.on_click(move |_, _, cx| {
+            library.update(cx, |library, cx| library.toggle_artist(artist.clone(), cx));
+        }),
+    })
 }
 
 pub(crate) fn playlist_menu(
@@ -526,11 +617,29 @@ pub(crate) fn item_menu(
             .playlist(&pin.id)
             .cloned()
             .map(|playlist| playlist_menu(playlist, playback.clone(), false, cx)),
-        PinKind::Artist => Some(artist_menu(pin.id.clone())),
+        PinKind::Artist => Some(artist_menu(
+            library
+                .read(cx)
+                .artist(&pin.id)
+                .cloned()
+                .unwrap_or_else(|| pinned_artist(pin)),
+            playback.clone(),
+            false,
+            cx,
+        )),
         PinKind::Song => saved_track(&pin.id, cx).map(|track| tracks.for_track(&track, cx)),
     };
 
     built.unwrap_or_else(|| sparse_menu(pin, playback))
+}
+
+pub(crate) fn pinned_artist(pin: &Pin) -> SavedArtist {
+    SavedArtist {
+        id: pin.id.clone(),
+        name: pin.title.clone(),
+        cover: pin.cover.clone(),
+        added_at: None,
+    }
 }
 
 fn sparse_menu(pin: &Pin, playback: Entity<Playback>) -> Menu {
@@ -607,10 +716,20 @@ fn transport_items(pin: &Pin, playback: Entity<Playback>) -> Vec<MenuItem> {
                 }),
         ],
         PinKind::Artist => vec![
-            MenuItem::new("play-pin", t!("common-play"))
+            MenuItem::new("play-pin", t!("menu-play-artist"))
                 .icon("icons/play.svg")
                 .on_click(move |_, _, cx| {
                     playback.update(cx, |playback, cx| playback.play_artist(&played, cx));
+                }),
+            MenuItem::new("play-pin-next", t!("menu-play-next"))
+                .icon("icons/list-plus.svg")
+                .on_click(move |_, _, cx| {
+                    nexting.update(cx, |playback, cx| playback.play_artist_next(&next, cx));
+                }),
+            MenuItem::new("enqueue-pin", t!("menu-add-artist-to-queue"))
+                .icon("icons/list-end.svg")
+                .on_click(move |_, _, cx| {
+                    queueing.update(cx, |playback, cx| playback.enqueue_artist(&queued, cx));
                 }),
         ],
         PinKind::Song => vec![

--- a/crates/views/src/shared/mod.rs
+++ b/crates/views/src/shared/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod hero;
 pub(crate) mod menu;
 pub(crate) mod page;
 pub(crate) mod picks;
+pub(crate) mod pins;
 pub(crate) mod playlist_editor;
 pub(crate) mod shelves;
 pub(crate) mod text;

--- a/crates/views/src/shared/picks.rs
+++ b/crates/views/src/shared/picks.rs
@@ -5,11 +5,11 @@ use gpui::{App, ClickEvent, Entity, MouseDownEvent, Pixels, SharedString, Window
 use music::Track;
 use state::{Playback, PlaybackState};
 use ui::{
-    ActiveTheme as _, Button, Card, Pin, PinKind, Pinnable, Text, clock, eyebrow, heading, snapped,
-    vacant,
+    ActiveTheme as _, Button, Card, Pinnable, Text, clock, eyebrow, heading, snapped, vacant,
 };
 
 use crate::shared::cells;
+use crate::shared::pins::Pinned as _;
 
 const ROWS: usize = 5;
 const MAX_COLUMNS: usize = 3;
@@ -297,10 +297,7 @@ fn pick(
         false => theme.foreground,
     };
     let playing = current && playback.read(cx).state() == &PlaybackState::Playing;
-    let pin = track
-        .id
-        .clone()
-        .map(|id| Pin::new(PinKind::Song, id, track.name.clone()).cover(track.cover.clone()));
+    let pin = track.pin();
     let pressed = {
         let tracks = tracks.clone();
         let playback = playback.clone();

--- a/crates/views/src/shared/pins.rs
+++ b/crates/views/src/shared/pins.rs
@@ -1,0 +1,68 @@
+use music::{Album, Playlist, SavedArtist, Track};
+use state::Hit;
+use ui::{Pin, PinKind};
+
+pub(crate) trait Pinned {
+    fn pin(&self) -> Option<Pin>;
+}
+
+impl Pinned for Track {
+    fn pin(&self) -> Option<Pin> {
+        let id = self.id.clone()?;
+
+        Some(Pin::new(PinKind::Song, id, self.name.clone()).cover(self.cover.clone()))
+    }
+}
+
+impl Pinned for Album {
+    fn pin(&self) -> Option<Pin> {
+        let cover = self.cover_large.clone().or_else(|| self.cover.clone());
+
+        Some(Pin::new(PinKind::Album, self.id.clone(), self.name.clone()).cover(cover))
+    }
+}
+
+impl Pinned for Playlist {
+    fn pin(&self) -> Option<Pin> {
+        Some(
+            Pin::new(PinKind::Playlist, self.id.clone(), self.name.clone())
+                .cover(self.cover.clone()),
+        )
+    }
+}
+
+impl Pinned for SavedArtist {
+    fn pin(&self) -> Option<Pin> {
+        Some(
+            Pin::new(PinKind::Artist, self.id.clone(), self.name.clone()).cover(self.cover.clone()),
+        )
+    }
+}
+
+impl Pinned for Hit {
+    fn pin(&self) -> Option<Pin> {
+        let (kind, id, name, cover) = match self {
+            Self::Song(track) => return track.pin(),
+            Self::Artist(artist) => (
+                PinKind::Artist,
+                artist.id.clone()?,
+                artist.name.clone(),
+                artist.cover.clone(),
+            ),
+            Self::Album(album) => (
+                PinKind::Album,
+                album.id.clone(),
+                album.name.clone(),
+                album.cover.clone(),
+            ),
+            Self::Playlist(playlist) => (
+                PinKind::Playlist,
+                playlist.id.clone(),
+                playlist.name.clone(),
+                playlist.cover.clone(),
+            ),
+        };
+
+        Some(Pin::new(kind, id, name).cover(cover))
+    }
+}

--- a/crates/views/src/shared/shelves.rs
+++ b/crates/views/src/shared/shelves.rs
@@ -1,7 +1,7 @@
 use gpui::prelude::*;
 use gpui::{
-    AnyElement, App, Context, Div, ElementId, Entity, FontWeight, Pixels, ScrollHandle,
-    ScrollWheelEvent, SharedString, WeakEntity, Window, div, point, px,
+    AnyElement, App, Context, Div, ElementId, Entity, FontWeight, MouseDownEvent, Pixels, Point,
+    ScrollHandle, ScrollWheelEvent, SharedString, WeakEntity, Window, div, point, px,
 };
 use std::cell::Cell;
 use std::rc::Rc;
@@ -10,11 +10,13 @@ use music::{Album, GenreItem, GenreSection, Playlist};
 use router::{Destination, navigate};
 use state::Playback;
 use ui::{
-    ActiveTheme as _, Button, Card, Deck, Glide, Mode, Skeleton, Text, Viewport, heading, snapped,
+    ActiveTheme as _, Button, Card, Deck, Glide, Mode, Popup, Skeleton, Text, Viewport, heading,
+    snapped,
 };
 
 use crate::shared::album_grid::CardGrid;
 use crate::shared::cards;
+use crate::shared::menu::Item;
 
 const PLATE: Pixels = px(260.);
 const LANES: usize = 5;
@@ -35,6 +37,7 @@ pub(crate) struct Shelves {
     playback: Entity<Playback>,
     rails: Vec<Rail>,
     above: Rc<Cell<Option<Pixels>>>,
+    context_menu: Option<(Item, Point<Pixels>)>,
 }
 
 impl Shelves {
@@ -44,6 +47,7 @@ impl Shelves {
             playback,
             rails: Vec::new(),
             above: Rc::new(Cell::new(None)),
+            context_menu: None,
         }
     }
 
@@ -80,6 +84,20 @@ impl Shelves {
 
     pub(crate) fn reset(&mut self) {
         self.rails.clear();
+        self.context_menu = None;
+    }
+
+    fn popup(&self, cx: &mut Context<Self>) -> Option<Popup> {
+        let (item, at) = self.context_menu.clone()?;
+
+        Some(
+            Popup::new(at, item.menu(self.playback.clone(), false, cx)).on_close(cx.listener(
+                |this, _, _, cx| {
+                    this.context_menu = None;
+                    cx.notify();
+                },
+            )),
+        )
     }
 
     pub(crate) fn render(
@@ -105,7 +123,7 @@ impl Shelves {
         let me = cx.entity().downgrade();
         let above = self.above.clone();
 
-        Deck::new(self.tag("stack", 0))
+        let stack = Deck::new(self.tag("stack", 0))
             .viewport(viewport)
             .rows(heights)
             .gap(STACK_GAP)
@@ -117,15 +135,20 @@ impl Shelves {
                 let Some(section) = sections.get(place) else {
                     return div().into_any_element();
                 };
+                let holder = view.downgrade();
                 let shelves = view.read(cx);
 
                 match mode {
-                    Mode::Cards => {
-                        shelves.rail(place, &sections, width, &view.downgrade(), window, cx)
-                    }
-                    Mode::List => shelves.lane(place, section, width, window, cx),
+                    Mode::Cards => shelves.rail(place, &sections, width, &holder, window, cx),
+                    Mode::List => shelves.lane(place, section, width, &holder, window, cx),
                 }
-            })
+            });
+
+        div()
+            .relative()
+            .w_full()
+            .child(stack)
+            .children(self.popup(cx))
             .into_any_element()
     }
 
@@ -168,6 +191,7 @@ impl Shelves {
         place: usize,
         section: &GenreSection,
         width: Pixels,
+        me: &WeakEntity<Self>,
         window: &Window,
         cx: &App,
     ) -> AnyElement {
@@ -177,7 +201,7 @@ impl Shelves {
             .iter()
             .take(lanes * ROWS)
             .enumerate()
-            .map(|(index, item)| self.card(place * 100 + index, item, None, cx))
+            .map(|(index, item)| self.card(place * 100 + index, item, None, me, cx))
             .collect();
 
         div()
@@ -273,8 +297,14 @@ impl Shelves {
                                     return div().into_any_element();
                                 };
 
-                                view.read(cx)
-                                    .card(place * 100 + index, item, Some(card), cx)
+                                let holder = view.downgrade();
+                                view.read(cx).card(
+                                    place * 100 + index,
+                                    item,
+                                    Some(card),
+                                    &holder,
+                                    cx,
+                                )
                             }),
                     ),
             )
@@ -336,10 +366,17 @@ impl Shelves {
             })
     }
 
-    fn card(&self, id: usize, item: &GenreItem, tile: Option<Pixels>, cx: &App) -> AnyElement {
+    fn card(
+        &self,
+        id: usize,
+        item: &GenreItem,
+        tile: Option<Pixels>,
+        me: &WeakEntity<Self>,
+        cx: &App,
+    ) -> AnyElement {
         match item {
-            GenreItem::Playlist(playlist) => self.playlist_card(id, playlist, tile, cx),
-            GenreItem::Album(album) => self.album_card(id, album, tile, cx),
+            GenreItem::Playlist(playlist) => self.playlist_card(id, playlist, tile, me, cx),
+            GenreItem::Album(album) => self.album_card(id, album, tile, me, cx),
             GenreItem::Genre(genre) => plate(slot("genre", id), genre, tile, cx),
         }
     }
@@ -349,17 +386,43 @@ impl Shelves {
         id: usize,
         playlist: &Playlist,
         tile: Option<Pixels>,
+        me: &WeakEntity<Self>,
         cx: &App,
     ) -> AnyElement {
         cards::playlist_card(slot("playlist", id), playlist, &self.playback, cx)
             .map(|card| dressed(card, tile, cx))
+            .menu(opener(me, Item::Playlist(playlist.clone())))
             .into_any_element()
     }
 
-    fn album_card(&self, id: usize, album: &Album, tile: Option<Pixels>, cx: &App) -> AnyElement {
+    fn album_card(
+        &self,
+        id: usize,
+        album: &Album,
+        tile: Option<Pixels>,
+        me: &WeakEntity<Self>,
+        cx: &App,
+    ) -> AnyElement {
         cards::album_card(slot("album", id), album, &self.playback, cx)
             .map(|card| dressed(card, tile, cx))
+            .menu(opener(me, Item::Album(album.clone())))
             .into_any_element()
+    }
+}
+
+fn opener(
+    me: &WeakEntity<Shelves>,
+    item: Item,
+) -> impl Fn(&MouseDownEvent, &mut Window, &mut App) + 'static {
+    let me = me.clone();
+
+    move |event: &MouseDownEvent, _: &mut Window, cx: &mut App| {
+        let at = event.position;
+        me.update(cx, |this, cx| {
+            this.context_menu = Some((item.clone(), at));
+            cx.notify();
+        })
+        .ok();
     }
 }
 

--- a/crates/views/src/shared/tracks/mod.rs
+++ b/crates/views/src/shared/tracks/mod.rs
@@ -17,13 +17,11 @@ use jiff::Timestamp;
 use music::Track;
 use router::Destination;
 use state::{Detail, Library, Playback, PlaybackState, Sonora};
-use ui::{
-    Button, Cell, ColumnSpec, GridSource, GridState, Menu, Pin, PinKind, ROW_GROUP, Scrollbar,
-    clock,
-};
+use ui::{Button, Cell, ColumnSpec, GridSource, GridState, Menu, Pin, ROW_GROUP, Scrollbar, clock};
 
 use crate::shared::cells;
 use crate::shared::hero::release_date_label;
+use crate::shared::pins::Pinned as _;
 
 pub(crate) use columns::{LIBRARY_COLUMNS, TrackField, album_columns, artist_columns};
 pub(crate) use sieve::TrackSieve;
@@ -348,10 +346,7 @@ impl GridSource for TrackSource {
     }
 
     fn pin(&self, row: usize, cx: &App) -> Option<Pin> {
-        let track = self.provider.tracks(cx).get(row)?;
-        let id = track.id.clone()?;
-
-        Some(Pin::new(PinKind::Song, id, track.name.clone()).cover(track.cover.clone()))
+        self.provider.tracks(cx).get(row)?.pin()
     }
 
     fn cell(&self, cell: Cell<TrackField>, cx: &mut App) -> AnyElement {

--- a/crates/views/src/shared/tracks/mod.rs
+++ b/crates/views/src/shared/tracks/mod.rs
@@ -293,6 +293,10 @@ impl TrackSource {
     pub(crate) fn at(&self, row: usize, cx: &App) -> Option<Track> {
         self.provider.tracks(cx).get(row).cloned()
     }
+
+    pub(crate) fn menu(&self) -> &ItemMenu {
+        &self.menu
+    }
 }
 
 impl GridSource for TrackSource {


### PR DESCRIPTION
## Summary

- let a list row be dragged by its name, not just by its cover
- drop a song, album, playlist or artist straight onto the queue, at the gap it was dropped in
- insert into the gap between two pinned items or two queued songs instead of appending
- define each model's drag pin once instead of at every render site
- give artists play, play next, add to queue and follow, wherever they appear
- add the context menus that shelf cards, library track cards, the song page and the player artwork were missing
- build every album, playlist and artist menu from one shared item
