### PR TITLE
feat: look for a newer version on every platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Sonora looks for a newer version on Linux and macOS too, where the setting for it was already
+  offered but never did anything. It only tells you: installing in place stays a Windows-only path,
+  because that is the only build Sonora ships an installer for. The setting starts off there, since
+  a distribution or a tap can trail a release by weeks and there is nothing to act on until it
+  catches up, and the notice says to update Sonora the way you installed it.
+
 ## [0.19.0] - 2026-08-27
 
 ### Added

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -468,10 +468,11 @@ lyrics-writers = Written by { $writers }
 
 update-available = Sonora { $version } is out
 update-detail = You are on { $running }. Read what changed, or update now.
+update-detail-notes = You are on { $running }. Read what changed, then update Sonora the way you installed it.
 update-notes = What's new
 update-now = Update
 update-later = Later
 update-working = Downloading the update…
 update-failed = The update could not be installed. Try again from the releases page.
 settings-check-updates = Check for updates
-settings-check-updates-detail = Ask GitHub once at startup whether a newer version is out
+settings-check-updates-detail = Ask GitHub once at startup whether a newer version is out. Sonora installs the update itself on Windows only; elsewhere it points you at what changed

--- a/crates/state/src/settings.rs
+++ b/crates/state/src/settings.rs
@@ -198,7 +198,7 @@ impl Default for Values {
             romanized_lyrics: true,
             romanization_scripts: RomanizationScripts::default(),
             adaptive_menu: false,
-            check_updates: true,
+            check_updates: cfg!(target_os = "windows"),
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
             sidebar_open: true,
             sidebar_right_width: DEFAULT_SIDEBAR_RIGHT_WIDTH,

--- a/crates/state/src/updates.rs
+++ b/crates/state/src/updates.rs
@@ -13,7 +13,7 @@ const INSTALLER: &str = "Sonora-Setup.exe";
 const SUMS: &str = "SHA256SUMS";
 const UNINSTALLER: &str = "unins000.exe";
 const RUNNING: &str = env!("CARGO_PKG_VERSION");
-const OFFERED: bool = cfg!(target_os = "windows");
+const INSTALLABLE: bool = cfg!(target_os = "windows");
 const AGENT: &str = concat!(
     "sonora/",
     env!("CARGO_PKG_VERSION"),
@@ -69,7 +69,7 @@ impl Updates {
     }
 
     pub fn installable(&self) -> bool {
-        OFFERED
+        INSTALLABLE
             && installed()
             && self
                 .offered()
@@ -118,7 +118,7 @@ impl Updates {
     }
 
     fn look(&mut self, cx: &mut Context<Self>) {
-        if !OFFERED || !self.settings.read(cx).check_updates() {
+        if !self.settings.read(cx).check_updates() {
             return;
         }
         let http = self.http.clone();

--- a/crates/views/src/chrome/update_notice.rs
+++ b/crates/views/src/chrome/update_notice.rs
@@ -98,7 +98,12 @@ impl Render for UpdateNotice {
                     div()
                         .text_size(theme.text(Text::Small))
                         .text_color(theme.muted_foreground)
-                        .child(t!("update-detail", running = env!("CARGO_PKG_VERSION"))),
+                        .child(match installable {
+                            true => t!("update-detail", running = env!("CARGO_PKG_VERSION")),
+                            false => {
+                                t!("update-detail-notes", running = env!("CARGO_PKG_VERSION"))
+                            }
+                        }),
                 )
             })
             .child(


### PR DESCRIPTION
## Summary

- run the update check on Linux and macOS, where the setting was offered but the check returned early
- keep installing in place a Windows-only path, so elsewhere the card only links to what changed
- start the setting off outside Windows, where a distribution or a tap can trail a release and there is nothing to act on
- say to update Sonora the way it was installed, rather than offering an update button that cannot exist