### PR TITLE
perf: shape a verse once, and stop pacing the sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Lyrics no longer hitch as a track loads or as verses scroll into view. Measuring a line asked the
+  text system to shape every piece of it separately, which on Japanese, Chinese and Korean lyrics is
+  one shaping call per character and, on the frame a sheet first appears, hundreds of them at once.
+  A line is shaped once now, and the widths that come back also account for the kerning between one
+  piece and the next, so the highlight sits exactly where the glyphs do.
+
 ## [0.19.1] - 2026-08-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Changed
-
-- The word-by-word highlight and the melody-break dots ask for at most 125 frames a second rather
-  than one per refresh. On a fast display that was a third of the frames spent advancing a fill by a
-  fraction of a pixel, and anything else drawing a frame still carries the lyrics along with it, so
-  nothing moves any less smoothly.
-
 ## [0.19.1] - 2026-08-27
 
 ### Changed

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -1828,16 +1828,28 @@ fn lyrics_wrap_rows(
         .map(|(text, _)| SharedString::from(text.clone()))
         .collect::<Vec<_>>();
     let spoken = parts.iter().map(|(_, word)| *word).collect::<Vec<_>>();
-    let widths = fragments
-        .iter()
-        .map(|fragment| {
-            let run = style.to_run(fragment.len());
-            window
-                .text_system()
-                .shape_line(fragment.clone(), font_size, &[run], None)
-                .width
-        })
-        .collect::<Vec<_>>();
+    // one shaped line per verse rather than one per fragment: a line of wide
+    // characters is a shaping call each otherwise, and the widths that come back
+    // this way also carry the kerning across a boundary
+    let whole = SharedString::from(
+        parts
+            .iter()
+            .map(|(text, _)| text.as_str())
+            .collect::<String>(),
+    );
+    let run = style.to_run(whole.len());
+    let shaped = window
+        .text_system()
+        .shape_line(whole, font_size, &[run], None);
+    let mut widths = Vec::with_capacity(parts.len());
+    let mut at = 0;
+    let mut left = shaped.x_for_index(0);
+    for (text, _) in parts {
+        at += text.len();
+        let right = shaped.x_for_index(at);
+        widths.push(right - left);
+        left = right;
+    }
     let breaks = fragments
         .iter()
         .enumerate()

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -42,9 +42,6 @@ const LYRICS_HORIZONTAL_INSET_REM: f32 = 1.5;
 const PINNED_SHARE: f32 = 0.25;
 const PIN: f32 = 0.3;
 const SPARE: f32 = 1.;
-// a sweep or a set of dots has nothing to say to a display running faster than
-// this, so frames past it are work with no picture to show for it
-const TICK: std::time::Duration = std::time::Duration::from_millis(8);
 const HAZE_STEPS: f32 = 8.;
 const SETTLE: std::time::Duration = std::time::Duration::from_secs(4);
 const INSTRUMENTAL_BREAK: std::time::Duration = std::time::Duration::from_secs(5);
@@ -228,8 +225,6 @@ pub(crate) struct Aside {
     lyrics_wraps: HashMap<usize, Wrapped>,
     lane_rooms: HashMap<usize, Pixels>,
     row_heights: Vec<Pixels>,
-    ticked: std::time::Instant,
-    tick: Option<Task<()>>,
 }
 
 impl Aside {
@@ -311,8 +306,6 @@ impl Aside {
             lyrics_wraps: HashMap::new(),
             lane_rooms: HashMap::new(),
             row_heights: Vec::new(),
-            ticked: std::time::Instant::now(),
-            tick: None,
         }
     }
 
@@ -354,32 +347,6 @@ impl Aside {
         self.departing_line = None;
         self.placing = true;
         self.forget_measurements();
-    }
-
-    /// Asks for the next frame of a continuous animation, no sooner than TICK
-    /// after the last one. Anything else drawing a frame carries it along, so
-    /// this only ever removes frames nobody would have seen.
-    fn tick(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let waited = self.ticked.elapsed();
-        if waited >= TICK {
-            self.ticked = std::time::Instant::now();
-            self.tick = None;
-            window.request_animation_frame();
-            return;
-        }
-        if self.tick.is_some() {
-            return;
-        }
-        let rest = TICK - waited;
-        self.tick = Some(cx.spawn(async move |this, cx| {
-            cx.background_executor().timer(rest).await;
-            this.update(cx, |this, cx| {
-                this.tick = None;
-                this.ticked = std::time::Instant::now();
-                cx.notify();
-            })
-            .ok();
-        }));
     }
 
     fn forget_measurements(&mut self) {
@@ -794,7 +761,7 @@ impl Aside {
                     && karaoke_effects
                     && active_line.is_some_and(|index| lines[index].worded())
                 {
-                    self.tick(window, cx);
+                    window.request_animation_frame();
                 }
                 if self.previous_active_line != active_line {
                     if self.previous_active_line.is_some() {
@@ -867,7 +834,7 @@ impl Aside {
                             continue;
                         }
                         if singing && instrumental_line == Some(index) {
-                            self.tick(window, cx);
+                            window.request_animation_frame();
                         }
                         let softness = match hazing && instrumental_line != Some(index) {
                             true => haze(viewport_haze(&scroll, rendered.len(), view, blur)),


### PR DESCRIPTION
## Summary

- revert the 8ms sweep pacer: the cap has no relation to the refresh rate, so it set an uneven cadence that reads as judder rather than as fewer frames
- measure a lyric line with one shaping call instead of one per fragment, which on Japanese, Chinese and Korean lyrics was one per character and, on the frame a sheet first appears, hundreds at once
- take the fragment widths from that single shaped line, so they carry the kerning between one piece and the next and the highlight sits exactly where the glyphs do