### PR TITLE
release 0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Sonora looks for a newer version on Linux and macOS too, where the setting for it was already
+  offered but never did anything. It only tells you: installing in place stays a Windows-only path,
+  because that is the only build Sonora ships an installer for. The setting starts off there, since
+  a distribution or a tap can trail a release by weeks and there is nothing to act on until it
+  catches up, and the notice says to update Sonora the way you installed it.
+
 ## [0.19.0] - 2026-08-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,21 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Sonora redraws far less of the window at once. A word-by-word lyric line, a melody break and a
+  verse change each rebuilt the player bar, the sidebar and the toolbar on every frame they
+  animated, and scrolling a busy screen rebuilt the same things again, so the two together could not
+  keep pace. Scrolling Home or your songs while the lyrics move is smooth now.
 - Sonora looks for a newer version on Linux and macOS too, where the setting for it was already
   offered but never did anything. It only tells you: installing in place stays a Windows-only path,
   because that is the only build Sonora ships an installer for. The setting starts off there, since
   a distribution or a tap can trail a release by weeks and there is nothing to act on until it
   catches up, and the notice says to update Sonora the way you installed it.
+
+### Fixed
+
+- Long descriptions in Settings wrap onto a second line instead of being cut off.
+- The lyrics panel measures a line once per panel width rather than on every frame, and a verse well
+  outside the panel holds its place without being laid out at all.
 
 ## [0.19.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-08-27
+
 ### Changed
 
 - Sonora redraws far less of the window at once. A word-by-word lyric line, a melody break and a
@@ -877,7 +879,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Initial release: a native Spotify client with playback, an interactive queue, the saved library,
 search, album, playlist, artist and song pages, context menus and adaptive theming.
 
-[unreleased]: https://github.com/nolight132/sonora/compare/v0.19.0...HEAD
+[unreleased]: https://github.com/nolight132/sonora/compare/v0.19.1...HEAD
+[0.19.1]: https://github.com/nolight132/sonora/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/nolight132/sonora/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/nolight132/sonora/compare/v0.17.1...v0.18.0
 [0.17.1]: https://github.com/nolight132/sonora/compare/v0.17.0...v0.17.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,25 @@ rather than a `type_complexity` warning. The one lint that cannot be satisfied o
 `crates/ui/src/input/mod.rs`; it carries a targeted `#[allow]` on that test. Don't rewrite the case
 to please the lint.
 
+### Profiling
+
+`gpui` carries a `profiler` feature, exposed as sonora's own `profiler` feature so normal builds
+pay nothing:
+
+```sh
+cargo run --features profiler          # then set any of:
+GPUI_DEBUG_OVERLAY=minimal|full        # frame time, phase split, cache hits, dirty count
+GPUI_SHOW_REPAINTS=1                   # wash every view a notify named, fading over 160ms
+GPUI_LOG_NOTIFIES=1                    # once a second, which views were notified and how often
+ZED_MEASUREMENTS=1                     # raw frame durations on stderr
+```
+
+`full` paints its readout as quads and costs a few ms itself, so time with it hidden. The wash marks
+the view a notify named, not the ancestors dragged along with it — dirtiness always walks up the view
+path, so a leaf can never repaint without its ancestors' render functions running. There is no
+damage tracking in the renderer: the whole window is redrawn every frame, so caching saves element
+construction, layout and scene assembly, never GPU fill.
+
 ### Runtime environment
 
 |                   |                                                                                                                                   |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1642,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2516,7 +2516,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2537,6 +2537,7 @@ dependencies = [
  "gpui_macros",
  "gpui_shared_string",
  "gpui_util",
+ "hdrhistogram",
  "heapless",
  "http_client",
  "image",
@@ -2586,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "gpui_apple"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "anyhow",
  "block",
@@ -2609,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2655,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -2701,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2712,7 +2713,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "gpui",
  "gpui_linux",
@@ -2723,7 +2724,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "schemars",
  "serde",
@@ -2733,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "anyhow",
  "log",
@@ -2743,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2769,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -2894,6 +2895,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d1053f4708f0af3cf9fc5bffc7e68a914a3c45becb231c80068c9c3f78bea"
+dependencies = [
+ "base64",
+ "byteorder",
+ "crossbeam-channel",
+ "flate2",
+ "nom 8.0.0",
+ "num-traits",
 ]
 
 [[package]]
@@ -3023,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4087,7 +4102,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -5037,7 +5052,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "collections",
  "serde",
@@ -5888,7 +5903,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "derive_refineable",
 ]
@@ -6320,7 +6335,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "async-task",
  "backtrace",
@@ -6986,7 +7001,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "heapless",
  "log",
@@ -8134,7 +8149,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "perf",
  "quote",
