### PR TITLE
chore: add a cargo prof alias

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+[alias]
+prof = "run --release --package sonora --features profiler"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,7 @@ to please the lint.
 pay nothing:
 
 ```sh
+cargo prof                             # alias for run --release --features profiler
 cargo run --features profiler          # then set any of:
 GPUI_DEBUG_OVERLAY=minimal|full        # frame time, phase split, cache hits, dirty count
 GPUI_SHOW_REPAINTS=1                   # wash every view a notify named, fading over 160ms


### PR DESCRIPTION
## Summary

- add `cargo prof`, which runs the release build with the `profiler` feature, so the overlay and repaint wash do not need the flag typed out