### PR TITLE
perf: cut repaint and virtualization overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The Songs tab in Your Library no longer stutters on a large collection. Its play button was
+  building a copy of every song in the list on every frame, so the bigger the library the worse it
+  scrolled.
 - A word-by-word lyric line never breaks in the middle of a word. Each word is laid out on its own
   so it would be squeezed rather than moved down when it did not fit, splitting "upon" across two
   lines as "u" and "pon". A word that does not fit now moves to the next line whole.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Album covers no longer leave a thin line across the player bar as they scroll past it. Card grids
+  and the shelves on Home were drawing one row beyond the edge of what you can see, and a single
+  pixel of it fell outside the clip.
 - The Songs tab in Your Library no longer stutters on a large collection. Its play button was
   building a copy of every song in the list on every frame, so the bigger the library the worse it
   scrolled.

--- a/crates/ui/src/card.rs
+++ b/crates/ui/src/card.rs
@@ -371,6 +371,7 @@ impl RenderOnce for Card {
                         let size = px((art / px(1.) * SCRIM_RATIO).round()).max(SCRIM_MIN);
 
                         div()
+                            .id("card-scrim")
                             .absolute()
                             .inset_0()
                             .when(!playing, |this| {
@@ -418,6 +419,7 @@ impl RenderOnce for Card {
         };
 
         let title = div()
+            .id("card-title")
             .min_w_0()
             .truncate()
             .when_some(drag_start.clone(), |this, drag_start| {
@@ -526,6 +528,7 @@ impl RenderOnce for Card {
             .children(trailing.map(|trailing| div().flex_none().child(trailing)))
             .children(action.map(|action| {
                 div()
+                    .id("card-action")
                     .flex_none()
                     .invisible()
                     .group_hover(CARD_GROUP, |style| style.visible())

--- a/crates/ui/src/controls.rs
+++ b/crates/ui/src/controls.rs
@@ -125,6 +125,7 @@ impl RenderOnce for WindowControls {
                     .child(
                         svg()
                             .path(control.icon())
+                            .id("glyph")
                             .size(GLYPH)
                             .flex_none()
                             .text_color(theme.muted_foreground)

--- a/crates/ui/src/deck.rs
+++ b/crates/ui/src/deck.rs
@@ -5,8 +5,6 @@ use gpui::{AnyElement, App, Div, ElementId, Pixels, StyleRefinement, Window, div
 
 use crate::grid::Viewport;
 
-const OVERSCAN: usize = 1;
-
 type Draw = Box<dyn Fn(usize, &mut Window, &mut App) -> AnyElement>;
 type Measure = Box<dyn Fn(Pixels, &mut Window, &mut App)>;
 
@@ -175,8 +173,8 @@ fn span(tops: &[Pixels], rows: &[Pixels], viewport: Viewport) -> Range<usize> {
     }
 
     let bottom = viewport.top + viewport.height;
-    let first = passed(tops, rows, viewport.top).saturating_sub(OVERSCAN);
-    let last = (tops.partition_point(|top| *top < bottom) + OVERSCAN).min(tops.len());
+    let first = passed(tops, rows, viewport.top);
+    let last = tops.partition_point(|top| *top < bottom);
 
     first..last.max(first)
 }

--- a/crates/ui/src/glide.rs
+++ b/crates/ui/src/glide.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
-use gpui::{Pixels, Point, ScrollHandle, Window, point, px};
+use gpui::{App, EntityId, Pixels, Point, ScrollHandle, Window, point, px};
 
 const EASE: f32 = 0.12;
 const HERTZ: f32 = 180.;
@@ -15,15 +15,42 @@ struct Drift {
     target: Point<Pixels>,
     gliding: bool,
     armed: bool,
+    eased: Option<f32>,
     beat: Option<Instant>,
 }
 
-#[derive(Clone, Default)]
-pub struct Glide(Rc<RefCell<Drift>>);
+#[derive(Clone)]
+pub struct Glide {
+    drift: Rc<RefCell<Drift>>,
+    pace: f32,
+    watched: Option<EntityId>,
+}
+
+impl Default for Glide {
+    fn default() -> Self {
+        Self::paced(EASE)
+    }
+}
 
 impl Glide {
+    pub fn paced(pace: f32) -> Self {
+        Self {
+            drift: Rc::default(),
+            pace,
+            watched: None,
+        }
+    }
+
+    pub fn set_pace(&mut self, pace: f32) {
+        self.pace = pace;
+    }
+
+    pub fn watch(&mut self, view: EntityId) {
+        self.watched = Some(view);
+    }
+
     pub fn sync(&self, scroll: &ScrollHandle) {
-        let mut drift = self.0.borrow_mut();
+        let mut drift = self.drift.borrow_mut();
         if !drift.gliding {
             drift.shown = scroll.offset();
         }
@@ -31,7 +58,7 @@ impl Glide {
 
     pub fn nudge(&self, scroll: &ScrollHandle, window: &mut Window) {
         {
-            let mut drift = self.0.borrow_mut();
+            let mut drift = self.drift.borrow_mut();
             let landed = scroll.offset();
             let step = landed - drift.shown;
             let from = match drift.gliding {
@@ -41,6 +68,7 @@ impl Glide {
 
             drift.target = held(from + step, scroll);
             drift.gliding = true;
+            drift.eased = None;
             scroll.set_offset(drift.shown);
         }
         self.schedule_frame(scroll, window);
@@ -48,27 +76,29 @@ impl Glide {
 
     pub fn aim(&self, scroll: &ScrollHandle, to: Point<Pixels>, window: &mut Window) {
         {
-            let mut drift = self.0.borrow_mut();
+            let mut drift = self.drift.borrow_mut();
             drift.target = held(to, scroll);
             drift.gliding = true;
+            drift.eased = Some(self.pace);
         }
         self.schedule_frame(scroll, window);
     }
 
     pub fn jump(&self, scroll: &ScrollHandle, to: Point<Pixels>) {
         let landed = {
-            let mut drift = self.0.borrow_mut();
+            let mut drift = self.drift.borrow_mut();
             drift.target = held(to, scroll);
             drift.shown = drift.target;
             drift.gliding = false;
             drift.beat = None;
+            drift.eased = None;
             drift.shown
         };
         scroll.set_offset(landed);
     }
 
     pub fn goal(&self, scroll: &ScrollHandle) -> Point<Pixels> {
-        let drift = self.0.borrow();
+        let drift = self.drift.borrow();
 
         match drift.gliding {
             true => drift.target,
@@ -78,7 +108,7 @@ impl Glide {
 
     fn schedule_frame(&self, scroll: &ScrollHandle, window: &mut Window) {
         {
-            let mut drift = self.0.borrow_mut();
+            let mut drift = self.drift.borrow_mut();
             if drift.armed {
                 return;
             }
@@ -87,12 +117,12 @@ impl Glide {
 
         let glide = self.clone();
         let scroll = scroll.clone();
-        window.on_next_frame(move |window, _| glide.step(&scroll, window));
+        window.on_next_frame(move |window, cx| glide.step(&scroll, window, cx));
     }
 
-    fn step(&self, scroll: &ScrollHandle, window: &mut Window) {
+    fn step(&self, scroll: &ScrollHandle, window: &mut Window, cx: &mut App) {
         let landed = {
-            let mut drift = self.0.borrow_mut();
+            let mut drift = self.drift.borrow_mut();
             drift.armed = false;
             if !drift.gliding {
                 return;
@@ -104,7 +134,8 @@ impl Glide {
                 .replace(now)
                 .map(|beat| now.duration_since(beat).min(STALL))
                 .unwrap_or(Duration::from_secs_f32(1. / HERTZ));
-            let ease = 1. - (1. - EASE).powf(elapsed.as_secs_f32() * HERTZ);
+            let pace = drift.eased.unwrap_or(EASE);
+            let ease = 1. - (1. - pace).powf(elapsed.as_secs_f32() * HERTZ);
 
             let target = held(drift.target, scroll);
             let step = target - drift.shown;
@@ -113,6 +144,7 @@ impl Glide {
                     drift.shown = target;
                     drift.gliding = false;
                     drift.beat = None;
+                    drift.eased = None;
                     target
                 }
                 false => {
@@ -123,7 +155,10 @@ impl Glide {
         };
 
         scroll.set_offset(landed);
-        window.refresh();
+        match self.watched {
+            Some(view) => cx.notify(view),
+            None => window.refresh(),
+        }
         self.schedule_frame(scroll, window);
     }
 }

--- a/crates/ui/src/scrollbar.rs
+++ b/crates/ui/src/scrollbar.rs
@@ -119,6 +119,7 @@ pub struct Scrollbar {
     linger: Option<Task<()>>,
     glide: Glide,
     following: bool,
+    nudges: u64,
 }
 
 impl Scrollbar {
@@ -137,6 +138,7 @@ impl Scrollbar {
             linger: None,
             glide: Glide::default(),
             following: false,
+            nudges: 0,
         }
     }
 
@@ -157,6 +159,16 @@ impl Scrollbar {
         self
     }
 
+    pub fn paced(mut self, pace: f32) -> Self {
+        self.glide.set_pace(pace);
+        self
+    }
+
+    pub fn watching(mut self, view: EntityId) -> Self {
+        self.glide.watch(view);
+        self
+    }
+
     pub fn track_inset(mut self, inset: Pixels) -> Self {
         self.track_inset = inset;
         self
@@ -166,8 +178,13 @@ impl Scrollbar {
         self.seen = offset;
     }
 
+    pub fn nudges(&self) -> u64 {
+        self.nudges
+    }
+
     pub fn nudge(&mut self, window: &mut Window) {
         self.following = false;
+        self.nudges = self.nudges.wrapping_add(1);
         self.glide.nudge(&self.scroll, window);
     }
 
@@ -242,6 +259,7 @@ impl Scrollbar {
     }
 
     fn moved(&mut self, offset: Pixels, cx: &mut Context<Self>) {
+        self.nudges = self.nudges.wrapping_add(1);
         if let Some(maximum) = self
             .scroll_guard
             .as_ref()

--- a/crates/views/src/chrome/player_bar.rs
+++ b/crates/views/src/chrome/player_bar.rs
@@ -50,7 +50,8 @@ impl PlayerBar {
         cx.observe(&library, |_, _, cx| cx.notify()).detach();
         cx.observe(&settings, |_, _, cx| cx.notify()).detach();
 
-        let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+        let me = cx.entity_id();
+        let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(me));
 
         Self {
             playback,

--- a/crates/views/src/chrome/sidebar_left.rs
+++ b/crates/views/src/chrome/sidebar_left.rs
@@ -72,8 +72,9 @@ impl SidebarLeft {
         let settings = Sonora::global(cx).settings.clone();
         let session = Sonora::global(cx).session.clone();
         let playback = Sonora::global(cx).playback.clone();
-        let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
-        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()));
+        let me = cx.entity_id();
+        let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(me));
+        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(me));
         let width = px(settings.read(cx).sidebar_width()).clamp(MIN_WIDTH, MAX_WIDTH);
         let open = settings.read(cx).sidebar_open();
         let trail = router::trail(cx);

--- a/crates/views/src/chrome/sidebar_right.rs
+++ b/crates/views/src/chrome/sidebar_right.rs
@@ -1,5 +1,5 @@
 use gpui::prelude::*;
-use gpui::{Context, Entity, Pixels, Render, Window, div, px};
+use gpui::{Context, Entity, Pixels, Render, StyleRefinement, Window, div, px};
 use state::{AppSettings, Playback, Queue, SideTab, Sonora};
 use ui::{ActiveTheme as _, MIN_CONTENT, Panel, Room, Side};
 
@@ -123,7 +123,11 @@ impl Render for SidebarRight {
             }))
             .when(!theme.transparent, |this| this.bg(theme.background))
             .border_color(theme.border)
-            .child(self.aside.clone())
+            .child(
+                self.aside
+                    .clone()
+                    .cached(StyleRefinement::default().size_full()),
+            )
             .into_any_element()
     }
 }

--- a/crates/views/src/screens/artist.rs
+++ b/crates/views/src/screens/artist.rs
@@ -123,8 +123,9 @@ impl ArtistView {
         cx: &mut Context<Self>,
     ) -> Self {
         let width = MIN_CONTENT;
-        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()));
-        let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+        let id = cx.entity_id();
+        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(id));
+        let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(id));
         let settings = Sonora::global(cx).settings.clone();
         let saved = settings.read(cx).table(SECTION);
         let sorting = settings.read(cx).sorting(SECTION);
@@ -134,7 +135,7 @@ impl ArtistView {
         let scroll = scrollbar.read(cx).scroll().clone();
         let shown = Rc::new(Cell::new(LISTED));
         let table = cx.new(|cx| {
-            let menu_scrollbar = cx.new(|_| Scrollbar::inset());
+            let menu_scrollbar = cx.new(|_| Scrollbar::inset().watching(id));
             let source = TrackSource::new(
                 columns,
                 ArtistTracks {
@@ -215,7 +216,7 @@ impl ArtistView {
             releases_expanded: false,
             width,
             scrollbar,
-            about_bar: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
+            about_bar: cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(id)),
             about_open: false,
             table,
             shown,

--- a/crates/views/src/screens/detail.rs
+++ b/crates/views/src/screens/detail.rs
@@ -19,7 +19,7 @@ use crate::chrome::tools::{self, Sift, Sliders};
 use crate::chrome::{Chrome, Searchable, Toolbar, Tooled};
 use crate::shared::hero::{HeroMetaStrip, HeroPlayButton, PageHero, release_date_label};
 use crate::shared::tracks::{
-    self, PlaybackStatus, TrackField, TrackSieve, TrackSource, Tracks, playback_status,
+    PlaybackStatus, TrackField, TrackSieve, TrackSource, Tracks, playback_status,
 };
 use crate::shared::{cells, page};
 
@@ -72,11 +72,12 @@ impl DetailView {
         let saved = settings.read(cx).table(section);
         let width = MIN_CONTENT;
 
-        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()));
+        let id = cx.entity_id();
+        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(id));
         let scroll = scrollbar.read(cx).scroll().clone();
 
         let table = cx.new(|cx| {
-            let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+            let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(id));
             let source = TrackSource::new(
                 columns,
                 DetailTracks(detail.clone()),
@@ -275,10 +276,10 @@ impl DetailView {
             .flex()
             .items_center()
             .gap_2()
-            .child(HeroPlayButton::new(
+            .child(HeroPlayButton::listed(
                 "play-detail",
                 label,
-                tracks::ordered(&self.table, cx),
+                &self.table,
                 self.playback.clone(),
             ))
             .children(self.library_button(cx))

--- a/crates/views/src/screens/genre.rs
+++ b/crates/views/src/screens/genre.rs
@@ -35,7 +35,8 @@ impl GenreView {
     ) -> Self {
         let settings = Sonora::global(cx).settings.clone();
         let mode = settings.read(cx).view_or(SECTION, Mode::Cards);
-        let shelves = cx.new(|_| Shelves::new("genre-shelf", playback.clone()));
+        let id = cx.entity_id();
+        let shelves = cx.new(|_| Shelves::new("genre-shelf", id, playback.clone()));
 
         cx.observe(&detail, |this, _, cx| {
             this.shelves.update(cx, |shelves, _| shelves.reset());
@@ -54,7 +55,7 @@ impl GenreView {
             detail,
             settings,
             shelves,
-            scrollbar: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
+            scrollbar: cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(id)),
             toolbar,
             popovers: Popovers::default(),
             mode,

--- a/crates/views/src/screens/home/mod.rs
+++ b/crates/views/src/screens/home/mod.rs
@@ -2,7 +2,7 @@ use crate::chrome::Chrome;
 use crate::shared::menu::ItemMenu;
 use gpui::prelude::*;
 use gpui::{Context, Entity, Pixels, Point, Render, ScrollHandle, Window, div, px};
-use state::{Home, Playback};
+use state::{Home, Playback, Sonora};
 use ui::{ActiveTheme as _, Mode, Popup, Scrollbar, Scroller};
 
 use crate::shared::cells;
@@ -31,7 +31,8 @@ impl HomeView {
         playback: Entity<Playback>,
         cx: &mut Context<Self>,
     ) -> Self {
-        let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+        let me = cx.entity_id();
+        let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(me));
         let track_menu = ItemMenu::new(playlist_scrollbar);
 
         cx.observe(&home, |this, _, cx| {
@@ -44,7 +45,10 @@ impl HomeView {
         let chrome = Chrome::entity(cx);
         cx.observe(&chrome, |_, _, cx| cx.notify()).detach();
 
-        let shelves = cx.new(|_| Shelves::new("home-shelf", playback.clone()));
+        let library = Sonora::global(cx).library.clone();
+        cx.observe(&library, |_, _, cx| cx.notify()).detach();
+
+        let shelves = cx.new(|_| Shelves::new("home-shelf", me, playback.clone()));
         cx.observe(&shelves, |_, _, cx| cx.notify()).detach();
 
         let current_playback = playback_status(&playback, cx);
@@ -65,7 +69,7 @@ impl HomeView {
             width: Pixels::ZERO,
             quick_picks_columns: 0,
             quick_picks_page: 0,
-            scrollbar: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
+            scrollbar: cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(me)),
             track_menu,
             context_menu: None,
         }

--- a/crates/views/src/screens/library/local.rs
+++ b/crates/views/src/screens/library/local.rs
@@ -113,11 +113,12 @@ impl LocalView {
             )
         };
 
-        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()));
+        let id = cx.entity_id();
+        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(id));
         let scroll = scrollbar.read(cx).scroll().clone();
 
         let tracks = cx.new(|cx| {
-            let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+            let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(id));
             let source = TrackSource::new(
                 LIBRARY_COLUMNS,
                 LocalTracks(library.clone()),
@@ -162,6 +163,7 @@ impl LocalView {
             for table in this.tables() {
                 table.refresh(cx);
             }
+            cx.notify();
         })
         .detach();
 

--- a/crates/views/src/screens/library/mod.rs
+++ b/crates/views/src/screens/library/mod.rs
@@ -201,11 +201,12 @@ impl LibraryView {
             |section: Section, cx: &App| settings.read(cx).view_or(section.key(), section.mode());
         let views = Section::ALL.map(|section| viewed(section, cx));
 
-        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()));
+        let id = cx.entity_id();
+        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(id));
         let scroll = scrollbar.read(cx).scroll().clone();
 
         let tracks = cx.new(|cx| {
-            let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+            let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(id));
             let source = TrackSource::new(
                 LIBRARY_COLUMNS,
                 LibraryTracks(library.clone()),
@@ -278,6 +279,7 @@ impl LibraryView {
             for table in this.tables() {
                 table.refresh(cx);
             }
+            cx.notify();
         })
         .detach();
 
@@ -317,7 +319,7 @@ impl LibraryView {
         let me = cx.entity();
         let toolbar = Toolbar::searchable(&me, cx);
 
-        let card_scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()));
+        let card_scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(id));
 
         Self {
             library,
@@ -471,10 +473,10 @@ impl LibraryView {
             .accent()
             .eyebrow(t!("detail-playlist"))
             .meta(strip)
-            .actions(HeroPlayButton::new(
+            .actions(HeroPlayButton::listed(
                 "play-liked-songs",
                 t!("library-play-liked-songs"),
-                tracks::ordered(&self.tracks, cx),
+                &self.tracks,
                 self.playback.clone(),
             ))
             .into_any_element()

--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -10,7 +10,7 @@ use ui::Input;
 
 use crate::chrome::Chrome;
 use crate::shared::menu::{ItemMenu, item_menu};
-use state::{Genres, Hit, Kind, Playback, Search};
+use state::{Genres, Hit, Kind, Playback, Search, Sonora};
 use ui::ActiveTheme as _;
 use ui::{
     Card, Deck, Pin, Pinnable, Popup, Room, Scrollbar, Scroller, Separator, Text, Theme, VAST,
@@ -94,6 +94,8 @@ impl SearchView {
         .detach();
         let chrome = Chrome::entity(cx);
         cx.observe(&chrome, |_, _, cx| cx.notify()).detach();
+        let library = Sonora::global(cx).library.clone();
+        cx.observe(&library, |_, _, cx| cx.notify()).detach();
         let current_playback = playback_status(&playback, cx);
         cx.observe(&playback, |this, playback, cx| {
             let current = playback_status(&playback, cx);
@@ -107,7 +109,8 @@ impl SearchView {
         let asked = input.read(cx).text().to_owned();
         search.update(cx, |search, cx| search.ask(&asked, cx));
 
-        let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+        let me = cx.entity_id();
+        let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(me));
 
         Self {
             input,
@@ -115,11 +118,11 @@ impl SearchView {
             genres,
             playback,
             playback_status: current_playback,
-            songs: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
-            artists: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
-            albums: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
-            mixed: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
-            browsing: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
+            songs: cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(me)),
+            artists: cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(me)),
+            albums: cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(me)),
+            mixed: cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(me)),
+            browsing: cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(me)),
             track_menu: ItemMenu::new(playlist_scrollbar),
             context_menu: None,
         }

--- a/crates/views/src/screens/song.rs
+++ b/crates/views/src/screens/song.rs
@@ -6,7 +6,7 @@ use gpui::{
 use i18n::t;
 use music::{Credit, Track};
 use router::{Destination, Link as _};
-use state::{Playback, SongDetail};
+use state::{Playback, SongDetail, Sonora};
 use ui::{
     ActiveTheme as _, Avatar, Button, Fact, InfoCard, Initials, Popup, Scrollbar, Scroller,
     Skeleton, Text, clock,
@@ -72,13 +72,16 @@ impl SongView {
         })
         .detach();
         cx.observe(&playback, |_, _, cx| cx.notify()).detach();
-        let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+        let library = Sonora::global(cx).library.clone();
+        cx.observe(&library, |_, _, cx| cx.notify()).detach();
+        let me = cx.entity_id();
+        let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(me));
 
         Self {
             detail,
             playback,
-            scrollbar: cx.new(|_| Scrollbar::new(gpui::ScrollHandle::new())),
-            about_bar: cx.new(|_| Scrollbar::new(gpui::ScrollHandle::new())),
+            scrollbar: cx.new(|_| Scrollbar::new(gpui::ScrollHandle::new()).watching(me)),
+            about_bar: cx.new(|_| Scrollbar::new(gpui::ScrollHandle::new()).watching(me)),
             about_open: false,
             track_menu: ItemMenu::new(playlist_scrollbar),
             context_menu: None,

--- a/crates/views/src/shared/cells.rs
+++ b/crates/views/src/shared/cells.rs
@@ -92,6 +92,7 @@ pub(crate) fn index<F>(
     let dimmed = |icon, color| {
         svg()
             .path(icon)
+            .id(("index-glyph", cell.row))
             .size(glyph(&theme))
             .flex_none()
             .text_color(color)
@@ -102,6 +103,7 @@ pub(crate) fn index<F>(
         Some(PlaybackState::Playing) => dimmed(PLAYING, theme.foreground),
         Some(_) => dimmed(PAUSE, theme.muted_foreground),
         None => div()
+            .id(("index-number", cell.row))
             .text_color(match playable {
                 true => theme.muted_foreground,
                 false => faded,

--- a/crates/views/src/shared/hero.rs
+++ b/crates/views/src/shared/hero.rs
@@ -9,8 +9,11 @@ use i18n::t;
 use music::Track;
 use state::{Playback, PlaybackState};
 use ui::{
-    ActiveTheme as _, Artwork, Button, ExplicitBadge, LEADING, Pin, Pinnable as _, Text, upper,
+    ActiveTheme as _, Artwork, Button, ExplicitBadge, GridState, LEADING, Pin, Pinnable as _, Text,
+    upper,
 };
+
+use crate::shared::tracks::{self, TrackSource};
 
 pub(crate) fn release_date_label(value: &str) -> SharedString {
     let parts: Vec<_> = value.split('-').collect();
@@ -87,11 +90,39 @@ impl RenderOnce for HeroMetaStrip {
     }
 }
 
+enum Listing {
+    Owned(Vec<Track>),
+    Listed(Entity<GridState<TrackSource>>),
+}
+
+impl Listing {
+    fn first(&self, cx: &App) -> Option<usize> {
+        match self {
+            Self::Owned(tracks) => tracks.iter().position(|track| track.playable),
+            Self::Listed(table) => tracks::first_playable(table, cx),
+        }
+    }
+
+    fn holds(&self, id: &str, cx: &App) -> bool {
+        match self {
+            Self::Owned(tracks) => tracks.iter().any(|track| track.id.as_deref() == Some(id)),
+            Self::Listed(table) => tracks::holds(table, id, cx),
+        }
+    }
+
+    fn queue(&self, cx: &App) -> Vec<Track> {
+        match self {
+            Self::Owned(tracks) => tracks.clone(),
+            Self::Listed(table) => tracks::ordered(table, cx),
+        }
+    }
+}
+
 #[derive(IntoElement)]
 pub(crate) struct HeroPlayButton {
     id: ElementId,
     label: SharedString,
-    tracks: Vec<Track>,
+    listing: Listing,
     playback: Entity<Playback>,
 }
 
@@ -105,7 +136,21 @@ impl HeroPlayButton {
         Self {
             id: id.into(),
             label: label.into(),
-            tracks,
+            listing: Listing::Owned(tracks),
+            playback,
+        }
+    }
+
+    pub(crate) fn listed(
+        id: impl Into<ElementId>,
+        label: impl Into<SharedString>,
+        table: &Entity<GridState<TrackSource>>,
+        playback: Entity<Playback>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            label: label.into(),
+            listing: Listing::Listed(table.clone()),
             playback,
         }
     }
@@ -113,16 +158,12 @@ impl HeroPlayButton {
 
 impl RenderOnce for HeroPlayButton {
     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
-        let first_playable = self.tracks.iter().position(|track| track.playable);
+        let first_playable = self.listing.first(cx);
         let state = {
             let playback = self.playback.read(cx);
             let current = playback.track().and_then(|track| track.id.as_deref());
             current
-                .filter(|current| {
-                    self.tracks
-                        .iter()
-                        .any(|track| track.id.as_deref() == Some(*current))
-                })
+                .filter(|current| self.listing.holds(current, cx))
                 .map(|_| playback.state().clone())
         };
         let (label, icon, blocked) = match &state {
@@ -133,7 +174,7 @@ impl RenderOnce for HeroPlayButton {
         };
         let disabled = first_playable.is_none() || blocked;
         let first_playable = first_playable.unwrap_or_default();
-        let tracks = self.tracks;
+        let listing = self.listing;
         let playback = self.playback;
 
         div().flex().child(
@@ -147,7 +188,10 @@ impl RenderOnce for HeroPlayButton {
                         Some(PlaybackState::Playing) => playback.pause(cx),
                         Some(PlaybackState::Paused) => playback.resume(cx),
                         Some(PlaybackState::Loading) => {}
-                        _ => playback.start(tracks.clone(), first_playable, cx),
+                        _ => {
+                            let queued = listing.queue(cx);
+                            playback.start(queued, first_playable, cx)
+                        }
                     });
                 }),
         )

--- a/crates/views/src/shared/shelves.rs
+++ b/crates/views/src/shared/shelves.rs
@@ -1,7 +1,7 @@
 use gpui::prelude::*;
 use gpui::{
-    AnyElement, App, Context, Div, ElementId, Entity, FontWeight, MouseDownEvent, Pixels, Point,
-    ScrollHandle, ScrollWheelEvent, SharedString, WeakEntity, Window, div, point, px,
+    AnyElement, App, Context, Div, ElementId, Entity, EntityId, FontWeight, MouseDownEvent, Pixels,
+    Point, ScrollHandle, ScrollWheelEvent, SharedString, WeakEntity, Window, div, point, px,
 };
 use std::cell::Cell;
 use std::rc::Rc;
@@ -34,6 +34,7 @@ type Rail = (ScrollHandle, Glide);
 
 pub(crate) struct Shelves {
     id: &'static str,
+    host: EntityId,
     playback: Entity<Playback>,
     rails: Vec<Rail>,
     above: Rc<Cell<Option<Pixels>>>,
@@ -41,9 +42,10 @@ pub(crate) struct Shelves {
 }
 
 impl Shelves {
-    pub(crate) fn new(id: &'static str, playback: Entity<Playback>) -> Self {
+    pub(crate) fn new(id: &'static str, host: EntityId, playback: Entity<Playback>) -> Self {
         Self {
             id,
+            host,
             playback,
             rails: Vec::new(),
             above: Rc::new(Cell::new(None)),
@@ -110,7 +112,9 @@ impl Shelves {
         cx: &mut Context<Self>,
     ) -> AnyElement {
         while self.rails.len() < sections.len() {
-            self.rails.push((ScrollHandle::new(), Glide::default()));
+            let mut glide = Glide::default();
+            glide.watch(self.host);
+            self.rails.push((ScrollHandle::new(), glide));
         }
         for (scroll, glide) in &self.rails {
             glide.sync(scroll);

--- a/crates/views/src/shared/tracks/mod.rs
+++ b/crates/views/src/shared/tracks/mod.rs
@@ -41,6 +41,30 @@ pub(crate) trait Tracks: 'static {
     fn is_loading(&self, cx: &App) -> bool;
 }
 
+pub(crate) fn first_playable(table: &Entity<GridState<TrackSource>>, cx: &App) -> Option<usize> {
+    let state = table.read(cx);
+    let delegate = state.delegate();
+
+    (0..delegate.row_count()).find(|display| {
+        delegate
+            .source()
+            .peek(delegate.row(*display), cx)
+            .is_some_and(|track| track.playable)
+    })
+}
+
+pub(crate) fn holds(table: &Entity<GridState<TrackSource>>, id: &str, cx: &App) -> bool {
+    let state = table.read(cx);
+    let delegate = state.delegate();
+
+    (0..delegate.row_count()).any(|display| {
+        delegate
+            .source()
+            .peek(delegate.row(display), cx)
+            .is_some_and(|track| track.id.as_deref() == Some(id))
+    })
+}
+
 pub(crate) fn ordered(table: &Entity<GridState<TrackSource>>, cx: &App) -> Vec<Track> {
     let state = table.read(cx);
     let delegate = state.delegate();
@@ -292,6 +316,10 @@ impl TrackSource {
 
     pub(crate) fn at(&self, row: usize, cx: &App) -> Option<Track> {
         self.provider.tracks(cx).get(row).cloned()
+    }
+
+    pub(crate) fn peek<'a>(&self, row: usize, cx: &'a App) -> Option<&'a Track> {
+        self.provider.tracks(cx).get(row)
     }
 
     pub(crate) fn menu(&self) -> &ItemMenu {

--- a/crates/views/src/shells/fullscreen.rs
+++ b/crates/views/src/shells/fullscreen.rs
@@ -82,7 +82,8 @@ impl FullscreenView {
         let aside = cx.new(|cx| Aside::new(queue.clone(), playback.clone(), SideTab::Lyrics, cx));
         aside.update(cx, |aside, _| aside.strip());
         cx.observe(&aside, |_, _, cx| cx.notify()).detach();
-        let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+        let me = cx.entity_id();
+        let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(me));
 
         let mut this = Self {
             playback,

--- a/crates/views/src/shells/workspace.rs
+++ b/crates/views/src/shells/workspace.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 
 use gpui::prelude::*;
-use gpui::{AnyView, App, Context, Entity, FocusHandle, Render, px};
+use gpui::{AnyView, App, Context, Entity, FocusHandle, Render, StyleRefinement, px};
 use gpui::{Window, div};
 use input::WORKSPACE_CONTEXT;
 use state::{Playback, Queue, SideTab};
@@ -225,7 +225,14 @@ impl Render for Workspace {
                                     .layer_scale(scale)
                                     .opacity(1. - hidden)
                                     .blur(VIEW_BLUR * hidden)
-                                    .child(self.content.clone()),
+                                    .child(match hidden > 0. {
+                                        true => self.content.clone().into_any_element(),
+                                        false => self
+                                            .content
+                                            .clone()
+                                            .cached(StyleRefinement::default().size_full())
+                                            .into_any_element(),
+                                    }),
                             ),
                     )
                     .child(self.sidebar_right.clone())


### PR DESCRIPTION
## Summary

- notify the view that owns a scroll instead of refreshing every window on every scroll frame
- point every scrollbar and glide at its own view, and repaint a screen when the state it renders changes
- build the hero play button from the table on demand, so the Songs tab no longer copies the whole library each frame
- stop a deck rendering the row past its viewport, which left a pixel of album art across the player bar
- give hovered cards, window controls and index cells a stable id so hover does not invalidate their parent
- cache the workspace content and the lyrics panel while nothing in them is animating