### PR TITLE
fix(state): keep the current track when normalisation or gapless changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto eol=lf
+
+*.png binary
+*.ico binary
+*.icns binary
+*.ttf binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Turning volume normalisation or gapless playback on or off keeps the song you are on. Both
+  settings can only take effect on a fresh player, so Sonora used to drop the track and send you
+  back to nothing; it now rebuilds the player and puts the song back where it was. A song that was
+  paused stays paused rather than starting itself.
 - YouTube tracks no longer leave a short silence between them. The audio YouTube serves carries a
   fraction of a second of encoder padding at each end, which nothing in the decoding stack was
   removing, so it played as a gap however early the next track was fetched. Sonora now reads how

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -1187,15 +1187,26 @@ impl Playback {
         self.restart_engine(cx);
     }
 
+    fn local_active(&self) -> bool {
+        self.track
+            .as_ref()
+            .and_then(|track| track.id.as_deref())
+            .is_some_and(music::is_local_id)
+    }
+
     fn restart_engine(&mut self, cx: &mut Context<Self>) {
-        if self.engine.is_some() {
-            let playback = self.session.read(cx).playback();
-            if let Some(playback) = playback {
-                self.start_engine(playback, cx);
-                return;
-            }
+        let playback = match self.engine.is_some() {
+            true => self.session.read(cx).playback(),
+            false => None,
+        };
+        let Some(playback) = playback else {
+            return cx.notify();
+        };
+
+        match self.local_active() {
+            true => self.start_engine(playback, cx),
+            false => self.rebind(playback, cx),
         }
-        cx.notify();
     }
 
     fn ask_for_reconnect(&mut self, cx: &mut Context<Self>) -> bool {
@@ -1237,12 +1248,7 @@ impl Playback {
         self.listen(events, false, cx);
         self.engine = Some(engine);
         self.refused = None;
-        let local_active = self
-            .track
-            .as_ref()
-            .and_then(|track| track.id.as_deref())
-            .is_some_and(music::is_local_id);
-        if !local_active {
+        if !self.local_active() {
             self.state = PlaybackState::Idle;
             self.position = Duration::ZERO;
             self.clock.reset(Duration::ZERO, false);
@@ -1283,12 +1289,7 @@ impl Playback {
     }
 
     fn on_backend_event(&mut self, event: BackendEvent, local: bool, cx: &mut Context<Self>) {
-        let active = self
-            .track
-            .as_ref()
-            .and_then(|track| track.id.as_deref())
-            .is_some_and(music::is_local_id);
-        if local != active {
+        if local != self.local_active() {
             return;
         }
         match event {
@@ -1379,12 +1380,7 @@ impl Playback {
         self.task = None;
         self.engine = None;
 
-        let local_active = self
-            .track
-            .as_ref()
-            .and_then(|track| track.id.as_deref())
-            .is_some_and(music::is_local_id);
-        if !local_active {
+        if !self.local_active() {
             self.load = None;
             self.fetch = None;
             self.enqueue = None;


### PR DESCRIPTION
## Summary

- keep the playing track and its position when volume normalisation or gapless playback is toggled, rebuilding the player and loading the song back where it was
- leave a paused song paused across the toggle instead of starting it
- leave an imported track alone on a toggle, since the local engine reads neither setting
- fold three copies of the same local-track check into one helper
- pin the working tree to lf line endings so a windows-side write cannot churn the whole repo