### PR TITLE
fix: keep the lyrics panel legible and in step with the song

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The Songs tab in Your Library no longer stutters on a large collection. Its play button was
+  building a copy of every song in the list on every frame, so the bigger the library the worse it
+  scrolled.
 - A word-by-word lyric line never breaks in the middle of a word. Each word is laid out on its own
   so it would be squeezed rather than moved down when it did not fit, splitting "upon" across two
   lines as "u" and "pon". A word that does not fit now moves to the next line whole.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Korean only. Albums, playlists and artists open as cards, an artist's own page as a list, and both
   sidebars are a little narrower. Anything you have already set is left alone.
 - The lyric line being sung is set a little larger than the rest, and grows into that size as it
-  arrives instead of only brightening.
+  arrives instead of only brightening. Entering or leaving fullscreen no longer replays that growth
+  for a line that arrived a while ago.
+- Background vocals only show on the line being sung. They fade in as the line arrives and fade out
+  as it leaves, instead of sitting under every line in the sheet, and the space they take opens and
+  closes with them so the lines below do not jump.
+- Lyrics blur and dim by how far a line sits from the one being sung on screen, not by how many
+  lines away it is. The lines next to the sung one are already slightly soft, and every line further
+  out is softer than the one before it, all the way to the edge of the panel. A line never fades so
+  far that it cannot be read, and pointing at one still brings it back sharp. The panel also takes
+  longer to carry the next line into place. Scrolling the lyrics by hand is unchanged.
 
 ### Removed
 
@@ -48,6 +57,25 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Lyrics no longer run past the edge of the panel. Japanese, Chinese and Korean lines had no place to
+  break, because a line was only ever split where it had a space, so a whole verse was laid out as
+  one unbreakable row. They now break between characters, and never before a closing bracket or a
+  mark like a comma that has to stay with the character in front of it.
+- Turning Karaoke lyrics on no longer widens the gaps between words. The line being sung was laid
+  out one box per word so it could be highlighted piece by piece, and each box was measured on its
+  own; it is now a single run per line with the highlight clipped over it, which is what every other
+  line already did.
+- The word-by-word highlight keeps pace with Japanese, Chinese and Korean lines, where it used to
+  stall and then jump ahead to catch up. It travels on an eased curve, which reads as a flourish
+  across a word of Latin letters but not across a single wide character, and lyrics for those
+  languages are timed one character at a time or, worse, a whole phrase at a time: the highlight
+  raced most of the way over a character and then crawled the rest. Wide characters and phrases now
+  fill at an even pace, and the soft edge the highlight carries no longer hardens on every character
+  it crosses, which was dragging the visible edge back half a character at a time. A word followed
+  by a rest also finishes where it is sung instead of drifting on through the silence.
+- Japanese, Chinese and Korean lyrics keep their spacing when a line's word timings do not line up
+  with its text. Sonora fell back to spacing the words out as if they were English, which put a gap
+  between every character.
 - Album covers no longer leave a thin line across the player bar as they scroll past it. Card grids
   and the shelves on Home were drawing one row beyond the edge of what you can see, and a single
   pixel of it fell outside the clip.
@@ -56,7 +84,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   scrolled.
 - A word-by-word lyric line never breaks in the middle of a word. Each word is laid out on its own
   so it would be squeezed rather than moved down when it did not fit, splitting "upon" across two
-  lines as "u" and "pon". A word that does not fit now moves to the next line whole.
+  lines as "u" and "pon". A word that does not fit now moves to the next line whole. Punctuation
+  timed as its own word goes with it, so a line no longer wraps to leave a lone "?" or "," on the
+  last row.
 - Turning volume normalisation or gapless playback on or off keeps the song you are on. Both
   settings can only take effect on a fresh player, so Sonora used to drop the track and send you
   back to nothing; it now rebuilds the player and puts the song back where it was. A song that was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Album covers no longer leave a thin line across the player bar as they scroll past it. Card grids
+  and the shelves on Home were drawing one row beyond the edge of what you can see, and a single
+  pixel of it fell outside the clip.
 - The Songs tab in Your Library no longer stutters on a large collection. Its play button was
   building a copy of every song in the list on every frame, so the bigger the library the worse it
   scrolled.