@@ -9692,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9709,7 +9724,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -9720,7 +9735,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=c780e4abaf71e57bd9749d1a1fe3c46595308506#c780e4abaf71e57bd9749d1a1fe3c46595308506"
+source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "i18n"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "fluent-bundle",
  "gpui",
@@ -3383,7 +3383,7 @@ dependencies = [
 
 [[package]]
 name = "input"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "gpui",
  "ui",
@@ -4217,7 +4217,7 @@ dependencies = [
 
 [[package]]
 name = "music"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6053,7 +6053,7 @@ dependencies = [
 
 [[package]]
 name = "router"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "gpui",
  "ui",
@@ -6799,7 +6799,7 @@ dependencies = [
 
 [[package]]
 name = "sonora"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -6928,7 +6928,7 @@ dependencies = [
 
 [[package]]
 name = "state"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7949,7 +7949,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "gpui",
  "i18n",
@@ -8274,7 +8274,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "views"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "gpui",
  "i18n",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ env_logger = "0.11"
 fastrand = "2.5"
 futures = "0.3"
 fluent-bundle = "0.16"
-gpui = { git = "https://github.com/nolight132/zed", rev = "1b8071574557dcdd870e460529d14be4c86ed602" }
-gpui_platform = { git = "https://github.com/nolight132/zed", rev = "1b8071574557dcdd870e460529d14be4c86ed602", features = [
+gpui = { git = "https://github.com/nolight132/gpui", rev = "f8741c100fe36515d012bd3887dc49854b985b2c" }
+gpui_platform = { git = "https://github.com/nolight132/gpui", rev = "f8741c100fe36515d012bd3887dc49854b985b2c", features = [
   "font-kit",
   "wayland",
   "x11",
@@ -110,6 +110,3 @@ opt-level = 2
 debug = false
 opt-level = 2
 
-[patch."https://github.com/nolight132/zed"]
-gpui = { git = "https://github.com/nolight132/gpui", rev = "c780e4abaf71e57bd9749d1a1fe3c46595308506" }
-gpui_platform = { git = "https://github.com/nolight132/gpui", rev = "c780e4abaf71e57bd9749d1a1fe3c46595308506" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.19.0"
+version = "0.19.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/nolight132/sonora"

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -468,10 +468,11 @@ lyrics-writers = Written by { $writers }
 
 update-available = Sonora { $version } is out
 update-detail = You are on { $running }. Read what changed, or update now.
+update-detail-notes = You are on { $running }. Read what changed, then update Sonora the way you installed it.
 update-notes = What's new
 update-now = Update
 update-later = Later
 update-working = Downloading the update…
 update-failed = The update could not be installed. Try again from the releases page.
 settings-check-updates = Check for updates
-settings-check-updates-detail = Ask GitHub once at startup whether a newer version is out
+settings-check-updates-detail = Ask GitHub once at startup whether a newer version is out. Sonora installs the update itself on Windows only; elsewhere it points you at what changed

--- a/crates/sonora/Cargo.toml
+++ b/crates/sonora/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+# the gpui frame overlay and repaint wash, off in normal builds
+profiler = ["gpui/profiler"]
+
 [dependencies]
 anyhow.workspace = true
 dirs.workspace = true

--- a/crates/state/src/settings.rs
+++ b/crates/state/src/settings.rs
@@ -537,7 +537,7 @@ impl AppSettings {
             return;
         }
         resume.position = position;
-        self.schedule_save(cx);
+        self.save_quietly(cx);
     }
 
     pub fn pins_before(&self, slugs: &[&str], slug: &str) -> usize {
@@ -703,6 +703,11 @@ impl AppSettings {
 
     fn schedule_save(&mut self, cx: &mut Context<Self>) {
         cx.notify();
+        self.save_quietly(cx);
+    }
+
+    /// Persists without waking observers, for values no view renders.
+    fn save_quietly(&mut self, cx: &mut Context<Self>) {
         self.save = Some(cx.spawn(async move |this, cx| {
             cx.background_executor().timer(SAVE_DELAY).await;
             this.update(cx, |this, _| this.save_now()).ok();

--- a/crates/state/src/settings.rs
+++ b/crates/state/src/settings.rs
@@ -198,7 +198,7 @@ impl Default for Values {
             romanized_lyrics: true,
             romanization_scripts: RomanizationScripts::default(),
             adaptive_menu: false,
-            check_updates: true,
+            check_updates: cfg!(target_os = "windows"),
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
             sidebar_open: true,
             sidebar_right_width: DEFAULT_SIDEBAR_RIGHT_WIDTH,

--- a/crates/state/src/updates.rs
+++ b/crates/state/src/updates.rs
@@ -13,7 +13,7 @@ const INSTALLER: &str = "Sonora-Setup.exe";
 const SUMS: &str = "SHA256SUMS";
 const UNINSTALLER: &str = "unins000.exe";
 const RUNNING: &str = env!("CARGO_PKG_VERSION");
-const OFFERED: bool = cfg!(target_os = "windows");
+const INSTALLABLE: bool = cfg!(target_os = "windows");
 const AGENT: &str = concat!(
     "sonora/",
     env!("CARGO_PKG_VERSION"),
@@ -69,7 +69,7 @@ impl Updates {
     }
 
     pub fn installable(&self) -> bool {
-        OFFERED
+        INSTALLABLE
             && installed()
             && self
                 .offered()
@@ -118,7 +118,7 @@ impl Updates {
     }
 
     fn look(&mut self, cx: &mut Context<Self>) {
-        if !OFFERED || !self.settings.read(cx).check_updates() {
+        if !self.settings.read(cx).check_updates() {
             return;
         }
         let http = self.http.clone();

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -41,6 +41,8 @@ const ACTIVE_VERSE_GROWTH: Pixels = px(2.);
 const LYRICS_HORIZONTAL_INSET_REM: f32 = 1.5;
 const PINNED_SHARE: f32 = 0.25;
 const PIN: f32 = 0.3;
+const SPARE: f32 = 1.;
+const HAZE_STEPS: f32 = 8.;
 const SETTLE: std::time::Duration = std::time::Duration::from_secs(4);
 const INSTRUMENTAL_BREAK: std::time::Duration = std::time::Duration::from_secs(5);
 const GLYPH: f32 = 0.35;
@@ -221,6 +223,8 @@ pub(crate) struct Aside {
     lyrics_wrap_width: Option<Pixels>,
     lyrics_wrap_size: Option<Pixels>,
     lyrics_wraps: HashMap<usize, Wrapped>,
+    lane_rooms: HashMap<usize, Pixels>,
+    row_heights: Vec<Pixels>,
 }
 
 impl Aside {
@@ -300,6 +304,8 @@ impl Aside {
             lyrics_wrap_width: None,
             lyrics_wrap_size: None,
             lyrics_wraps: HashMap::new(),
+            lane_rooms: HashMap::new(),
+            row_heights: Vec::new(),
         }
     }
 
@@ -340,7 +346,13 @@ impl Aside {
         self.previous_active_line = None;
         self.departing_line = None;
         self.placing = true;
+        self.forget_measurements();
+    }
+
+    fn forget_measurements(&mut self) {
         self.lyrics_wraps.clear();
+        self.lane_rooms.clear();
+        self.row_heights.clear();
     }
 
     fn set_hovered(&mut self, index: usize, over: bool, cx: &mut Context<Self>) {
@@ -738,7 +750,7 @@ impl Aside {
         if self.lyrics_wrap_width != Some(wrap_width) || self.lyrics_wrap_size != Some(wrap_size) {
             self.lyrics_wrap_width = Some(wrap_width);
             self.lyrics_wrap_size = Some(wrap_size);
-            self.lyrics_wraps.clear();
+            self.forget_measurements();
             window.request_animation_frame();
         }
 
@@ -775,7 +787,22 @@ impl Aside {
                 if hazing && scroll.bounds_for_item(0).is_none() {
                     window.request_animation_frame();
                 }
-                let mut rendered = Vec::with_capacity(lyric_row_count(lines));
+                let count = lyric_row_count(lines);
+                if self.row_heights.len() != count {
+                    self.row_heights = vec![px(0.); count];
+                }
+                let holds = |line: Option<usize>| line.map(|line| line_row(lines, line));
+                let grown = [holds(active_line), holds(self.departing_line)];
+                for row in 0..count {
+                    if grown.contains(&Some(row)) {
+                        continue;
+                    }
+                    if let Some(item) = scroll.bounds_for_item(row) {
+                        self.row_heights[row] = item.size.height;
+                    }
+                }
+                let slack = view.size.height * SPARE;
+                let mut rendered = Vec::with_capacity(count);
 
                 for (index, line) in lines.iter().enumerate() {
                     let seek = line.start;
@@ -794,9 +821,18 @@ impl Aside {
                     let haze = |depth: f32| match (waking, settling) {
                         (true, _) => depth * (1. - sharpen),
                         (false, true) => depth * sharpen,
-                        (false, false) => depth,
+                        (false, false) => stepped(depth),
                     };
                     if has_instrumental {
+                        let row = rendered.len();
+                        if let Some(held) = spared(&scroll, row, view, slack)
+                            .then(|| self.row_heights.get(row).copied())
+                            .flatten()
+                            .filter(|held| *held > px(0.))
+                        {
+                            rendered.push(div().h(held).flex_none().into_any_element());
+                            continue;
+                        }
                         if singing && instrumental_line == Some(index) {
                             window.request_animation_frame();
                         }
@@ -826,17 +862,33 @@ impl Aside {
                         rendered.push(notes.into_any_element());
                     }
 
-                    let text = SharedString::from(line.text.clone());
+                    let active = Some(index) == active_line;
+                    let departing = Some(index) == self.departing_line;
+                    let row = rendered.len();
+                    if !active
+                        && !departing
+                        && let Some(held) = spared(&scroll, row, view, slack)
+                            .then(|| self.row_heights.get(row).copied())
+                            .flatten()
+                            .filter(|held| *held > px(0.))
+                    {
+                        rendered.push(div().h(held).flex_none().into_any_element());
+                        continue;
+                    }
+
                     let karaoke = Some(index) == active_line && line.worded() && karaoke_effects;
                     let primary_karaoke = karaoke && line.words.is_some();
-                    let fragments = lyrics_fragments(&line.text, line.words.as_deref());
-                    let wrapped = match self.lyrics_wraps.get(&index) {
-                        Some(wrapped) => Some(wrapped.clone()),
-                        None => lyrics_wrap_rows(&fragments, wrap_size, wrap_width, window)
-                            .inspect(|wrapped| {
-                                self.lyrics_wraps.insert(index, wrapped.clone());
-                            }),
-                    };
+                    if let std::collections::hash_map::Entry::Vacant(slot) =
+                        self.lyrics_wraps.entry(index)
+                    {
+                        let parts = lyrics_parts(&line.text, line.words.as_deref());
+                        if let Some(wrapped) =
+                            lyrics_wrap_rows(&parts, wrap_size, wrap_width, window)
+                        {
+                            slot.insert(wrapped);
+                        }
+                    }
+                    let wrapped = self.lyrics_wraps.get(&index);
                     let line_has_ended = active_line.is_some_and(|active| index < active)
                         || line_has_passed(line, position);
                     let tint = match (Some(index) == active_line, line_has_ended) {
@@ -846,29 +898,21 @@ impl Aside {
                         (false, false) => theme.muted_foreground.opacity(AHEAD),
                     };
 
-                    let active = Some(index) == active_line;
-                    let departing = Some(index) == self.departing_line;
                     let dimming = (animations && departing).then_some(self.departure);
                     let growing =
                         animations && active && self.arrived.elapsed() < Motion::Base.span();
 
                     let primary = match (primary_karaoke, line.words.as_ref(), wrapped) {
-                        (true, Some(words), Some(wrapped)) => karaoke_lane(
-                            &line.text,
-                            line.start,
-                            words,
-                            position,
-                            verse,
-                            line.voice,
-                            sung,
-                            Some(wrapped),
-                        )
-                        .into_any_element(),
-                        (_, _, Some(wrapped)) => {
-                            fixed_lyrics_lane(&fragments, &wrapped.rows, line.voice)
+                        (true, Some(words), Some(plan)) => {
+                            karaoke_lane(plan, line.start, words, position, verse, line.voice, sung)
                                 .into_any_element()
                         }
-                        _ => div().child(text).into_any_element(),
+                        (_, _, Some(plan)) => {
+                            fixed_lyrics_lane(&plan.text, line.voice).into_any_element()
+                        }
+                        _ => div()
+                            .child(SharedString::from(line.text.clone()))
+                            .into_any_element(),
                     };
                     let fade = match (line.secondary.is_empty(), active, departing) {
                         (true, _, _) => None,
@@ -876,9 +920,9 @@ impl Aside {
                         (_, _, true) => Some(("lane-out", self.departure, animations)),
                         _ => None,
                     };
-                    let lanes =
-                        fade.map(|(tag, take, animated)| {
-                            let arriving = tag == "lane-in";
+                    let room = fade.map(|_| match self.lane_rooms.get(&index) {
+                        Some(room) => *room,
+                        None => {
                             let room = lanes_room(
                                 &line.secondary,
                                 romanization_scripts,
@@ -886,6 +930,13 @@ impl Aside {
                                 wrap_width,
                                 window,
                             );
+                            self.lane_rooms.insert(index, room);
+                            room
+                        }
+                    });
+                    let lanes =
+                        fade.zip(room).map(|((tag, take, animated), room)| {
+                            let arriving = tag == "lane-in";
                             let group = div().flex().flex_col().gap_1().children(
                                 line.secondary.iter().map(|lane| {
                                     let sung_by_end = line
@@ -1337,46 +1388,55 @@ impl Render for Aside {
     }
 }
 
-fn fixed_lyrics_lane(fragments: &[String], rows: &[Range<usize>], voice: Voice) -> Div {
+fn fixed_lyrics_lane(rows: &[SharedString], voice: Voice) -> Div {
     div().flex().flex_col().children(rows.iter().map(|row| {
-        let text = fragments[row.clone()].concat();
         div()
             .w_full()
             .when(!voice.lead(), |this| this.text_right())
-            .child(SharedString::from(text))
+            .child(row.clone())
     }))
 }
 
+// a lane with no measured plan of its own, split on the spot
+fn loose_plan(line: &str, words: &[music::LyricsWord]) -> Wrapped {
+    let parts = karaoke_parts(line, words);
+    let fragments = parts
+        .iter()
+        .map(|(text, _)| SharedString::from(text.clone()))
+        .collect::<Vec<_>>();
+    let spoken = parts.iter().map(|(_, word)| *word).collect::<Vec<_>>();
+    Wrapped {
+        spans: Vec::new(),
+        evenly: evenly_filled(&fragments, &spoken),
+        fragments,
+        spoken,
+        rows: Vec::new(),
+        widths: Vec::new(),
+        text: Vec::new(),
+    }
+}
+
 fn karaoke_lane(
-    line: &str,
+    plan: &Wrapped,
     line_start: std::time::Duration,
     words: &[music::LyricsWord],
     position: std::time::Duration,
     verse: Pixels,
     voice: Voice,
     sung: Sung,
-    wrapped: Option<Wrapped>,
 ) -> Div {
     let theme = &sung.theme;
     let edge_fade = verse * REVEAL;
-    let parts = karaoke_parts(line, words);
-    let fragments = parts
-        .iter()
-        .map(|(text, _)| text.clone())
-        .collect::<Vec<_>>();
-    let spoken = parts.iter().map(|(_, word)| *word).collect::<Vec<_>>();
+    let Wrapped {
+        fragments,
+        spoken,
+        evenly,
+        ..
+    } = plan;
     let windows = (0..words.len())
         .map(|word| {
             let (start, end) = karaoke_window(line_start, words, word);
             (start, end, word + 1 >= words.len())
-        })
-        .collect::<Vec<_>>();
-    let evenly = (0..words.len())
-        .map(|word| {
-            parts.iter().filter(|(_, spoke)| *spoke == word).count() > 1
-                || parts
-                    .iter()
-                    .any(|(text, spoke)| *spoke == word && text.chars().any(wide))
         })
         .collect::<Vec<_>>();
     let sweep = |word: usize| match (windows.get(word), evenly.get(word)) {
@@ -1411,24 +1471,19 @@ fn karaoke_lane(
             })
     };
 
-    match wrapped {
-        Some(Wrapped { rows, widths }) => {
-            div()
-                .flex()
-                .flex_col()
-                .text_left()
-                .children(rows.into_iter().map(|row| {
-                    let text = SharedString::from(fragments[row.clone()].concat());
-                    let reveal = revealed(
-                        row, &widths, &spoken, &windows, &evenly, position, edge_fade,
-                    );
-                    div()
-                        .flex()
-                        .when(!voice.lead(), |this| this.justify_end())
-                        .child(lit(text, reveal))
-                }))
-        }
-        None => div()
+    match plan.rows.is_empty() {
+        false => div()
+            .flex()
+            .flex_col()
+            .text_left()
+            .children((0..plan.rows.len()).map(|row| {
+                let reveal = revealed(plan, row, &windows, position, edge_fade);
+                div()
+                    .flex()
+                    .when(!voice.lead(), |this| this.justify_end())
+                    .child(lit(plan.text[row].clone(), reveal))
+            })),
+        true => div()
             .flex()
             .flex_wrap()
             .text_left()
@@ -1444,7 +1499,7 @@ fn karaoke_lane(
                         false => 0.,
                     },
                 };
-                lit(SharedString::from(fragments[index].clone()), reveal)
+                lit(fragments[index].clone(), reveal)
             })),
     }
 }
@@ -1458,11 +1513,9 @@ struct Reveal {
 }
 
 fn revealed(
-    row: Range<usize>,
-    widths: &[Pixels],
-    spoken: &[usize],
+    plan: &Wrapped,
+    row: usize,
     windows: &[(std::time::Duration, std::time::Duration, bool)],
-    evenly: &[bool],
     position: std::time::Duration,
     fade: Pixels,
 ) -> Reveal {
@@ -1470,9 +1523,9 @@ fn revealed(
     let mut landing = 0.;
     let mut offset = px(0.);
     let mut soft = false;
-    for index in row {
-        let mine = widths.get(index).copied().unwrap_or(px(0.));
-        let word = spoken.get(index).copied().unwrap_or(index);
+    for index in plan.rows[row].clone() {
+        let mine = plan.widths.get(index).copied().unwrap_or(px(0.));
+        let word = plan.spoken.get(index).copied().unwrap_or(index);
         let Some(&(start, end, last)) = windows.get(word) else {
             offset += mine;
             continue;
@@ -1480,7 +1533,7 @@ fn revealed(
 
         // a wide character or a phrase timed as one word fills at an even pace;
         // the eased curve only reads as a flourish across Latin letters
-        let even = evenly.get(word).copied().unwrap_or(false);
+        let even = plan.evenly.get(word).copied().unwrap_or(false);
         soft |= even;
         let share = match even {
             true => progress_between(start, end, position),
@@ -1489,15 +1542,7 @@ fn revealed(
         if share > 0. {
             // a word covering several fragments hands each its own slice of the
             // sweep, and the edge follows whichever reaches furthest
-            let before: Pixels = (0..index)
-                .filter(|place| spoken.get(*place).copied() == Some(word))
-                .filter_map(|place| widths.get(place).copied())
-                .sum();
-            let whole: Pixels = before
-                + (index..spoken.len())
-                    .filter(|place| spoken.get(*place).copied() == Some(word))
-                    .filter_map(|place| widths.get(place).copied())
-                    .sum();
+            let (before, whole) = plan.spans.get(index).copied().unwrap_or((px(0.), mine));
             let part = match mine > px(0.) {
                 true => ((whole * share - before) / mine).clamp(0., 1.),
                 false => 0.,
@@ -1555,7 +1600,13 @@ fn secondary_lyrics_lane(
         .text_size(size)
         .map(|this| match (karaoke_capable, lane.words.as_ref()) {
             (true, Some(words)) => this.child(karaoke_lane(
-                &lane.text, lane.start, words, position, size, voice, sung, None,
+                &loose_plan(&lane.text, words),
+                lane.start,
+                words,
+                position,
+                size,
+                voice,
+                sung,
             )),
             _ => this.child(SharedString::from(lane.text.clone())),
         });
@@ -1631,6 +1682,7 @@ fn karaoke_window(
     (start, end)
 }
 
+#[cfg(test)]
 fn karaoke_fragments(line: &str, words: &[music::LyricsWord]) -> Vec<String> {
     karaoke_parts(line, words)
         .into_iter()
@@ -1715,10 +1767,14 @@ fn active_verse_size(verse: Pixels) -> Pixels {
     verse + ACTIVE_VERSE_GROWTH
 }
 
-fn lyrics_fragments(line: &str, words: Option<&[music::LyricsWord]>) -> Vec<String> {
+fn lyrics_parts(line: &str, words: Option<&[music::LyricsWord]>) -> Vec<(String, usize)> {
     match words {
-        Some(words) if !words.is_empty() => karaoke_fragments(line, words),
-        _ => plain_lyrics_fragments(line),
+        Some(words) if !words.is_empty() => karaoke_parts(line, words),
+        _ => plain_lyrics_fragments(line)
+            .into_iter()
+            .enumerate()
+            .map(|(index, piece)| (piece, index))
+            .collect(),
     }
 }
 
@@ -1743,14 +1799,20 @@ fn plain_lyrics_fragments(line: &str) -> Vec<String> {
     fragments
 }
 
+// everything a line needs to lay out and light up, measured once per width
 #[derive(Clone)]
 struct Wrapped {
+    fragments: Vec<SharedString>,
+    spoken: Vec<usize>,
     rows: Vec<Range<usize>>,
     widths: Vec<Pixels>,
+    spans: Vec<(Pixels, Pixels)>,
+    evenly: Vec<bool>,
+    text: Vec<SharedString>,
 }
 
 fn lyrics_wrap_rows(
-    fragments: &[String],
+    parts: &[(String, usize)],
     font_size: Pixels,
     width: Pixels,
     window: &mut Window,
@@ -1761,18 +1823,18 @@ fn lyrics_wrap_rows(
 
     let mut style = window.text_style();
     style.font_weight = FontWeight::SEMIBOLD;
+    let fragments = parts
+        .iter()
+        .map(|(text, _)| SharedString::from(text.clone()))
+        .collect::<Vec<_>>();
+    let spoken = parts.iter().map(|(_, word)| *word).collect::<Vec<_>>();
     let widths = fragments
         .iter()
         .map(|fragment| {
             let run = style.to_run(fragment.len());
             window
                 .text_system()
-                .shape_line(
-                    SharedString::from(fragment.clone()),
-                    font_size,
-                    &[run],
-                    None,
-                )
+                .shape_line(fragment.clone(), font_size, &[run], None)
                 .width
         })
         .collect::<Vec<_>>();
@@ -1784,10 +1846,63 @@ fn lyrics_wrap_rows(
             None => true,
         })
         .collect::<Vec<_>>();
+    let rows = wrap_fragment_widths(&widths, &breaks, width);
+    let text = rows
+        .iter()
+        .map(|row| {
+            SharedString::from(parts[row.clone()].iter().fold(
+                String::new(),
+                |mut whole, (piece, _)| {
+                    whole.push_str(piece);
+                    whole
+                },
+            ))
+        })
+        .collect::<Vec<_>>();
+
     Some(Wrapped {
-        rows: wrap_fragment_widths(&widths, &breaks, width),
+        spans: word_spans(&spoken, &widths),
+        evenly: evenly_filled(&fragments, &spoken),
+        fragments,
+        spoken,
+        rows,
         widths,
+        text,
     })
+}
+
+// a fragment's own slice of the word it belongs to
+fn word_spans(spoken: &[usize], widths: &[Pixels]) -> Vec<(Pixels, Pixels)> {
+    let words = spoken.iter().copied().max().map_or(0, |last| last + 1);
+    let mut wholes = vec![px(0.); words];
+    for (index, word) in spoken.iter().enumerate() {
+        wholes[*word] += widths.get(index).copied().unwrap_or(px(0.));
+    }
+    let mut befores = vec![px(0.); words];
+    spoken
+        .iter()
+        .enumerate()
+        .map(|(index, word)| {
+            let before = befores[*word];
+            befores[*word] += widths.get(index).copied().unwrap_or(px(0.));
+            (before, wholes[*word])
+        })
+        .collect()
+}
+
+fn evenly_filled(fragments: &[SharedString], spoken: &[usize]) -> Vec<bool> {
+    let words = spoken.iter().copied().max().map_or(0, |last| last + 1);
+    let mut pieces = vec![0usize; words];
+    let mut broad = vec![false; words];
+    for (index, word) in spoken.iter().enumerate() {
+        pieces[*word] += 1;
+        broad[*word] |= fragments[index].chars().any(wide);
+    }
+    pieces
+        .into_iter()
+        .zip(broad)
+        .map(|(pieces, broad)| pieces > 1 || broad)
+        .collect()
 }
 
 fn separable(left: &str, right: &str) -> bool {
@@ -1979,8 +2094,26 @@ fn lanes_room(
 }
 
 fn wrapped_rows(text: &str, size: Pixels, width: Pixels, window: &mut Window) -> usize {
-    let fragments = plain_lyrics_fragments(text);
-    lyrics_wrap_rows(&fragments, size, width, window).map_or(1, |wrapped| wrapped.rows.len().max(1))
+    let parts = lyrics_parts(text, None);
+    lyrics_wrap_rows(&parts, size, width, window).map_or(1, |wrapped| wrapped.rows.len().max(1))
+}
+
+// rows this far outside the panel are held open by their measured height alone
+fn spared(scroll: &ScrollHandle, row: usize, view: Bounds<Pixels>, slack: Pixels) -> bool {
+    let height = view.size.height;
+    let Some(item) = scroll.bounds_for_item(row) else {
+        return false;
+    };
+    if height <= px(0.) {
+        return false;
+    }
+    let top = item.origin.y - view.origin.y + scroll.offset().y;
+    top + item.size.height + slack < px(0.) || top - slack > height
+}
+
+// bucketed depth keeps neighbouring rows on one filter instead of one each
+fn stepped(depth: f32) -> f32 {
+    (depth * HAZE_STEPS).round() / HAZE_STEPS
 }
 
 fn viewport_haze(scroll: &ScrollHandle, row: usize, view: Bounds<Pixels>, margin: Pixels) -> f32 {

--- a/crates/views/src/chrome/player_bar.rs
+++ b/crates/views/src/chrome/player_bar.rs
@@ -338,6 +338,16 @@ impl PlayerBar {
     }
 }
 
+impl PlayerBar {
+    pub(crate) fn height(window: &Window, cx: &gpui::App) -> Pixels {
+        let theme = *cx.theme();
+        match !Room::of(window.viewport_size().width).fits(Room::Roomy) {
+            true => ui::snapped(theme.metrics.player_bar + theme.metrics.pad * 3., window),
+            false => ui::snapped(theme.metrics.player_bar, window),
+        }
+    }
+}
+
 impl Render for PlayerBar {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = *cx.theme();
@@ -345,10 +355,7 @@ impl Render for PlayerBar {
         let empty = muted.opacity(0.3);
         let span = Room::of(window.viewport_size().width);
         let stacked = !span.fits(Room::Roomy);
-        let height = match stacked {
-            true => ui::snapped(theme.metrics.player_bar + theme.metrics.pad * 3., window),
-            false => ui::snapped(theme.metrics.player_bar, window),
-        };
+        let height = Self::height(window, cx);
         let clock_text = theme.text(ui::Text::Tiny);
 
         let show_track = span.fits(Room::Snug);

--- a/crates/views/src/chrome/sidebar_left.rs
+++ b/crates/views/src/chrome/sidebar_left.rs
@@ -154,6 +154,10 @@ impl SidebarLeft {
         cx.notify();
     }
 
+    pub(crate) fn shown_width(&self) -> Pixels {
+        self.width
+    }
+
     pub fn occupied_width(&self) -> Pixels {
         match self.is_open() && !self.overlays() {
             true => self.width,

--- a/crates/views/src/chrome/sidebar_right.rs
+++ b/crates/views/src/chrome/sidebar_right.rs
@@ -30,7 +30,6 @@ impl SidebarRight {
         let open = settings.read(cx).sidebar_right_open();
         let tab = settings.read(cx).sidebar_right_tab();
         let aside = cx.new(|cx| Aside::new(queue, playback, tab, cx));
-        cx.observe(&aside, |_, _, cx| cx.notify()).detach();
 
         Self {
             aside,

--- a/crates/views/src/chrome/update_notice.rs
+++ b/crates/views/src/chrome/update_notice.rs
@@ -98,7 +98,12 @@ impl Render for UpdateNotice {
                     div()
                         .text_size(theme.text(Text::Small))
                         .text_color(theme.muted_foreground)
-                        .child(t!("update-detail", running = env!("CARGO_PKG_VERSION"))),
+                        .child(match installable {
+                            true => t!("update-detail", running = env!("CARGO_PKG_VERSION")),
+                            false => {
+                                t!("update-detail-notes", running = env!("CARGO_PKG_VERSION"))
+                            }
+                        }),
                 )
             })
             .child(

--- a/crates/views/src/screens/settings.rs
+++ b/crates/views/src/screens/settings.rs
@@ -1531,9 +1531,7 @@ impl SettingsView {
                     )
                     .child(
                         div()
-                            .overflow_hidden()
-                            .whitespace_nowrap()
-                            .text_ellipsis()
+                            .min_w_0()
                             .text_color(muted)
                             .text_size(small)
                             .child(detail),

--- a/crates/views/src/shells/fullscreen.rs
+++ b/crates/views/src/shells/fullscreen.rs
@@ -81,7 +81,6 @@ impl FullscreenView {
         cx.observe(&library, |_, _, cx| cx.notify()).detach();
         let aside = cx.new(|cx| Aside::new(queue.clone(), playback.clone(), SideTab::Lyrics, cx));
         aside.update(cx, |aside, _| aside.strip());
-        cx.observe(&aside, |_, _, cx| cx.notify()).detach();
         let me = cx.entity_id();
         let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(me));
 

--- a/crates/views/src/shells/workspace.rs
+++ b/crates/views/src/shells/workspace.rs
@@ -184,6 +184,16 @@ impl Render for Workspace {
         Chrome::publish(left, right, cx);
         let covered = self.sidebar_right.read(cx).covers_content(window);
         let overlay = self.sidebar.read(cx).overlays();
+        let sidebar_width = self.sidebar.read(cx).shown_width();
+        let bar_height = PlayerBar::height(window, cx);
+        let sidebar = match overlay {
+            true => self.sidebar.clone().into_any_element(),
+            false => self
+                .sidebar
+                .clone()
+                .cached(StyleRefinement::default().w(sidebar_width).h_full())
+                .into_any_element(),
+        };
         let hidden = self.hidden(window, cx);
         let scale = 1. - VIEW_ZOOM * hidden;
 
@@ -202,7 +212,7 @@ impl Render for Workspace {
                     .flex()
                     .flex_1()
                     .min_h_0()
-                    .when(!overlay, |this| this.child(self.sidebar.clone()))
+                    .when(!overlay, |this| this.child(sidebar))
                     .child(
                         div()
                             .relative()
@@ -241,7 +251,11 @@ impl Render for Workspace {
             .child(
                 div()
                     .relative()
-                    .child(self.player_bar.clone())
+                    .child(
+                        self.player_bar
+                            .clone()
+                            .cached(StyleRefinement::default().w_full().h(bar_height)),
+                    )
                     .child(self.toasts.clone()),
             )
             .child(self.playlist_editor.clone())


### PR DESCRIPTION
## Summary

- shrink what a frame redraws: cache the player bar and left sidebar, stop the lyrics panel notifying its host twice, and save the resume position without waking every settings observer
- measure a lyric line once per panel width and hold off-panel verses at their measured height
- tell Linux and macOS about a newer version, without offering to install it
- wrap long settings descriptions
- release 0.19.1