### PR TITLE
fix: close the gap between tracks on imported and youtube playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- YouTube tracks no longer leave a short silence between them. The audio YouTube serves carries a
+  fraction of a second of encoder padding at each end, which nothing in the decoding stack was
+  removing, so it played as a gap however early the next track was fetched. Sonora now reads how
+  much to drop from the file itself and trims it.
 - Imported tracks run into one another with no gap. The next track was already decoded and waiting
   behind the current one, but Sonora tore it down and started it again the moment the song changed,
   so every boundary cost a stumble.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Imported tracks run into one another with no gap. The next track was already decoded and waiting
+  behind the current one, but Sonora tore it down and started it again the moment the song changed,
+  so every boundary cost a stumble.
 - Spotify playback on Windows no longer hisses in the background, which was loudest at low volume.
   Sonora asked the output device for a stream it could not give and settled for the poorest sample
   format on offer instead of the one the device already runs at, so every track was played through

--- a/crates/music/src/audio.rs
+++ b/crates/music/src/audio.rs
@@ -189,3 +189,83 @@ impl<I: Source> Source for SmoothGain<I> {
         self.input.try_seek(position)
     }
 }
+
+pub struct Trimmed<I> {
+    input: I,
+    head: u64,
+    body: Option<u64>,
+    emitted: u64,
+    primed: bool,
+    lane: u64,
+}
+
+impl<I: Source> Trimmed<I> {
+    pub fn new(input: I, skip: Duration, take: Option<Duration>) -> Self {
+        let lane = (input.sample_rate() as u64) * (input.channels().max(1) as u64);
+        let samples = |span: Duration| (span.as_secs_f64() * lane as f64).round() as u64;
+
+        Self {
+            head: samples(skip),
+            body: take.map(samples),
+            emitted: 0,
+            primed: false,
+            lane,
+            input,
+        }
+    }
+
+    fn offset(&self) -> Duration {
+        Duration::from_secs_f64(self.head as f64 / self.lane as f64)
+    }
+}
+
+impl<I: Source> Iterator for Trimmed<I> {
+    type Item = f32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if !self.primed {
+            self.primed = true;
+            for _ in 0..self.head {
+                self.input.next()?;
+            }
+        }
+        if self.body.is_some_and(|body| self.emitted >= body) {
+            return None;
+        }
+
+        let sample = self.input.next()?;
+        self.emitted += 1;
+        Some(sample)
+    }
+}
+
+impl<I: Source> Source for Trimmed<I> {
+    fn current_span_len(&self) -> Option<usize> {
+        self.input.current_span_len()
+    }
+
+    fn channels(&self) -> u16 {
+        self.input.channels()
+    }
+
+    fn sample_rate(&self) -> u32 {
+        self.input.sample_rate()
+    }
+
+    fn total_duration(&self) -> Option<Duration> {
+        match self.body {
+            Some(body) => Some(Duration::from_secs_f64(body as f64 / self.lane as f64)),
+            None => self
+                .input
+                .total_duration()
+                .map(|whole| whole.saturating_sub(self.offset())),
+        }
+    }
+
+    fn try_seek(&mut self, position: Duration) -> Result<(), SeekError> {
+        self.input.try_seek(position + self.offset())?;
+        self.primed = true;
+        self.emitted = (position.as_secs_f64() * self.lane as f64).round() as u64;
+        Ok(())
+    }
+}