--- a/crates/ui/src/card.rs
+++ b/crates/ui/src/card.rs
@@ -371,6 +371,7 @@ impl RenderOnce for Card {
                         let size = px((art / px(1.) * SCRIM_RATIO).round()).max(SCRIM_MIN);
 
                         div()
+                            .id("card-scrim")
                             .absolute()
                             .inset_0()
                             .when(!playing, |this| {
@@ -418,6 +419,7 @@ impl RenderOnce for Card {
         };
 
         let title = div()
+            .id("card-title")
             .min_w_0()
             .truncate()
             .when_some(drag_start.clone(), |this, drag_start| {
@@ -526,6 +528,7 @@ impl RenderOnce for Card {
             .children(trailing.map(|trailing| div().flex_none().child(trailing)))
             .children(action.map(|action| {
                 div()
+                    .id("card-action")
                     .flex_none()
                     .invisible()
                     .group_hover(CARD_GROUP, |style| style.visible())

--- a/crates/ui/src/controls.rs
+++ b/crates/ui/src/controls.rs
@@ -125,6 +125,7 @@ impl RenderOnce for WindowControls {
                     .child(
                         svg()
                             .path(control.icon())
+                            .id("glyph")
                             .size(GLYPH)
                             .flex_none()
                             .text_color(theme.muted_foreground)

--- a/crates/ui/src/deck.rs
+++ b/crates/ui/src/deck.rs
@@ -5,8 +5,6 @@ use gpui::{AnyElement, App, Div, ElementId, Pixels, StyleRefinement, Window, div
 
 use crate::grid::Viewport;
 
-const OVERSCAN: usize = 1;
-
 type Draw = Box<dyn Fn(usize, &mut Window, &mut App) -> AnyElement>;
 type Measure = Box<dyn Fn(Pixels, &mut Window, &mut App)>;
 
@@ -175,8 +173,8 @@ fn span(tops: &[Pixels], rows: &[Pixels], viewport: Viewport) -> Range<usize> {
     }
 
     let bottom = viewport.top + viewport.height;
-    let first = passed(tops, rows, viewport.top).saturating_sub(OVERSCAN);
-    let last = (tops.partition_point(|top| *top < bottom) + OVERSCAN).min(tops.len());
+    let first = passed(tops, rows, viewport.top);
+    let last = tops.partition_point(|top| *top < bottom);
 
     first..last.max(first)
 }

--- a/crates/ui/src/glide.rs
+++ b/crates/ui/src/glide.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
-use gpui::{Pixels, Point, ScrollHandle, Window, point, px};
+use gpui::{App, EntityId, Pixels, Point, ScrollHandle, Window, point, px};
 
 const EASE: f32 = 0.12;
 const HERTZ: f32 = 180.;
@@ -15,15 +15,42 @@ struct Drift {
     target: Point<Pixels>,
     gliding: bool,
     armed: bool,
+    eased: Option<f32>,
     beat: Option<Instant>,
 }
 
-#[derive(Clone, Default)]
-pub struct Glide(Rc<RefCell<Drift>>);
+#[derive(Clone)]
+pub struct Glide {
+    drift: Rc<RefCell<Drift>>,
+    pace: f32,
+    watched: Option<EntityId>,
+}
+
+impl Default for Glide {
+    fn default() -> Self {
+        Self::paced(EASE)
+    }
+}
 
 impl Glide {
+    pub fn paced(pace: f32) -> Self {
+        Self {
+            drift: Rc::default(),
+            pace,
+            watched: None,
+        }
+    }
+
+    pub fn set_pace(&mut self, pace: f32) {
+        self.pace = pace;
+    }
+
+    pub fn watch(&mut self, view: EntityId) {
+        self.watched = Some(view);
+    }
+
     pub fn sync(&self, scroll: &ScrollHandle) {
-        let mut drift = self.0.borrow_mut();
+        let mut drift = self.drift.borrow_mut();
         if !drift.gliding {
             drift.shown = scroll.offset();
         }
@@ -31,7 +58,7 @@ impl Glide {
 
     pub fn nudge(&self, scroll: &ScrollHandle, window: &mut Window) {
         {
-            let mut drift = self.0.borrow_mut();
+            let mut drift = self.drift.borrow_mut();
             let landed = scroll.offset();
             let step = landed - drift.shown;
             let from = match drift.gliding {
@@ -41,6 +68,7 @@ impl Glide {
 
             drift.target = held(from + step, scroll);
             drift.gliding = true;
+            drift.eased = None;
             scroll.set_offset(drift.shown);
         }
         self.schedule_frame(scroll, window);
@@ -48,27 +76,29 @@ impl Glide {
 
     pub fn aim(&self, scroll: &ScrollHandle, to: Point<Pixels>, window: &mut Window) {
         {
-            let mut drift = self.0.borrow_mut();
+            let mut drift = self.drift.borrow_mut();
             drift.target = held(to, scroll);
             drift.gliding = true;
+            drift.eased = Some(self.pace);
         }
         self.schedule_frame(scroll, window);
     }
 
     pub fn jump(&self, scroll: &ScrollHandle, to: Point<Pixels>) {
         let landed = {
-            let mut drift = self.0.borrow_mut();
+            let mut drift = self.drift.borrow_mut();
             drift.target = held(to, scroll);
             drift.shown = drift.target;
             drift.gliding = false;
             drift.beat = None;
+            drift.eased = None;
             drift.shown
         };
         scroll.set_offset(landed);
     }
 
     pub fn goal(&self, scroll: &ScrollHandle) -> Point<Pixels> {
-        let drift = self.0.borrow();
+        let drift = self.drift.borrow();
 
         match drift.gliding {
             true => drift.target,
@@ -78,7 +108,7 @@ impl Glide {
 
     fn schedule_frame(&self, scroll: &ScrollHandle, window: &mut Window) {
         {
-            let mut drift = self.0.borrow_mut();
+            let mut drift = self.drift.borrow_mut();
             if drift.armed {
                 return;
             }
@@ -87,12 +117,12 @@ impl Glide {
 
         let glide = self.clone();
         let scroll = scroll.clone();
-        window.on_next_frame(move |window, _| glide.step(&scroll, window));
+        window.on_next_frame(move |window, cx| glide.step(&scroll, window, cx));
     }
 
-    fn step(&self, scroll: &ScrollHandle, window: &mut Window) {
+    fn step(&self, scroll: &ScrollHandle, window: &mut Window, cx: &mut App) {
         let landed = {
-            let mut drift = self.0.borrow_mut();
+            let mut drift = self.drift.borrow_mut();
             drift.armed = false;
             if !drift.gliding {
                 return;
@@ -104,7 +134,8 @@ impl Glide {
                 .replace(now)
                 .map(|beat| now.duration_since(beat).min(STALL))
                 .unwrap_or(Duration::from_secs_f32(1. / HERTZ));
-            let ease = 1. - (1. - EASE).powf(elapsed.as_secs_f32() * HERTZ);
+            let pace = drift.eased.unwrap_or(EASE);
+            let ease = 1. - (1. - pace).powf(elapsed.as_secs_f32() * HERTZ);
 
             let target = held(drift.target, scroll);
             let step = target - drift.shown;
@@ -113,6 +144,7 @@ impl Glide {
                     drift.shown = target;
                     drift.gliding = false;
                     drift.beat = None;
+                    drift.eased = None;
                     target
                 }
                 false => {
@@ -123,7 +155,10 @@ impl Glide {
         };
 
         scroll.set_offset(landed);
-        window.refresh();
+        match self.watched {
+            Some(view) => cx.notify(view),
+            None => window.refresh(),
+        }
         self.schedule_frame(scroll, window);
     }
 }

--- a/crates/ui/src/scrollbar.rs
+++ b/crates/ui/src/scrollbar.rs
@@ -119,6 +119,7 @@ pub struct Scrollbar {
     linger: Option<Task<()>>,
     glide: Glide,
     following: bool,
+    nudges: u64,
 }
 
 impl Scrollbar {
@@ -137,6 +138,7 @@ impl Scrollbar {
             linger: None,
             glide: Glide::default(),
             following: false,
+            nudges: 0,
         }
     }
 
@@ -157,6 +159,16 @@ impl Scrollbar {
         self
     }
 
+    pub fn paced(mut self, pace: f32) -> Self {
+        self.glide.set_pace(pace);
+        self
+    }
+
+    pub fn watching(mut self, view: EntityId) -> Self {
+        self.glide.watch(view);
+        self
+    }
+
     pub fn track_inset(mut self, inset: Pixels) -> Self {
         self.track_inset = inset;
         self
@@ -166,8 +178,13 @@ impl Scrollbar {
         self.seen = offset;
     }
 
+    pub fn nudges(&self) -> u64 {
+        self.nudges
+    }
+
     pub fn nudge(&mut self, window: &mut Window) {
         self.following = false;
+        self.nudges = self.nudges.wrapping_add(1);
         self.glide.nudge(&self.scroll, window);
     }
 
@@ -242,6 +259,7 @@ impl Scrollbar {
     }
 
     fn moved(&mut self, offset: Pixels, cx: &mut Context<Self>) {
+        self.nudges = self.nudges.wrapping_add(1);
         if let Some(maximum) = self
             .scroll_guard
             .as_ref()

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, ops::Range};
 use gpui::prelude::*;
 
 use gpui::{
-    Animation, AnimationExt as _, App, Context, Div, DragMoveEvent, Entity, FontWeight,
+    Animation, AnimationExt as _, App, Bounds, Context, Div, DragMoveEvent, Entity, FontWeight,
     MouseDownEvent, Pixels, Point, Render, ScrollHandle, ScrollStrategy, ScrollWheelEvent,
     SharedString, Task, UniformListScrollHandle, Window, div, ease_in_out, px, relative, svg,
     uniform_list,
@@ -29,8 +29,13 @@ const QUEUE: &str = "queue";
 const FADE: f32 = 96.;
 const REST: f32 = FADE * 0.75;
 const TAIL_ROWS: usize = 2;
-const BLUR: f32 = 0.07;
+const BLUR: f32 = 0.13;
+const VEIL: f32 = 0.3;
+const HAZE: f32 = 0.45;
+const VERSE_FADE: f32 = 1.25;
+const VERSE_GLIDE: f32 = 0.07;
 const PAST: f32 = 0.4;
+const AHEAD: f32 = 0.6;
 const REVEAL: f32 = 0.6;
 const ACTIVE_VERSE_GROWTH: Pixels = px(2.);
 const LYRICS_HORIZONTAL_INSET_REM: f32 = 1.5;
@@ -44,6 +49,7 @@ const SWEEP_LEAST: std::time::Duration = std::time::Duration::from_millis(180);
 const SWEEP_STRETCH: f32 = 1.4;
 const SWEPT: f32 = 0.98;
 const LANDING: f32 = 0.2;
+const LANE_LEADING: f32 = 1.7;
 
 fn track(queue: &Queue, position: QueuePosition) -> Option<Track> {
     match position {
@@ -185,7 +191,7 @@ pub(crate) struct Aside {
     tab: SideTab,
     verse_bar: Entity<Scrollbar>,
     followed: Option<usize>,
-    goal: Option<Pixels>,
+    nudges: u64,
     pinned: bool,
     nudged: Option<std::time::Instant>,
     verse_of: Option<String>,
@@ -209,14 +215,12 @@ pub(crate) struct Aside {
     previous_active_line: Option<usize>,
     departing_line: Option<usize>,
     departed: std::time::Instant,
+    arrived: std::time::Instant,
     arrival: u64,
     departure: u64,
-    focused: Option<usize>,
-    faded: Option<usize>,
-    shifted: std::time::Instant,
     lyrics_wrap_width: Option<Pixels>,
     lyrics_wrap_size: Option<Pixels>,
-    lyrics_wrap_rows: HashMap<usize, Vec<Range<usize>>>,
+    lyrics_wraps: HashMap<usize, Wrapped>,
 }
 
 impl Aside {
@@ -243,14 +247,20 @@ impl Aside {
         let chrome = Chrome::entity(cx);
         cx.observe(&chrome, |_, _, cx| cx.notify()).detach();
 
+        let me = cx.entity_id();
         let scroll = UniformListScrollHandle::new();
-        let scrollbar = cx.new(|_| Scrollbar::new(scroll.0.borrow().base_handle.clone()));
-        let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+        let scrollbar =
+            cx.new(|_| Scrollbar::new(scroll.0.borrow().base_handle.clone()).watching(me));
+        let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(me));
         let lyrics = Sonora::global(cx).lyrics.clone();
         cx.observe(&lyrics, |_, _, cx| cx.notify()).detach();
         let settings = Sonora::global(cx).settings.clone();
         cx.observe(&settings, |_, _, cx| cx.notify()).detach();
-        let verse_bar = cx.new(|_| Scrollbar::new(ScrollHandle::new()));
+        let verse_bar = cx.new(|_| {
+            Scrollbar::new(ScrollHandle::new())
+                .paced(VERSE_GLIDE)
+                .watching(me)
+        });
 
         Self {
             queue,
@@ -260,7 +270,7 @@ impl Aside {
             tab,
             verse_bar,
             followed: None,
-            goal: None,
+            nudges: 0,
             pinned: true,
             nudged: None,
             verse_of: None,
@@ -284,14 +294,12 @@ impl Aside {
             previous_active_line: None,
             departing_line: None,
             departed: std::time::Instant::now(),
+            arrived: std::time::Instant::now(),
             arrival: 0,
             departure: 0,
-            focused: None,
-            faded: None,
-            shifted: std::time::Instant::now(),
             lyrics_wrap_width: None,
             lyrics_wrap_size: None,
-            lyrics_wrap_rows: HashMap::new(),
+            lyrics_wraps: HashMap::new(),
         }
     }
 
@@ -331,19 +339,8 @@ impl Aside {
     fn forget_verse(&mut self) {
         self.previous_active_line = None;
         self.departing_line = None;
-        self.focused = None;
-        self.faded = None;
         self.placing = true;
-        self.lyrics_wrap_rows.clear();
-    }
-
-    fn drift_progress(&self, window: &mut Window) -> f32 {
-        let span = Motion::Base.span().as_secs_f32().max(f32::EPSILON);
-        let progress = (self.shifted.elapsed().as_secs_f32() / span).clamp(0., 1.);
-        if progress < 1. {
-            window.request_animation_frame();
-        }
-        ease_in_out(progress)
+        self.lyrics_wraps.clear();
     }
 
     fn set_hovered(&mut self, index: usize, over: bool, cx: &mut Context<Self>) {
@@ -734,22 +731,26 @@ impl Aside {
             false => theme.text(Text::Title),
         };
         let wrap_size = active_verse_size(verse);
-        let wrap_width = (self.verse_bar.read(cx).scroll().bounds().size.width
+        let scroll = self.verse_bar.read(cx).scroll().clone();
+        let wrap_width = (scroll.bounds().size.width
             - window.rem_size() * LYRICS_HORIZONTAL_INSET_REM)
             .max(px(0.));
         if self.lyrics_wrap_width != Some(wrap_width) || self.lyrics_wrap_size != Some(wrap_size) {
             self.lyrics_wrap_width = Some(wrap_width);
             self.lyrics_wrap_size = Some(wrap_size);
-            self.lyrics_wrap_rows.clear();
+            self.lyrics_wraps.clear();
             window.request_animation_frame();
         }
 
         let mut body: Vec<gpui::AnyElement> = match (&lines, &state) {
             (Some(lines), _) => {
-                if singing && karaoke_effects && lines.iter().any(|line| line.worded()) {
+                let active_line = sung_line(lines, position);
+                if singing
+                    && karaoke_effects
+                    && active_line.is_some_and(|index| lines[index].worded())
+                {
                     window.request_animation_frame();
                 }
-                let active_line = sung_line(lines, position);
                 if self.previous_active_line != active_line {
                     if self.previous_active_line.is_some() {
                         self.departing_line = self.previous_active_line;
@@ -758,33 +759,22 @@ impl Aside {
                     }
                     if active_line.is_some() {
                         self.arrival = self.arrival.wrapping_add(1);
+                        self.arrived = std::time::Instant::now();
                     }
                     self.previous_active_line = active_line;
                 }
-                if self.departing_line.is_some() && self.departed.elapsed() >= Motion::Quick.span()
-                {
+                if self.departing_line.is_some() && self.departed.elapsed() >= Motion::Base.span() {
                     self.departing_line = None;
                 }
                 let instrumental_line = active_instrumental(lines, position);
-                let focus_line = active_line
-                    .or(instrumental_line)
-                    .or(self.focused)
-                    .unwrap_or(0);
-                if self.focused != Some(focus_line) {
-                    self.faded = self.focused;
-                    self.focused = Some(focus_line);
-                    self.shifted = std::time::Instant::now();
-                }
                 let animations = ui::motion::animates(cx);
-                let blur = match effects() {
-                    true => verse * BLUR,
-                    false => px(0.),
-                };
+                let hazing = effects();
+                let blur = verse * BLUR;
                 let sharpen = self.sharpen_progress(window);
-                let drift = match self.faded.is_some() && animations && blur > px(0.) {
-                    true => self.drift_progress(window),
-                    false => 1.,
-                };
+                let view = scroll.bounds();
+                if hazing && scroll.bounds_for_item(0).is_none() {
+                    window.request_animation_frame();
+                }
                 let mut rendered = Vec::with_capacity(lyric_row_count(lines));
 
                 for (index, line) in lines.iter().enumerate() {
@@ -799,27 +789,21 @@ impl Aside {
                     };
                     let instrumental_has_passed = position >= line.start;
 
-                    let near = index == focus_line || index == focus_line + 1;
-                    let hazed = !near;
                     let waking = self.hovered == Some(index);
                     let settling = self.fading == Some(index);
-                    let haze = |hazed: bool| match (hazed, waking, settling) {
-                        (false, _, _) => 0.,
-                        (true, true, _) => 1. - sharpen,
-                        (true, false, true) => sharpen,
-                        (true, false, false) => 1.,
+                    let haze = |depth: f32| match (waking, settling) {
+                        (true, _) => depth * (1. - sharpen),
+                        (false, true) => depth * sharpen,
+                        (false, false) => depth,
                     };
-                    let was_near = self
-                        .faded
-                        .is_some_and(|focus| index == focus || index == focus + 1);
-                    let from = haze(!was_near);
-                    let to = haze(hazed);
-                    let softness = from + (to - from) * drift;
-
                     if has_instrumental {
                         if singing && instrumental_line == Some(index) {
                             window.request_animation_frame();
                         }
+                        let softness = match hazing && instrumental_line != Some(index) {
+                            true => haze(viewport_haze(&scroll, rendered.len(), view, blur)),
+                            false => 0.,
+                        };
                         let notes = instrumental_row(
                             instrumental_progress,
                             instrumental_has_passed,
@@ -834,7 +818,11 @@ impl Aside {
                         .on_click(cx.listener(move |this, _, _, cx| {
                             this.seek_lyrics(instrumental_start, cx);
                         }))
-                        .when(softness > 0., |this| this.blur(blur * softness));
+                        .when(softness > 0., |this| this.opacity(1. - VEIL * softness))
+                        .map(|this| match (blur * softness).round() {
+                            soft if soft > px(0.) => this.blur(soft),
+                            _ => this,
+                        });
                         rendered.push(notes.into_any_element());
                     }
 
@@ -842,11 +830,11 @@ impl Aside {
                     let karaoke = Some(index) == active_line && line.worded() && karaoke_effects;
                     let primary_karaoke = karaoke && line.words.is_some();
                     let fragments = lyrics_fragments(&line.text, line.words.as_deref());
-                    let primary_rows = match self.lyrics_wrap_rows.get(&index) {
-                        Some(rows) => Some(rows.clone()),
+                    let wrapped = match self.lyrics_wraps.get(&index) {
+                        Some(wrapped) => Some(wrapped.clone()),
                         None => lyrics_wrap_rows(&fragments, wrap_size, wrap_width, window)
-                            .inspect(|rows| {
-                                self.lyrics_wrap_rows.insert(index, rows.clone());
+                            .inspect(|wrapped| {
+                                self.lyrics_wraps.insert(index, wrapped.clone());
                             }),
                     };
                     let line_has_ended = active_line.is_some_and(|active| index < active)
@@ -855,14 +843,17 @@ impl Aside {
                         (true, _) if primary_karaoke => theme.muted_foreground,
                         (true, _) => theme.foreground,
                         (false, true) => theme.muted_foreground.opacity(PAST),
-                        (false, false) => theme.muted_foreground,
+                        (false, false) => theme.muted_foreground.opacity(AHEAD),
                     };
 
-                    let dimming = (animations && Some(index) == self.departing_line)
-                        .then_some(self.departure);
+                    let active = Some(index) == active_line;
+                    let departing = Some(index) == self.departing_line;
+                    let dimming = (animations && departing).then_some(self.departure);
+                    let growing =
+                        animations && active && self.arrived.elapsed() < Motion::Base.span();
 
-                    let primary = match (primary_karaoke, line.words.as_ref(), primary_rows) {
-                        (true, Some(words), Some(rows)) => karaoke_lane(
+                    let primary = match (primary_karaoke, line.words.as_ref(), wrapped) {
+                        (true, Some(words), Some(wrapped)) => karaoke_lane(
                             &line.text,
                             line.start,
                             words,
@@ -870,14 +861,66 @@ impl Aside {
                             verse,
                             line.voice,
                             sung,
-                            Some(rows),
+                            Some(wrapped),
                         )
                         .into_any_element(),
-                        (_, _, Some(rows)) => {
-                            fixed_lyrics_lane(&fragments, &rows, line.voice).into_any_element()
+                        (_, _, Some(wrapped)) => {
+                            fixed_lyrics_lane(&fragments, &wrapped.rows, line.voice)
+                                .into_any_element()
                         }
                         _ => div().child(text).into_any_element(),
                     };
+                    let fade = match (line.secondary.is_empty(), active, departing) {
+                        (true, _, _) => None,
+                        (_, true, _) => Some(("lane-in", self.arrival, growing)),
+                        (_, _, true) => Some(("lane-out", self.departure, animations)),
+                        _ => None,
+                    };
+                    let lanes =
+                        fade.map(|(tag, take, animated)| {
+                            let arriving = tag == "lane-in";
+                            let room = lanes_room(
+                                &line.secondary,
+                                romanization_scripts,
+                                theme.text(Text::Body),
+                                wrap_width,
+                                window,
+                            );
+                            let group = div().flex().flex_col().gap_1().children(
+                                line.secondary.iter().map(|lane| {
+                                    let sung_by_end = line
+                                        .sung_end()
+                                        .is_some_and(|end| secondary_lane_started(lane, end));
+                                    secondary_lyrics_lane(
+                                        lane,
+                                        true,
+                                        line_has_ended,
+                                        position,
+                                        dimming.filter(|_| sung_by_end),
+                                        line.voice,
+                                        sung,
+                                    )
+                                }),
+                            );
+                            match animated {
+                                true => group
+                                    .overflow_hidden()
+                                    .with_animation(
+                                        (tag, take as usize),
+                                        Animation::new(Motion::Base.span())
+                                            .with_easing(ease_in_out),
+                                        move |this, t| {
+                                            let shown = match arriving {
+                                                true => t,
+                                                false => 1. - t,
+                                            };
+                                            this.opacity(shown).max_h(room * shown)
+                                        },
+                                    )
+                                    .into_any_element(),
+                                false => group.into_any_element(),
+                            }
+                        });
                     let content = div()
                         .flex()
                         .flex_col()
@@ -888,21 +931,12 @@ impl Aside {
                             selected_romanization(&line.romanized, romanization_scripts),
                             |this, text| this.child(romanized_lyrics_lane(text, &theme)),
                         )
-                        .children(line.secondary.iter().map(|lane| {
-                            let sung_by_end = line
-                                .sung_end()
-                                .is_some_and(|end| secondary_lane_started(lane, end));
-                            secondary_lyrics_lane(
-                                lane,
-                                Some(index) == active_line,
-                                line_has_ended,
-                                position,
-                                dimming.filter(|_| sung_by_end),
-                                line.voice,
-                                sung,
-                            )
-                        }));
+                        .children(lanes);
 
+                    let softness = match hazing && Some(index) != active_line {
+                        true => haze(viewport_haze(&scroll, rendered.len(), view, blur)),
+                        false => 0.,
+                    };
                     let traded = index
                         .checked_sub(1)
                         .is_some_and(|previous| lines[previous].voice != line.voice);
@@ -916,9 +950,7 @@ impl Aside {
                         .hover(|style| style.bg(theme.table_hover))
                         .text_size(verse)
                         .text_color(tint)
-                        .when(Some(index) == active_line, |this| {
-                            this.font_weight(FontWeight::SEMIBOLD)
-                        })
+                        .font_weight(FontWeight::SEMIBOLD)
                         .on_hover(cx.listener(move |this, over: &bool, _, cx| {
                             this.set_hovered(index, *over, cx)
                         }))
@@ -927,15 +959,17 @@ impl Aside {
                         }))
                         .child(content);
 
-                    let verse_line =
-                        verse_line.when(softness > 0., |this| this.blur(blur * softness));
-                    let active = Some(index) == active_line;
-                    let growing = animations && active;
-                    let departing = dimming.is_some();
+                    let verse_line = verse_line
+                        .when(softness > 0., |this| this.opacity(1. - VEIL * softness))
+                        .map(|this| match (blur * softness).round() {
+                            soft if soft > px(0.) => this.blur(soft),
+                            _ => this,
+                        });
+                    let shrinking = dimming.is_some();
                     let active_size = active_verse_size(verse);
-                    let unsung = theme.muted_foreground;
+                    let unsung = theme.muted_foreground.opacity(AHEAD);
                     let lit = theme.foreground;
-                    let verse_line = match (growing, departing) {
+                    let verse_line = match (growing, shrinking) {
                         (true, _) => verse_line
                             .with_animation(
                                 ("verse-grow", self.arrival as usize),
@@ -975,6 +1009,7 @@ impl Aside {
                         .flex_col()
                         .gap_1()
                         .text_size(theme.text(Text::Body))
+                        .font_weight(FontWeight::SEMIBOLD)
                         .text_color(theme.muted_foreground)
                         .child(SharedString::from(text.clone()))
                         .when_some(
@@ -1035,7 +1070,10 @@ impl Aside {
             .px_1()
             .pt(over)
             .pb(under)
-            .when(effects(), |this| this.fade_edges(px(FADE), px(FADE)))
+            .when(effects(), |this| {
+                let fade = verse * VERSE_FADE;
+                this.fade_edges(fade, fade)
+            })
             .children(body)
     }
 
@@ -1062,7 +1100,6 @@ impl Aside {
         self.aiming = false;
         self.rested = None;
         self.followed = None;
-        self.goal = None;
         self.nudged = None;
     }
 
@@ -1075,13 +1112,11 @@ impl Aside {
 
     fn pin_verse(&mut self, sung: Option<usize>, window: &mut Window, cx: &mut Context<Self>) {
         let scroll = self.verse_bar.read(cx).scroll().clone();
-        let aimed = self.verse_bar.read(cx).goal();
         let resting = scroll.offset().y;
-        if let Some(goal) = self.goal
-            && (aimed - goal).abs() > px(1.)
-        {
+        let nudges = self.verse_bar.read(cx).nudges();
+        if self.nudges != nudges {
+            self.nudges = nudges;
             self.pinned = false;
-            self.goal = None;
             self.nudged = Some(std::time::Instant::now());
         }
         if !self.pinned {
@@ -1127,7 +1162,6 @@ impl Aside {
             true => self.verse_bar.update(cx, |bar, _| bar.place(goal)),
             false => self.verse_bar.update(cx, |bar, _| bar.aim(goal, window)),
         }
-        self.goal = Some(self.verse_bar.read(cx).goal());
     }
 
     fn pin(&mut self, sections: Sections, window: &Window, cx: &Context<Self>) {
@@ -1231,7 +1265,7 @@ impl Render for Aside {
             .id("aside")
             .flex()
             .flex_col()
-            .flex_1()
+            .size_full()
             .min_h_0()
             .min_w_0()
             .on_drag_move(cx.listener(|this, _: &DragMoveEvent<DraggedPin>, _, cx| {
@@ -1307,8 +1341,8 @@ fn fixed_lyrics_lane(fragments: &[String], rows: &[Range<usize>], voice: Voice) 
     div().flex().flex_col().children(rows.iter().map(|row| {
         let text = fragments[row.clone()].concat();
         div()
-            .flex()
-            .when(!voice.lead(), |this| this.justify_end())
+            .w_full()
+            .when(!voice.lead(), |this| this.text_right())
             .child(SharedString::from(text))
     }))
 }
@@ -1321,57 +1355,176 @@ fn karaoke_lane(
     verse: Pixels,
     voice: Voice,
     sung: Sung,
-    rows: Option<Vec<Range<usize>>>,
+    wrapped: Option<Wrapped>,
 ) -> Div {
     let theme = &sung.theme;
     let edge_fade = verse * REVEAL;
-    let fragments = karaoke_fragments(line, words);
-    let fragment = |index: usize| {
-        let text = SharedString::from(fragments[index].clone());
-        let (highlight_start, highlight_end) = karaoke_window(line_start, words, index);
-        let tail = index + 1 >= words.len();
-        let highlighted = swept(highlight_start, highlight_end, position, tail);
-        let landing = ((1. - highlighted) / LANDING).min(1.);
+    let parts = karaoke_parts(line, words);
+    let fragments = parts
+        .iter()
+        .map(|(text, _)| text.clone())
+        .collect::<Vec<_>>();
+    let spoken = parts.iter().map(|(_, word)| *word).collect::<Vec<_>>();
+    let windows = (0..words.len())
+        .map(|word| {
+            let (start, end) = karaoke_window(line_start, words, word);
+            (start, end, word + 1 >= words.len())
+        })
+        .collect::<Vec<_>>();
+    let evenly = (0..words.len())
+        .map(|word| {
+            parts.iter().filter(|(_, spoke)| *spoke == word).count() > 1
+                || parts
+                    .iter()
+                    .any(|(text, spoke)| *spoke == word && text.chars().any(wide))
+        })
+        .collect::<Vec<_>>();
+    let sweep = |word: usize| match (windows.get(word), evenly.get(word)) {
+        (Some(&(start, end, _)), Some(true)) => progress_between(start, end, position),
+        (Some(&(start, end, tail)), _) => swept(start, end, position, tail),
+        (None, _) => 0.,
+    };
+    let lit = |text: SharedString, reveal: Reveal| {
         div()
             .relative()
             .flex_none()
             .whitespace_nowrap()
             .child(text.clone())
-            .when(highlighted > 0., |this| {
+            .when(reveal.shown, |this| {
                 this.child(
                     div()
                         .absolute()
                         .left_0()
                         .top_0()
                         .bottom_0()
-                        .w(relative(highlighted))
+                        .map(|this| match reveal.width {
+                            Some(width) => this.w(width),
+                            None => this.w(relative(reveal.share)),
+                        })
                         .overflow_hidden()
                         .text_color(theme.foreground)
-                        .when(highlighted < 1., |this| {
-                            this.fade_sides(px(0.), edge_fade * landing)
+                        .when(reveal.landing > 0., |this| {
+                            this.fade_sides(px(0.), edge_fade * reveal.landing)
                         })
                         .child(div().whitespace_nowrap().child(text)),
                 )
             })
     };
 
-    match rows {
-        Some(rows) => div()
-            .flex()
-            .flex_col()
-            .text_left()
-            .children(rows.into_iter().map(|row| {
-                div()
-                    .flex()
-                    .when(!voice.lead(), |this| this.justify_end())
-                    .children(row.map(&fragment))
-            })),
+    match wrapped {
+        Some(Wrapped { rows, widths }) => {
+            div()
+                .flex()
+                .flex_col()
+                .text_left()
+                .children(rows.into_iter().map(|row| {
+                    let text = SharedString::from(fragments[row.clone()].concat());
+                    let reveal = revealed(
+                        row, &widths, &spoken, &windows, &evenly, position, edge_fade,
+                    );
+                    div()
+                        .flex()
+                        .when(!voice.lead(), |this| this.justify_end())
+                        .child(lit(text, reveal))
+                }))
+        }
         None => div()
             .flex()
             .flex_wrap()
             .text_left()
             .when(!voice.lead(), |this| this.justify_end())
-            .children((0..fragments.len()).map(fragment)),
+            .children((0..fragments.len()).map(|index| {
+                let share = sweep(spoken.get(index).copied().unwrap_or(index));
+                let reveal = Reveal {
+                    shown: share > 0.,
+                    width: None,
+                    share,
+                    landing: match share < 1. {
+                        true => ((1. - share) / LANDING).min(1.),
+                        false => 0.,
+                    },
+                };
+                lit(SharedString::from(fragments[index].clone()), reveal)
+            })),
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Reveal {
+    shown: bool,
+    width: Option<Pixels>,
+    share: f32,
+    landing: f32,
+}
+
+fn revealed(
+    row: Range<usize>,
+    widths: &[Pixels],
+    spoken: &[usize],
+    windows: &[(std::time::Duration, std::time::Duration, bool)],
+    evenly: &[bool],
+    position: std::time::Duration,
+    fade: Pixels,
+) -> Reveal {
+    let mut front = px(0.);
+    let mut landing = 0.;
+    let mut offset = px(0.);
+    let mut soft = false;
+    for index in row {
+        let mine = widths.get(index).copied().unwrap_or(px(0.));
+        let word = spoken.get(index).copied().unwrap_or(index);
+        let Some(&(start, end, last)) = windows.get(word) else {
+            offset += mine;
+            continue;
+        };
+
+        // a wide character or a phrase timed as one word fills at an even pace;
+        // the eased curve only reads as a flourish across Latin letters
+        let even = evenly.get(word).copied().unwrap_or(false);
+        soft |= even;
+        let share = match even {
+            true => progress_between(start, end, position),
+            false => swept(start, end, position, last),
+        };
+        if share > 0. {
+            // a word covering several fragments hands each its own slice of the
+            // sweep, and the edge follows whichever reaches furthest
+            let before: Pixels = (0..index)
+                .filter(|place| spoken.get(*place).copied() == Some(word))
+                .filter_map(|place| widths.get(place).copied())
+                .sum();
+            let whole: Pixels = before
+                + (index..spoken.len())
+                    .filter(|place| spoken.get(*place).copied() == Some(word))
+                    .filter_map(|place| widths.get(place).copied())
+                    .sum();
+            let part = match mine > px(0.) {
+                true => ((whole * share - before) / mine).clamp(0., 1.),
+                false => 0.,
+            };
+            let reach = offset + mine * part;
+            if part > 0. && reach > front {
+                front = reach;
+                landing = match share < 1. {
+                    true => ((1. - share) / LANDING).min(1.),
+                    false => 0.,
+                };
+            }
+        }
+        offset += mine;
+    }
+
+    // an even fill holds one soft edge, never wider than the text left to
+    // reveal: hardening it on every character would drag the edge back each time
+    if soft && fade > px(0.) {
+        landing = ((offset - front) / fade).min(1.);
+    }
+
+    Reveal {
+        shown: front > px(0.),
+        width: Some(front),
+        share: 1.,
+        landing,
     }
 }
 
@@ -1394,7 +1547,7 @@ fn secondary_lyrics_lane(
         (_, _, true) => theme.muted_foreground,
         (true, _, false) => theme.foreground,
         (false, true, false) => theme.muted_foreground.opacity(PAST),
-        (false, false, false) => theme.muted_foreground,
+        (false, false, false) => theme.muted_foreground.opacity(AHEAD),
     };
     let size = theme.text(Text::Body);
     let karaoke_capable = sung.karaoke && lane.worded();
@@ -1466,14 +1619,26 @@ fn karaoke_window(
         0 => line_start.min(word.start),
         _ => word.start,
     };
-    let end = words
-        .get(index + 1)
-        .map(|next| next.start.max(start))
-        .unwrap_or_else(|| word.end.max(start));
+    let sung = word.end.max(start);
+    let end = match words.get(index + 1) {
+        // a rest after a word ends its sweep there rather than dragging it along
+        Some(next) => match sung > start {
+            true => next.start.max(start).min(sung),
+            false => next.start.max(start),
+        },
+        None => sung,
+    };
     (start, end)
 }
 
 fn karaoke_fragments(line: &str, words: &[music::LyricsWord]) -> Vec<String> {
+    karaoke_parts(line, words)
+        .into_iter()
+        .map(|(text, _)| text)
+        .collect()
+}
+
+fn karaoke_parts(line: &str, words: &[music::LyricsWord]) -> Vec<(String, usize)> {
     let mut starts = Vec::with_capacity(words.len());
     let mut cursor = 0;
     for word in words {
@@ -1494,22 +1659,24 @@ fn karaoke_fragments(line: &str, words: &[music::LyricsWord]) -> Vec<String> {
     starts
         .iter()
         .enumerate()
-        .map(|(index, start)| {
+        .flat_map(|(index, start)| {
             let start = match index {
                 0 => 0,
                 _ => *start,
             };
             let end = starts.get(index + 1).copied().unwrap_or(line.len());
-            line[start..end].to_owned()
+            plain_lyrics_fragments(&line[start..end])
+                .into_iter()
+                .map(move |piece| (piece, index))
         })
         .collect()
 }
 
-fn spaced_words(words: &[music::LyricsWord]) -> Vec<String> {
+fn spaced_words(words: &[music::LyricsWord]) -> Vec<(String, usize)> {
     words
         .iter()
         .enumerate()
-        .map(|(index, word)| {
+        .flat_map(|(index, word)| {
             let mut text = word.text.clone();
             if words
                 .get(index + 1)
@@ -1517,7 +1684,9 @@ fn spaced_words(words: &[music::LyricsWord]) -> Vec<String> {
             {
                 text.push(' ');
             }
-            text
+            plain_lyrics_fragments(&text)
+                .into_iter()
+                .map(move |piece| (piece, index))
         })
         .collect()
 }
@@ -1530,6 +1699,9 @@ fn needs_space(left: &str, right: &str) -> bool {
         return false;
     };
     if last.is_whitespace() || first.is_whitespace() {
+        return false;
+    }
+    if wide(last) || wide(first) {
         return false;
     }
     !matches!(last, '(' | '[' | '{' | '\'' | '’' | '-' | '—')
@@ -1554,14 +1726,16 @@ fn plain_lyrics_fragments(line: &str) -> Vec<String> {
     let mut fragments = Vec::new();
     let mut start = 0;
     let mut spacing = false;
+    let mut previous = None;
     for (index, letter) in line.char_indices() {
         if letter.is_whitespace() {
             spacing = true;
-        } else if spacing {
+        } else if spacing || previous.is_some_and(|previous| parts(previous, letter)) {
             fragments.push(line[start..index].to_owned());
             start = index;
             spacing = false;
         }
+        previous = Some(letter);
     }
     if start < line.len() {
         fragments.push(line[start..].to_owned());
@@ -1569,12 +1743,18 @@ fn plain_lyrics_fragments(line: &str) -> Vec<String> {
     fragments
 }
 
+#[derive(Clone)]
+struct Wrapped {
+    rows: Vec<Range<usize>>,
+    widths: Vec<Pixels>,
+}
+
 fn lyrics_wrap_rows(
     fragments: &[String],
     font_size: Pixels,
     width: Pixels,
     window: &mut Window,
-) -> Option<Vec<Range<usize>>> {
+) -> Option<Wrapped> {
     if width <= px(0.) {
         return None;
     }
@@ -1596,19 +1776,91 @@ fn lyrics_wrap_rows(
                 .width
         })
         .collect::<Vec<_>>();
-    Some(wrap_fragment_widths(&widths, width))
+    let breaks = fragments
+        .iter()
+        .enumerate()
+        .map(|(index, fragment)| match index.checked_sub(1) {
+            Some(previous) => separable(&fragments[previous], fragment),
+            None => true,
+        })
+        .collect::<Vec<_>>();
+    Some(Wrapped {
+        rows: wrap_fragment_widths(&widths, &breaks, width),
+        widths,
+    })
 }
 
-fn wrap_fragment_widths(widths: &[Pixels], width: Pixels) -> Vec<Range<usize>> {
+fn separable(left: &str, right: &str) -> bool {
+    if left.ends_with(char::is_whitespace) || right.starts_with(char::is_whitespace) {
+        return true;
+    }
+
+    match (left.chars().next_back(), right.chars().next()) {
+        (Some(left), Some(right)) => parts(left, right),
+        _ => false,
+    }
+}
+
+fn wide(letter: char) -> bool {
+    matches!(letter,
+        '\u{2E80}'..='\u{303E}'
+        | '\u{3041}'..='\u{33FF}'
+        | '\u{3400}'..='\u{4DBF}'
+        | '\u{4E00}'..='\u{9FFF}'
+        | '\u{A000}'..='\u{A4CF}'
+        | '\u{AC00}'..='\u{D7AF}'
+        | '\u{F900}'..='\u{FAFF}'
+        | '\u{FF00}'..='\u{FF60}'
+    )
+}
+
+fn parts(left: char, right: char) -> bool {
+    if !wide(left) || !wide(right) {
+        return false;
+    }
+
+    !matches!(
+        right,
+        '、' | '。'
+            | '，'
+            | '．'
+            | '！'
+            | '？'
+            | '：'
+            | '；'
+            | '」'
+            | '』'
+            | '）'
+            | '】'
+            | '〉'
+            | '》'
+            | '〕'
+            | '・'
+            | 'ー'
+            | '…'
+            | '々'
+            | 'ゝ'
+            | 'ゞ'
+            | 'っ'
+            | 'ッ'
+    ) && !matches!(left, '「' | '『' | '（' | '【' | '〈' | '《' | '〔')
+}
+
+fn wrap_fragment_widths(widths: &[Pixels], breaks: &[bool], width: Pixels) -> Vec<Range<usize>> {
     let mut rows = Vec::new();
     let mut start = 0;
     let mut used = px(0.);
 
     for (index, fragment) in widths.iter().copied().enumerate() {
-        if index > start && used + fragment > width {
-            rows.push(start..index);
-            start = index;
-            used = px(0.);
+        if index > start
+            && used + fragment > width
+            && let Some(split) = (start + 1..=index)
+                .rev()
+                .find(|at| breaks.get(*at).copied().unwrap_or(true))
+        {
+            rows.push(start..split);
+            used = widths[split..index].iter().copied().sum();
+            start = split;
         }
         used += fragment;
     }
@@ -1706,6 +1958,52 @@ fn sung_line(lines: &[music::LyricsLine], position: std::time::Duration) -> Opti
     }
 }
 
+fn lanes_room(
+    lanes: &[music::LyricsLane],
+    scripts: Option<RomanizationScripts>,
+    size: Pixels,
+    width: Pixels,
+    window: &mut Window,
+) -> Pixels {
+    let rows = lanes
+        .iter()
+        .map(|lane| {
+            let spoken = wrapped_rows(&lane.text, size, width, window);
+            let romanized = selected_romanization(&lane.romanized, scripts)
+                .map_or(0, |text| wrapped_rows(&text, size, width, window));
+            spoken + romanized
+        })
+        .sum::<usize>();
+
+    size * LANE_LEADING * rows as f32
+}
+
+fn wrapped_rows(text: &str, size: Pixels, width: Pixels, window: &mut Window) -> usize {
+    let fragments = plain_lyrics_fragments(text);
+    lyrics_wrap_rows(&fragments, size, width, window).map_or(1, |wrapped| wrapped.rows.len().max(1))
+}
+
+fn viewport_haze(scroll: &ScrollHandle, row: usize, view: Bounds<Pixels>, margin: Pixels) -> f32 {
+    let height = view.size.height;
+    let Some(item) = scroll.bounds_for_item(row) else {
+        return 0.;
+    };
+    if height <= px(0.) {
+        return 0.;
+    }
+    let top = item.origin.y - view.origin.y + scroll.offset().y;
+    if top + item.size.height + margin < px(0.) || top - margin > height {
+        return 0.;
+    }
+    let travel = top - height * PIN;
+    let reach = height
+        * match travel >= px(0.) {
+            true => 1. - PIN,
+            false => PIN,
+        };
+    (travel.abs() / reach.max(px(1.))).clamp(0., 1.).powf(HAZE)
+}
+
 fn line_has_passed(line: &music::LyricsLine, position: std::time::Duration) -> bool {
     line.sung_end().is_some_and(|end| position >= end)
 }
@@ -1721,7 +2019,11 @@ fn instrumental_row(progress: f32, past: bool, verse: Pixels, theme: &ui::Theme)
             let note_progress = (progress * 3. - index as f32).clamp(0., 1.);
             let tint = match past {
                 true => theme.muted_foreground.opacity(PAST),
-                false => mix(theme.muted_foreground, theme.primary, note_progress),
+                false => mix(
+                    theme.muted_foreground.opacity(AHEAD),
+                    theme.primary,
+                    note_progress,
+                ),
             };
             div()
                 .size(note_size)
@@ -1984,14 +2286,14 @@ mod tests {
 
     #[test]
     fn lyrics_wrap_at_the_active_size_plan() {
-        let rows = wrap_fragment_widths(&[px(40.), px(35.), px(30.), px(20.)], px(80.));
+        let rows = wrap_fragment_widths(&[px(40.), px(35.), px(30.), px(20.)], &[true; 4], px(80.));
 
         assert_eq!(rows, [0..2, 2..4]);
     }
 
     #[test]
     fn lyrics_keep_an_oversized_fragment_on_its_own_row() {
-        let rows = wrap_fragment_widths(&[px(120.), px(30.), px(30.)], px(80.));
+        let rows = wrap_fragment_widths(&[px(120.), px(30.), px(30.)], &[true; 3], px(80.));
 
         assert_eq!(rows, [0..1, 1..3]);
     }
@@ -2013,7 +2315,7 @@ mod tests {
 
         assert_eq!(
             karaoke_window(Duration::from_millis(1000), &words, 0),
-            (Duration::from_millis(1000), Duration::from_millis(2000))
+            (Duration::from_millis(1000), Duration::from_millis(1900))
         );
     }
 

--- a/crates/views/src/chrome/player_bar.rs
+++ b/crates/views/src/chrome/player_bar.rs
@@ -50,7 +50,8 @@ impl PlayerBar {
         cx.observe(&library, |_, _, cx| cx.notify()).detach();
         cx.observe(&settings, |_, _, cx| cx.notify()).detach();
 
-        let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+        let me = cx.entity_id();
+        let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(me));
 
         Self {
             playback,

--- a/crates/views/src/chrome/sidebar_left.rs
+++ b/crates/views/src/chrome/sidebar_left.rs
@@ -72,8 +72,9 @@ impl SidebarLeft {
         let settings = Sonora::global(cx).settings.clone();
         let session = Sonora::global(cx).session.clone();
         let playback = Sonora::global(cx).playback.clone();
-        let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
-        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()));
+        let me = cx.entity_id();
+        let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(me));
+        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(me));
         let width = px(settings.read(cx).sidebar_width()).clamp(MIN_WIDTH, MAX_WIDTH);
         let open = settings.read(cx).sidebar_open();
         let trail = router::trail(cx);

--- a/crates/views/src/chrome/sidebar_right.rs
+++ b/crates/views/src/chrome/sidebar_right.rs
@@ -1,5 +1,5 @@
 use gpui::prelude::*;
-use gpui::{Context, Entity, Pixels, Render, Window, div, px};
+use gpui::{Context, Entity, Pixels, Render, StyleRefinement, Window, div, px};
 use state::{AppSettings, Playback, Queue, SideTab, Sonora};
 use ui::{ActiveTheme as _, MIN_CONTENT, Panel, Room, Side};
 
@@ -123,7 +123,11 @@ impl Render for SidebarRight {
             }))
             .when(!theme.transparent, |this| this.bg(theme.background))
             .border_color(theme.border)
-            .child(self.aside.clone())
+            .child(
+                self.aside
+                    .clone()
+                    .cached(StyleRefinement::default().size_full()),
+            )
             .into_any_element()
     }
 }

--- a/crates/views/src/screens/artist.rs
+++ b/crates/views/src/screens/artist.rs
@@ -123,8 +123,9 @@ impl ArtistView {
         cx: &mut Context<Self>,
     ) -> Self {
         let width = MIN_CONTENT;
-        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()));
-        let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+        let id = cx.entity_id();
+        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(id));
+        let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(id));
         let settings = Sonora::global(cx).settings.clone();
         let saved = settings.read(cx).table(SECTION);
         let sorting = settings.read(cx).sorting(SECTION);
@@ -134,7 +135,7 @@ impl ArtistView {
         let scroll = scrollbar.read(cx).scroll().clone();
         let shown = Rc::new(Cell::new(LISTED));
         let table = cx.new(|cx| {
-            let menu_scrollbar = cx.new(|_| Scrollbar::inset());
+            let menu_scrollbar = cx.new(|_| Scrollbar::inset().watching(id));
             let source = TrackSource::new(
                 columns,
                 ArtistTracks {
@@ -215,7 +216,7 @@ impl ArtistView {
             releases_expanded: false,
             width,
             scrollbar,
-            about_bar: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
+            about_bar: cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(id)),
             about_open: false,
             table,
             shown,

--- a/crates/views/src/screens/detail.rs
+++ b/crates/views/src/screens/detail.rs
@@ -19,7 +19,7 @@ use crate::chrome::tools::{self, Sift, Sliders};
 use crate::chrome::{Chrome, Searchable, Toolbar, Tooled};
 use crate::shared::hero::{HeroMetaStrip, HeroPlayButton, PageHero, release_date_label};
 use crate::shared::tracks::{
-    self, PlaybackStatus, TrackField, TrackSieve, TrackSource, Tracks, playback_status,
+    PlaybackStatus, TrackField, TrackSieve, TrackSource, Tracks, playback_status,
 };
 use crate::shared::{cells, page};
 
@@ -72,11 +72,12 @@ impl DetailView {
         let saved = settings.read(cx).table(section);
         let width = MIN_CONTENT;
 
-        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()));
+        let id = cx.entity_id();
+        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(id));
         let scroll = scrollbar.read(cx).scroll().clone();
 
         let table = cx.new(|cx| {
-            let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+            let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(id));
             let source = TrackSource::new(
                 columns,
                 DetailTracks(detail.clone()),
@@ -275,10 +276,10 @@ impl DetailView {
             .flex()
             .items_center()
             .gap_2()
-            .child(HeroPlayButton::new(
+            .child(HeroPlayButton::listed(
                 "play-detail",
                 label,
-                tracks::ordered(&self.table, cx),
+                &self.table,
                 self.playback.clone(),
             ))
             .children(self.library_button(cx))

--- a/crates/views/src/screens/genre.rs
+++ b/crates/views/src/screens/genre.rs
@@ -35,7 +35,8 @@ impl GenreView {
     ) -> Self {
         let settings = Sonora::global(cx).settings.clone();
         let mode = settings.read(cx).view_or(SECTION, Mode::Cards);
-        let shelves = cx.new(|_| Shelves::new("genre-shelf", playback.clone()));
+        let id = cx.entity_id();
+        let shelves = cx.new(|_| Shelves::new("genre-shelf", id, playback.clone()));
 
         cx.observe(&detail, |this, _, cx| {
             this.shelves.update(cx, |shelves, _| shelves.reset());
@@ -54,7 +55,7 @@ impl GenreView {
             detail,
             settings,
             shelves,
-            scrollbar: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
+            scrollbar: cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(id)),
             toolbar,
             popovers: Popovers::default(),
             mode,

--- a/crates/views/src/screens/home/mod.rs
+++ b/crates/views/src/screens/home/mod.rs
@@ -2,7 +2,7 @@ use crate::chrome::Chrome;
 use crate::shared::menu::ItemMenu;
 use gpui::prelude::*;
 use gpui::{Context, Entity, Pixels, Point, Render, ScrollHandle, Window, div, px};
-use state::{Home, Playback};
+use state::{Home, Playback, Sonora};
 use ui::{ActiveTheme as _, Mode, Popup, Scrollbar, Scroller};
 
 use crate::shared::cells;
@@ -31,7 +31,8 @@ impl HomeView {
         playback: Entity<Playback>,
         cx: &mut Context<Self>,
     ) -> Self {
-        let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+        let me = cx.entity_id();
+        let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(me));
         let track_menu = ItemMenu::new(playlist_scrollbar);
 
         cx.observe(&home, |this, _, cx| {
@@ -44,7 +45,10 @@ impl HomeView {
         let chrome = Chrome::entity(cx);
         cx.observe(&chrome, |_, _, cx| cx.notify()).detach();
 
-        let shelves = cx.new(|_| Shelves::new("home-shelf", playback.clone()));
+        let library = Sonora::global(cx).library.clone();
+        cx.observe(&library, |_, _, cx| cx.notify()).detach();
+
+        let shelves = cx.new(|_| Shelves::new("home-shelf", me, playback.clone()));
         cx.observe(&shelves, |_, _, cx| cx.notify()).detach();
 
         let current_playback = playback_status(&playback, cx);
@@ -65,7 +69,7 @@ impl HomeView {
             width: Pixels::ZERO,
             quick_picks_columns: 0,
             quick_picks_page: 0,
-            scrollbar: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
+            scrollbar: cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(me)),
             track_menu,
             context_menu: None,
         }

--- a/crates/views/src/screens/library/local.rs
+++ b/crates/views/src/screens/library/local.rs
@@ -113,11 +113,12 @@ impl LocalView {
             )
         };
 
-        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()));
+        let id = cx.entity_id();
+        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(id));
         let scroll = scrollbar.read(cx).scroll().clone();
 
         let tracks = cx.new(|cx| {
-            let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+            let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(id));
             let source = TrackSource::new(
                 LIBRARY_COLUMNS,
                 LocalTracks(library.clone()),
@@ -162,6 +163,7 @@ impl LocalView {
             for table in this.tables() {
                 table.refresh(cx);
             }
+            cx.notify();
         })
         .detach();
 

--- a/crates/views/src/screens/library/mod.rs
+++ b/crates/views/src/screens/library/mod.rs
@@ -201,11 +201,12 @@ impl LibraryView {
             |section: Section, cx: &App| settings.read(cx).view_or(section.key(), section.mode());
         let views = Section::ALL.map(|section| viewed(section, cx));
 
-        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()));
+        let id = cx.entity_id();
+        let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(id));
         let scroll = scrollbar.read(cx).scroll().clone();
 
         let tracks = cx.new(|cx| {
-            let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+            let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(id));
             let source = TrackSource::new(
                 LIBRARY_COLUMNS,
                 LibraryTracks(library.clone()),
@@ -278,6 +279,7 @@ impl LibraryView {
             for table in this.tables() {
                 table.refresh(cx);
             }
+            cx.notify();
         })
         .detach();
 
@@ -317,7 +319,7 @@ impl LibraryView {
         let me = cx.entity();
         let toolbar = Toolbar::searchable(&me, cx);
 
-        let card_scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()));
+        let card_scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(id));
 
         Self {
             library,
@@ -471,10 +473,10 @@ impl LibraryView {
             .accent()
             .eyebrow(t!("detail-playlist"))
             .meta(strip)
-            .actions(HeroPlayButton::new(
+            .actions(HeroPlayButton::listed(
                 "play-liked-songs",
                 t!("library-play-liked-songs"),
-                tracks::ordered(&self.tracks, cx),
+                &self.tracks,
                 self.playback.clone(),
             ))
             .into_any_element()

--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -10,7 +10,7 @@ use ui::Input;
 
 use crate::chrome::Chrome;
 use crate::shared::menu::{ItemMenu, item_menu};
-use state::{Genres, Hit, Kind, Playback, Search};
+use state::{Genres, Hit, Kind, Playback, Search, Sonora};
 use ui::ActiveTheme as _;
 use ui::{
     Card, Deck, Pin, Pinnable, Popup, Room, Scrollbar, Scroller, Separator, Text, Theme, VAST,
@@ -94,6 +94,8 @@ impl SearchView {
         .detach();
         let chrome = Chrome::entity(cx);
         cx.observe(&chrome, |_, _, cx| cx.notify()).detach();
+        let library = Sonora::global(cx).library.clone();
+        cx.observe(&library, |_, _, cx| cx.notify()).detach();
         let current_playback = playback_status(&playback, cx);
         cx.observe(&playback, |this, playback, cx| {
             let current = playback_status(&playback, cx);
@@ -107,7 +109,8 @@ impl SearchView {
         let asked = input.read(cx).text().to_owned();
         search.update(cx, |search, cx| search.ask(&asked, cx));
 
-        let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+        let me = cx.entity_id();
+        let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(me));
 
         Self {
             input,
@@ -115,11 +118,11 @@ impl SearchView {
             genres,
             playback,
             playback_status: current_playback,
-            songs: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
-            artists: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
-            albums: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
-            mixed: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
-            browsing: cx.new(|_| Scrollbar::new(ScrollHandle::new())),
+            songs: cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(me)),
+            artists: cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(me)),
+            albums: cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(me)),
+            mixed: cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(me)),
+            browsing: cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(me)),
             track_menu: ItemMenu::new(playlist_scrollbar),
             context_menu: None,
         }

--- a/crates/views/src/screens/song.rs
+++ b/crates/views/src/screens/song.rs
@@ -6,7 +6,7 @@ use gpui::{
 use i18n::t;
 use music::{Credit, Track};
 use router::{Destination, Link as _};
-use state::{Playback, SongDetail};
+use state::{Playback, SongDetail, Sonora};
 use ui::{
     ActiveTheme as _, Avatar, Button, Fact, InfoCard, Initials, Popup, Scrollbar, Scroller,
     Skeleton, Text, clock,
@@ -72,13 +72,16 @@ impl SongView {
         })
         .detach();
         cx.observe(&playback, |_, _, cx| cx.notify()).detach();
-        let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+        let library = Sonora::global(cx).library.clone();
+        cx.observe(&library, |_, _, cx| cx.notify()).detach();
+        let me = cx.entity_id();
+        let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(me));
 
         Self {
             detail,
             playback,
-            scrollbar: cx.new(|_| Scrollbar::new(gpui::ScrollHandle::new())),
-            about_bar: cx.new(|_| Scrollbar::new(gpui::ScrollHandle::new())),
+            scrollbar: cx.new(|_| Scrollbar::new(gpui::ScrollHandle::new()).watching(me)),
+            about_bar: cx.new(|_| Scrollbar::new(gpui::ScrollHandle::new()).watching(me)),
             about_open: false,
             track_menu: ItemMenu::new(playlist_scrollbar),
             context_menu: None,

--- a/crates/views/src/shared/cells.rs
+++ b/crates/views/src/shared/cells.rs
@@ -92,6 +92,7 @@ pub(crate) fn index<F>(
     let dimmed = |icon, color| {
         svg()
             .path(icon)
+            .id(("index-glyph", cell.row))
             .size(glyph(&theme))
             .flex_none()
             .text_color(color)
@@ -102,6 +103,7 @@ pub(crate) fn index<F>(
         Some(PlaybackState::Playing) => dimmed(PLAYING, theme.foreground),
         Some(_) => dimmed(PAUSE, theme.muted_foreground),
         None => div()
+            .id(("index-number", cell.row))
             .text_color(match playable {
                 true => theme.muted_foreground,
                 false => faded,

--- a/crates/views/src/shared/hero.rs
+++ b/crates/views/src/shared/hero.rs
@@ -9,8 +9,11 @@ use i18n::t;
 use music::Track;
 use state::{Playback, PlaybackState};
 use ui::{
-    ActiveTheme as _, Artwork, Button, ExplicitBadge, LEADING, Pin, Pinnable as _, Text, upper,
+    ActiveTheme as _, Artwork, Button, ExplicitBadge, GridState, LEADING, Pin, Pinnable as _, Text,
+    upper,
 };
+
+use crate::shared::tracks::{self, TrackSource};
 
 pub(crate) fn release_date_label(value: &str) -> SharedString {
     let parts: Vec<_> = value.split('-').collect();
@@ -87,11 +90,39 @@ impl RenderOnce for HeroMetaStrip {
     }
 }
 
+enum Listing {
+    Owned(Vec<Track>),
+    Listed(Entity<GridState<TrackSource>>),
+}
+
+impl Listing {
+    fn first(&self, cx: &App) -> Option<usize> {
+        match self {
+            Self::Owned(tracks) => tracks.iter().position(|track| track.playable),
+            Self::Listed(table) => tracks::first_playable(table, cx),
+        }
+    }
+
+    fn holds(&self, id: &str, cx: &App) -> bool {
+        match self {
+            Self::Owned(tracks) => tracks.iter().any(|track| track.id.as_deref() == Some(id)),
+            Self::Listed(table) => tracks::holds(table, id, cx),
+        }
+    }
+
+    fn queue(&self, cx: &App) -> Vec<Track> {
+        match self {
+            Self::Owned(tracks) => tracks.clone(),
+            Self::Listed(table) => tracks::ordered(table, cx),
+        }
+    }
+}
+
 #[derive(IntoElement)]
 pub(crate) struct HeroPlayButton {
     id: ElementId,
     label: SharedString,
-    tracks: Vec<Track>,
+    listing: Listing,
     playback: Entity<Playback>,
 }
 
@@ -105,7 +136,21 @@ impl HeroPlayButton {
         Self {
             id: id.into(),
             label: label.into(),
-            tracks,
+            listing: Listing::Owned(tracks),
+            playback,
+        }
+    }
+
+    pub(crate) fn listed(
+        id: impl Into<ElementId>,
+        label: impl Into<SharedString>,
+        table: &Entity<GridState<TrackSource>>,
+        playback: Entity<Playback>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            label: label.into(),
+            listing: Listing::Listed(table.clone()),
             playback,
         }
     }
@@ -113,16 +158,12 @@ impl HeroPlayButton {
 
 impl RenderOnce for HeroPlayButton {
     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
-        let first_playable = self.tracks.iter().position(|track| track.playable);
+        let first_playable = self.listing.first(cx);
         let state = {
             let playback = self.playback.read(cx);
             let current = playback.track().and_then(|track| track.id.as_deref());
             current
-                .filter(|current| {
-                    self.tracks
-                        .iter()
-                        .any(|track| track.id.as_deref() == Some(*current))
-                })
+                .filter(|current| self.listing.holds(current, cx))
                 .map(|_| playback.state().clone())
         };
         let (label, icon, blocked) = match &state {
@@ -133,7 +174,7 @@ impl RenderOnce for HeroPlayButton {
         };
         let disabled = first_playable.is_none() || blocked;
         let first_playable = first_playable.unwrap_or_default();
-        let tracks = self.tracks;
+        let listing = self.listing;
         let playback = self.playback;
 
         div().flex().child(
@@ -147,7 +188,10 @@ impl RenderOnce for HeroPlayButton {
                         Some(PlaybackState::Playing) => playback.pause(cx),
                         Some(PlaybackState::Paused) => playback.resume(cx),
                         Some(PlaybackState::Loading) => {}
-                        _ => playback.start(tracks.clone(), first_playable, cx),
+                        _ => {
+                            let queued = listing.queue(cx);
+                            playback.start(queued, first_playable, cx)
+                        }
                     });
                 }),
         )

--- a/crates/views/src/shared/shelves.rs
+++ b/crates/views/src/shared/shelves.rs
@@ -1,7 +1,7 @@
 use gpui::prelude::*;
 use gpui::{
-    AnyElement, App, Context, Div, ElementId, Entity, FontWeight, MouseDownEvent, Pixels, Point,
-    ScrollHandle, ScrollWheelEvent, SharedString, WeakEntity, Window, div, point, px,
+    AnyElement, App, Context, Div, ElementId, Entity, EntityId, FontWeight, MouseDownEvent, Pixels,
+    Point, ScrollHandle, ScrollWheelEvent, SharedString, WeakEntity, Window, div, point, px,
 };
 use std::cell::Cell;
 use std::rc::Rc;
@@ -34,6 +34,7 @@ type Rail = (ScrollHandle, Glide);
 
 pub(crate) struct Shelves {
     id: &'static str,
+    host: EntityId,
     playback: Entity<Playback>,
     rails: Vec<Rail>,
     above: Rc<Cell<Option<Pixels>>>,
@@ -41,9 +42,10 @@ pub(crate) struct Shelves {
 }
 
 impl Shelves {
-    pub(crate) fn new(id: &'static str, playback: Entity<Playback>) -> Self {
+    pub(crate) fn new(id: &'static str, host: EntityId, playback: Entity<Playback>) -> Self {
         Self {
             id,
+            host,
             playback,
             rails: Vec::new(),
             above: Rc::new(Cell::new(None)),
@@ -110,7 +112,9 @@ impl Shelves {
         cx: &mut Context<Self>,
     ) -> AnyElement {
         while self.rails.len() < sections.len() {
-            self.rails.push((ScrollHandle::new(), Glide::default()));
+            let mut glide = Glide::default();
+            glide.watch(self.host);
+            self.rails.push((ScrollHandle::new(), glide));
         }
         for (scroll, glide) in &self.rails {
             glide.sync(scroll);

--- a/crates/views/src/shared/tracks/mod.rs
+++ b/crates/views/src/shared/tracks/mod.rs
@@ -41,6 +41,30 @@ pub(crate) trait Tracks: 'static {
     fn is_loading(&self, cx: &App) -> bool;
 }
 
+pub(crate) fn first_playable(table: &Entity<GridState<TrackSource>>, cx: &App) -> Option<usize> {
+    let state = table.read(cx);
+    let delegate = state.delegate();
+
+    (0..delegate.row_count()).find(|display| {
+        delegate
+            .source()
+            .peek(delegate.row(*display), cx)
+            .is_some_and(|track| track.playable)
+    })
+}
+
+pub(crate) fn holds(table: &Entity<GridState<TrackSource>>, id: &str, cx: &App) -> bool {
+    let state = table.read(cx);
+    let delegate = state.delegate();
+
+    (0..delegate.row_count()).any(|display| {
+        delegate
+            .source()
+            .peek(delegate.row(display), cx)
+            .is_some_and(|track| track.id.as_deref() == Some(id))
+    })
+}
+
 pub(crate) fn ordered(table: &Entity<GridState<TrackSource>>, cx: &App) -> Vec<Track> {
     let state = table.read(cx);
     let delegate = state.delegate();
@@ -292,6 +316,10 @@ impl TrackSource {
 
     pub(crate) fn at(&self, row: usize, cx: &App) -> Option<Track> {
         self.provider.tracks(cx).get(row).cloned()
+    }
+
+    pub(crate) fn peek<'a>(&self, row: usize, cx: &'a App) -> Option<&'a Track> {
+        self.provider.tracks(cx).get(row)
     }
 
     pub(crate) fn menu(&self) -> &ItemMenu {

--- a/crates/views/src/shells/fullscreen.rs
+++ b/crates/views/src/shells/fullscreen.rs
@@ -82,7 +82,8 @@ impl FullscreenView {
         let aside = cx.new(|cx| Aside::new(queue.clone(), playback.clone(), SideTab::Lyrics, cx));
         aside.update(cx, |aside, _| aside.strip());
         cx.observe(&aside, |_, _, cx| cx.notify()).detach();
-        let playlist_scrollbar = cx.new(|_| Scrollbar::inset());
+        let me = cx.entity_id();
+        let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(me));
 
         let mut this = Self {
             playback,

--- a/crates/views/src/shells/workspace.rs
+++ b/crates/views/src/shells/workspace.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 
 use gpui::prelude::*;
-use gpui::{AnyView, App, Context, Entity, FocusHandle, Render, px};
+use gpui::{AnyView, App, Context, Entity, FocusHandle, Render, StyleRefinement, px};
 use gpui::{Window, div};
 use input::WORKSPACE_CONTEXT;
 use state::{Playback, Queue, SideTab};
@@ -225,7 +225,14 @@ impl Render for Workspace {
                                     .layer_scale(scale)
                                     .opacity(1. - hidden)
                                     .blur(VIEW_BLUR * hidden)
-                                    .child(self.content.clone()),
+                                    .child(match hidden > 0. {
+                                        true => self.content.clone().into_any_element(),
+                                        false => self
+                                            .content
+                                            .clone()
+                                            .cached(StyleRefinement::default().size_full())
+                                            .into_any_element(),
+                                    }),
                             ),
                     )
                     .child(self.sidebar_right.clone())


### PR DESCRIPTION
## Summary

- blur and dim a lyric line by how far it sits from the sung one on screen rather than by how many lines away it is, never far enough to be unreadable
- show background vocals only on the line being sung, fading them and the space they take in and out
- carry the next line into place more slowly, leaving manual scrolling untouched
- lay a word-by-word line out as one run per row, so turning karaoke on no longer widens word gaps or breaks a word across rows
- break Japanese, Chinese and Korean lines between characters, never before a mark that has to stay with the character before it
- fill wide characters and phrase-timed words at an even pace, and hold one soft highlight edge per row, so the highlight no longer stalls and jumps on CJK lyrics
- finish a word's highlight where it is sung instead of dragging it through a following rest