### PR TITLE
fix(music): open the audio output at the device default format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Spotify playback on Windows no longer hisses in the background, which was loudest at low volume.
+  Sonora asked the output device for a stream it could not give and settled for the poorest sample
+  format on offer instead of the one the device already runs at, so every track was played through
+  a needlessly coarse output. It now opens the device at its own format, the way YouTube and
+  imported tracks always have.
 - Rows in the list view of Albums, Playlists and Artists can be dragged by their name. The name
   column swallowed the press, so the only place a row could be picked up from was its cover.
 - Dropping something in the space between two pinned items in the sidebar, or between two queued

--- a/crates/music/src/audio.rs
+++ b/crates/music/src/audio.rs
@@ -26,12 +26,6 @@ impl Volume {
     }
 }
 
-pub struct Wanted {
-    pub channels: u16,
-    pub sample_rate: u32,
-    pub format: Box<dyn FnOnce(cpal::SampleFormat) -> cpal::SampleFormat>,
-}
-
 pub struct Output {
     sink: Arc<rodio::Sink>,
     volume: Volume,
@@ -39,40 +33,28 @@ pub struct Output {
 }
 
 impl Output {
-    pub fn open(volume: Volume, wanted: Option<Wanted>) -> Result<Self> {
+    pub fn open(volume: Volume) -> Result<Self> {
         let host = cpal::default_host();
         let device = host
             .default_output_device()
             .context("no audio output device")?;
 
-        log::info!(
-            "sink: using {}",
-            device.name().unwrap_or_else(|_| "unknown".to_owned())
-        );
-
         let default = device
             .default_output_config()
             .map_err(|error| anyhow::anyhow!("cannot read the output config: {error}"))?;
-        let (config, format) = match wanted {
-            Some(wanted) => {
-                let config = device
-                    .supported_output_configs()
-                    .map_err(|error| anyhow::anyhow!("cannot list the output configs: {error}"))?
-                    .find(|config| config.channels() == wanted.channels)
-                    .and_then(|config| {
-                        config
-                            .try_with_sample_rate(cpal::SampleRate(wanted.sample_rate))
-                            .or_else(|| config.try_with_sample_rate(default.sample_rate()))
-                    })
-                    .unwrap_or(default);
-                let format = (wanted.format)(config.sample_format());
-                (config.config(), format)
-            }
-            None => (default.config(), default.sample_format()),
-        };
+
+        log::info!(
+            "sink: using {} at {} Hz, {} channels, {}",
+            device.name().unwrap_or_else(|_| "unknown".to_owned()),
+            default.sample_rate().0,
+            default.channels(),
+            default.sample_format()
+        );
+
+        let format = default.sample_format();
         let builder = OutputStreamBuilder::default()
             .with_device(device)
-            .with_config(&config)
+            .with_config(&default.config())
             .with_sample_format(format);
         let mut stream = builder
             .open_stream()
@@ -109,31 +91,43 @@ pub struct SmoothGain<I> {
     target: f32,
     step: f32,
 
+    ramp: Duration,
     frames_left: u32,
     ramp_frames: u32,
 
     channel: u16,
     channels: u16,
+    rate: u32,
 }
 
 impl<I: Source> SmoothGain<I> {
-    pub fn new(input: I, volume: Volume, initial: f32, duration: Duration) -> Self {
-        let channels = input.channels();
-        let ramp_frames = (duration.as_secs_f64() * input.sample_rate() as f64)
-            .round()
-            .max(1.0) as u32;
-
+    pub fn new(input: I, volume: Volume, initial: f32, ramp: Duration) -> Self {
         Self {
             input,
             volume,
             current: initial,
             target: initial,
             step: 0.0,
+            ramp,
             frames_left: 0,
-            ramp_frames,
+            ramp_frames: 1,
             channel: 0,
-            channels,
+            channels: 0,
+            rate: 0,
         }
+    }
+
+    fn resync(&mut self) {
+        let channels = self.input.channels().max(1);
+        let rate = self.input.sample_rate().max(1);
+        if channels == self.channels && rate == self.rate {
+            return;
+        }
+
+        self.channels = channels;
+        self.rate = rate;
+        self.ramp_frames = (self.ramp.as_secs_f64() * rate as f64).round().max(1.0) as u32;
+        self.frames_left = self.frames_left.min(self.ramp_frames);
     }
 }
 
@@ -144,6 +138,7 @@ impl<I: Source> Iterator for SmoothGain<I> {
         let sample = self.input.next()?;
 
         if self.channel == 0 {
+            self.resync();
             let requested = self.volume.get().max(0.0);
 
             if requested.to_bits() != self.target.to_bits() {
@@ -165,7 +160,7 @@ impl<I: Source> Iterator for SmoothGain<I> {
         let output = sample * self.current;
 
         self.channel += 1;
-        if self.channel == self.channels {
+        if self.channel >= self.channels {
             self.channel = 0;
         }
 

--- a/crates/music/src/spotify/playback.rs
+++ b/crates/music/src/spotify/playback.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use anyhow::{Context as _, Result};
 use async_trait::async_trait;
 use librespot_core::{Session, SpotifyUri};
-use librespot_playback::config::{AudioFormat, Bitrate, PlayerConfig};
+use librespot_playback::config::{Bitrate, PlayerConfig};
 use librespot_playback::mixer::NoOpVolume;
 use librespot_playback::player::{Player, PlayerEvent};
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -68,7 +68,7 @@ impl Engine {
         let sink_volume = volume.clone();
         let sink_flush = flush.clone();
         let player = Player::new(player_config, session, Box::new(NoOpVolume), move || {
-            BlazingSink::boxed(AudioFormat::default(), sink_flush, sink_volume)
+            BlazingSink::boxed(sink_flush, sink_volume)
         });
 
         let events = Events(player.get_player_event_channel());

--- a/crates/music/src/spotify/sink.rs
+++ b/crates/music/src/spotify/sink.rs
@@ -3,12 +3,11 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use librespot_playback::audio_backend::{Sink, SinkError, SinkResult};
-use librespot_playback::config::AudioFormat;
 use librespot_playback::convert::Converter;
 use librespot_playback::decoder::AudioPacket;
 use librespot_playback::{NUM_CHANNELS, SAMPLE_RATE};
 
-use crate::audio::{Output, Volume, Wanted};
+use crate::audio::{Output, Volume};
 
 const QUEUED_CHUNKS: usize = 26;
 const DRAIN_POLL: Duration = Duration::from_millis(10);
@@ -32,21 +31,16 @@ pub struct BlazingSink {
 }
 
 impl BlazingSink {
-    pub fn open(format: AudioFormat, flush: Flush, volume: Volume) -> Result<Self, SinkError> {
-        let wanted = Wanted {
-            channels: NUM_CHANNELS as u16,
-            sample_rate: SAMPLE_RATE,
-            format: Box::new(move |device| output_sample_format(format, device)),
-        };
-        let output = Output::open(volume, Some(wanted))
+    pub fn open(flush: Flush, volume: Volume) -> Result<Self, SinkError> {
+        let output = Output::open(volume)
             .map_err(|error| SinkError::ConnectionRefused(error.to_string()))?;
         output.sink().pause();
 
         Ok(Self { output, flush })
     }
 
-    pub fn boxed(format: AudioFormat, flush: Flush, volume: Volume) -> Box<dyn Sink> {
-        match Self::open(format, flush, volume) {
+    pub fn boxed(flush: Flush, volume: Volume) -> Box<dyn Sink> {
+        match Self::open(flush, volume) {
             Ok(sink) => Box::new(sink),
             Err(error) => {
                 log::error!("sink: cannot open an output device: {error}");
@@ -96,19 +90,5 @@ struct Silence;
 impl Sink for Silence {
     fn write(&mut self, _packet: AudioPacket, _converter: &mut Converter) -> SinkResult<()> {
         Ok(())
-    }
-}
-
-fn output_sample_format(input: AudioFormat, device: cpal::SampleFormat) -> cpal::SampleFormat {
-    if cfg!(target_os = "windows") {
-        device
-    } else {
-        match input {
-            AudioFormat::F64 => cpal::SampleFormat::F64,
-            AudioFormat::F32 => cpal::SampleFormat::F32,
-            AudioFormat::S32 => cpal::SampleFormat::I32,
-            AudioFormat::S24 | AudioFormat::S24_3 => cpal::SampleFormat::I24,
-            AudioFormat::S16 => cpal::SampleFormat::I16,
-        }
     }
 }

--- a/crates/music/src/youtube/playback.rs
+++ b/crates/music/src/youtube/playback.rs
@@ -165,7 +165,7 @@ async fn engine_loop(
     mut commands: UnboundedReceiver<Command>,
     events: UnboundedSender<PlaybackEvent>,
 ) {
-    let output = match Output::open(Volume::new(config.gain), None) {
+    let output = match Output::open(Volume::new(config.gain)) {
         Ok(output) => output,
         Err(error) => {
             log::error!("playback: cannot open audio output: {error:#}");


### PR DESCRIPTION
## Summary

- open the audio output at the device's own sample format and rate instead of negotiating one
- read the gain ramp's channel count and sample rate from the source that is actually playing
- log the rate, channel count and sample format the output stream opened at

Closes #65