--- a/crates/music/src/local/playback.rs
+++ b/crates/music/src/local/playback.rs
@@ -11,8 +11,14 @@ use crate::{PlaybackConfig, PlaybackEvent, PlaybackEvents, PlaybackFactory, Play
 const POLL: Duration = Duration::from_millis(20);
 
 enum Command {
-    Load { id: String, at: Option<Duration> },
-    Preload { id: String },
+    Load {
+        id: String,
+        at: Option<Duration>,
+        seamless: bool,
+    },
+    Preload {
+        id: String,
+    },
     Play,
     Pause,
     Seek(Duration),
@@ -41,11 +47,12 @@ struct Engine {
 }
 
 impl Player for Engine {
-    fn load(&self, track_id: &str, _seamless: bool) -> Result<()> {
+    fn load(&self, track_id: &str, seamless: bool) -> Result<()> {
         self.commands
             .send(Command::Load {
                 id: track_id.to_owned(),
                 at: None,
+                seamless,
             })
             .context("cannot reach local playback engine")
     }
@@ -55,6 +62,7 @@ impl Player for Engine {
             .send(Command::Load {
                 id: track_id.to_owned(),
                 at: Some(at),
+                seamless: false,
             })
             .context("cannot reach local playback engine")
     }
@@ -147,7 +155,19 @@ async fn engine_loop(
             command = commands.recv() => {
                 let Some(command) = command else { break };
                 match command {
-                    Command::Load { id, at } => {
+                    Command::Load { id, at, seamless } => {
+                        let segued = seamless
+                            && at.is_none()
+                            && current.as_ref().is_some_and(|slot| slot.id == id);
+                        if segued {
+                            playing = true;
+                            sink.play();
+                            if let Some(length) = current.as_ref().and_then(|slot| slot.length) {
+                                events.send(PlaybackEvent::Length(length)).ok();
+                            }
+                            events.send(PlaybackEvent::Playing(sink.get_pos())).ok();
+                            continue;
+                        }
                         events.send(PlaybackEvent::Loading(at.unwrap_or_default())).ok();
                         sink.clear();
                         current = None;
@@ -181,9 +201,8 @@ async fn engine_loop(
                         }
                     }
                     Command::Preload { id } => {
-                        let known = current.as_ref().is_some_and(|slot| slot.id == id)
-                            || queued.as_ref().is_some_and(|slot| slot.id == id);
-                        if known || current.is_none() {
+                        let known = current.as_ref().is_some_and(|slot| slot.id == id);
+                        if known || current.is_none() || queued.is_some() {
                             continue;
                         }
                         match load(&sink, &id) {

--- a/crates/music/src/youtube/mod.rs
+++ b/crates/music/src/youtube/mod.rs
@@ -3,6 +3,7 @@ mod auth;
 mod client;
 mod genres;
 mod playback;
+mod trim;
 mod wire;
 
 use std::path::PathBuf;

--- a/crates/music/src/youtube/playback.rs
+++ b/crates/music/src/youtube/playback.rs
@@ -7,7 +7,8 @@ use async_trait::async_trait;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use ytmusic::YtMusic;
 
-use crate::audio::{Output, RAMP, SmoothGain, Volume};
+use crate::audio::{Output, RAMP, SmoothGain, Trimmed, Volume};
+use crate::youtube::trim;
 use crate::{PlaybackConfig, PlaybackEvent, PlaybackEvents, PlaybackFactory, Player};
 
 const NORMAL_CAP: f32 = 1.0;
@@ -446,6 +447,20 @@ fn append(
         false => gain,
     };
     let source = decode(loaded.data.clone())?;
+    let edit = trim::from_mp4(&loaded.data);
+    match edit {
+        Some(edit) => log::debug!(
+            "playback: {id} trims {:?} of priming, plays {:?}",
+            edit.skip,
+            edit.take
+        ),
+        None => log::debug!("playback: {id} carries no edit list"),
+    }
+    let source = Trimmed::new(
+        source,
+        edit.map(|edit| edit.skip).unwrap_or_default(),
+        edit.and_then(|edit| edit.take),
+    );
     sink.append(SmoothGain::new(source, envelope.clone(), initial, RAMP));
     Ok(Slot {
         id: id.to_string(),

--- a/crates/music/src/youtube/trim.rs
+++ b/crates/music/src/youtube/trim.rs
@@ -1,0 +1,85 @@
+use std::time::Duration;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Trim {
+    pub skip: Duration,
+    pub take: Option<Duration>,
+}
+
+pub fn from_mp4(data: &[u8]) -> Option<Trim> {
+    let moov = child(data, b"moov")?;
+    let movie = timescale(child(moov, b"mvhd")?)?;
+    let trak = child(moov, b"trak")?;
+    let media = timescale(child(child(trak, b"mdia")?, b"mdhd")?)?;
+
+    let elst = child(child(trak, b"edts")?, b"elst")?;
+    let (segment, at) = edit(elst)?;
+
+    Some(Trim {
+        skip: Duration::from_secs_f64(at as f64 / media as f64),
+        take: (segment > 0).then(|| Duration::from_secs_f64(segment as f64 / movie as f64)),
+    })
+}
+
+fn child<'a>(data: &'a [u8], kind: &[u8; 4]) -> Option<&'a [u8]> {
+    let mut at = 0usize;
+    while at + 8 <= data.len() {
+        let size = u32::from_be_bytes(data[at..at + 4].try_into().ok()?) as u64;
+        let name = &data[at + 4..at + 8];
+        let (head, size) = match size {
+            1 => {
+                let large = data.get(at + 8..at + 16)?;
+                (16usize, u64::from_be_bytes(large.try_into().ok()?))
+            }
+            0 => (8usize, (data.len() - at) as u64),
+            _ => (8usize, size),
+        };
+        let size = usize::try_from(size).ok()?;
+        if size < head || at + size > data.len() {
+            return None;
+        }
+        if name == kind {
+            return Some(&data[at + head..at + size]);
+        }
+        at += size;
+    }
+    None
+}
+
+fn timescale(header: &[u8]) -> Option<u64> {
+    let at = match header.first()? {
+        1 => 20,
+        _ => 12,
+    };
+    let field = header.get(at..at + 4)?;
+    let scale = u32::from_be_bytes(field.try_into().ok()?);
+    (scale > 0).then_some(scale as u64)
+}
+
+fn edit(elst: &[u8]) -> Option<(u64, u64)> {
+    let version = *elst.first()?;
+    let count = u32::from_be_bytes(elst.get(4..8)?.try_into().ok()?);
+    let (width, mut at) = match version {
+        1 => (20usize, 8usize),
+        _ => (12usize, 8usize),
+    };
+
+    for _ in 0..count {
+        let entry = elst.get(at..at + width)?;
+        let (segment, media) = match version {
+            1 => (
+                u64::from_be_bytes(entry.get(0..8)?.try_into().ok()?),
+                i64::from_be_bytes(entry.get(8..16)?.try_into().ok()?),
+            ),
+            _ => (
+                u32::from_be_bytes(entry.get(0..4)?.try_into().ok()?) as u64,
+                i32::from_be_bytes(entry.get(4..8)?.try_into().ok()?) as i64,
+            ),
+        };
+        if media >= 0 {
+            return Some((segment, media as u64));
+        }
+        at += width;
+    }
+    None
+}


### PR DESCRIPTION
## Summary

- keep imported tracks playing through a track change instead of clearing the sink and decoding the queued track again
- trim the aac priming and padding youtube serves, read from the file's own edit list, so tracks meet without silence
- stop stacking a second preload on the local sink when the queue changes mid-track