### PR TITLE
fix: do not swap lyrics mid-verse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- A better set of lyrics arriving mid-verse no longer takes over the line you are reading. Sonora
+  asks several sources at once and shows the best answer so far, upgrading from plain to synced to
+  word-by-word as they come in, which used to swap the words under you, snap the sheet to a new
+  position and start the highlight over. It now finishes the verse on screen and takes the better
+  sheet up at the next one, keeping the line that was already growing rather than replaying it. A
+  source you pick yourself still applies at once, and so does one that arrives between verses or
+  while playback is paused.
+
 - The word-by-word highlight no longer slips backwards inside a word. Lyrics providers split a word
   where it is sung in two — "nothing" arrives as "no" and "thing" — and the soft trail the highlight
   carries hardened at every one of those boundaries and softened again on the next, which moved the

--- a/crates/state/src/lyrics.rs
+++ b/crates/state/src/lyrics.rs
@@ -2,12 +2,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use gpui::{Context, Entity, Task};
+use gpui::{App, Context, Entity, Task};
 use music::{Lyrics as Sheet, LyricsHit, LyricsProvider, LyricsQuery, MusicApi, Track, TrackKey};
 use tokio::task::JoinSet;
 
 use crate::sheets::Sheets;
-use crate::{Io, Playback, Queue, Session, join};
+use crate::{Io, Playback, PlaybackState, Queue, Session, join};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LyricsState {
@@ -28,12 +28,15 @@ struct Native {
     id: String,
 }
 
+type Waiting = (Vec<LyricsHit>, Option<LyricsHit>);
+
 pub struct Lyrics {
     state: LyricsState,
     hits: Vec<LyricsHit>,
     chosen: usize,
     picked: bool,
     revision: u64,
+    waiting: Option<Waiting>,
     following: Option<String>,
     cache: HashMap<String, Found>,
     store: Sheets,
@@ -74,6 +77,7 @@ impl Lyrics {
             chosen: 0,
             picked: false,
             revision: 0,
+            waiting: None,
             following: None,
             cache: HashMap::new(),
             store: Sheets::new(),
@@ -115,6 +119,7 @@ impl Lyrics {
         }
         self.chosen = index;
         self.picked = true;
+        self.waiting = None;
         self.revision = self.revision.wrapping_add(1);
         cx.notify();
     }
@@ -140,6 +145,7 @@ impl Lyrics {
         self.following = Some(id.clone());
         self.chosen = 0;
         self.picked = false;
+        self.waiting = None;
         self.revision = self.revision.wrapping_add(1);
 
         if let Some(found) = self.remembered(&id, cx) {
@@ -187,6 +193,7 @@ impl Lyrics {
         self.hits.clear();
         self.chosen = 0;
         self.picked = false;
+        self.waiting = None;
         self.revision = self.revision.wrapping_add(1);
         self.state = LyricsState::Idle;
         cx.notify();
@@ -317,11 +324,63 @@ impl Lyrics {
         displayed: Option<&LyricsHit>,
         cx: &mut Context<Self>,
     ) {
+        // A better sheet arriving part-way through a verse would swap the words
+        // under the reader and restart the highlight, so it waits for the line
+        // on screen to be sung.
+        if self.mid_verse(cx) && self.differs(&ranked, displayed) {
+            self.waiting = Some((ranked, displayed.cloned()));
+            return;
+        }
+        self.apply(ranked, displayed, cx);
+    }
+
+    fn apply(
+        &mut self,
+        ranked: Vec<LyricsHit>,
+        displayed: Option<&LyricsHit>,
+        cx: &mut Context<Self>,
+    ) {
         self.pin(ranked, displayed);
         if !self.hits.is_empty() {
             self.state = LyricsState::Ready;
         }
         cx.notify();
+    }
+
+    /// Takes up a sheet that was held back, once the verse it would have
+    /// interrupted is over.
+    pub fn settle(&mut self, cx: &mut Context<Self>) {
+        let Some((ranked, displayed)) = self.waiting.take() else {
+            return;
+        };
+        self.apply(ranked, displayed.as_ref(), cx);
+    }
+
+    /// Whether a verse of the sheet on screen is being sung right now.
+    fn mid_verse(&self, cx: &App) -> bool {
+        let playback = self.playback.read(cx);
+        if *playback.state() != PlaybackState::Playing {
+            return false;
+        }
+        let Some(hit) = self.current() else {
+            return false;
+        };
+        let music::Lyrics::Synced { lines } = &hit.lyrics else {
+            return false;
+        };
+        music::lyrics::active(lines, playback.live_position()).is_some()
+    }
+
+    /// Whether taking this ranking up would change the words on screen.
+    fn differs(&self, ranked: &[LyricsHit], displayed: Option<&LyricsHit>) -> bool {
+        let anchor = match self.picked {
+            true => self.hits.get(self.chosen),
+            false => displayed,
+        };
+        let next = anchor
+            .and_then(|anchor| ranked.iter().find(|hit| same(hit, anchor)))
+            .or_else(|| ranked.first());
+        next.map(|hit| &hit.lyrics) != self.current().map(|hit| &hit.lyrics)
     }
 
     fn remember(
@@ -347,8 +406,13 @@ impl Lyrics {
             },
         );
         if current {
-            self.pin(hits, displayed);
-            self.state = state_for(&self.hits, instrumental);
+            match self.mid_verse(cx) && self.differs(&hits, displayed) {
+                true => self.waiting = Some((hits, displayed.cloned())),
+                false => {
+                    self.pin(hits, displayed);
+                    self.state = state_for(&self.hits, instrumental);
+                }
+            }
             cx.notify();
             self.prefetch(cx);
         }

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -225,6 +225,7 @@ pub(crate) struct Aside {
     lyrics_wraps: HashMap<usize, Wrapped>,
     lane_rooms: HashMap<usize, Pixels>,
     row_heights: Vec<Pixels>,
+    swapped: bool,
 }
 
 impl Aside {
@@ -306,6 +307,7 @@ impl Aside {
             lyrics_wraps: HashMap::new(),
             lane_rooms: HashMap::new(),
             row_heights: Vec::new(),
+            swapped: false,
         }
     }
 
@@ -343,9 +345,15 @@ impl Aside {
     }
 
     fn forget_verse(&mut self) {
+        self.reset_verse();
+        self.placing = true;
+    }
+
+    /// Drops what was measured and which line was sung, leaving the panel to
+    /// carry itself to the new line rather than jump there.
+    fn reset_verse(&mut self) {
         self.previous_active_line = None;
         self.departing_line = None;
-        self.placing = true;
         self.forget_measurements();
     }
 
@@ -689,6 +697,9 @@ impl Aside {
         let theme = *cx.theme();
         let position = self.playback.read(cx).live_position();
         let singing = matches!(self.playback.read(cx).state(), PlaybackState::Playing);
+        if !singing {
+            self.lyrics.update(cx, |lyrics, cx| lyrics.settle(cx));
+        }
         let lyrics = self.lyrics.read(cx);
         let state = lyrics.state().clone();
         let shown = lyrics.current().map(|hit| hit.lyrics.clone());
@@ -724,8 +735,9 @@ impl Aside {
                 .update(cx, |bar, _| bar.remember_offset(scroll.offset().y));
         } else if self.verse_take != take {
             self.verse_take = take;
-            self.forget_verse();
+            self.reset_verse();
             self.anchor_verse();
+            self.swapped = true;
         }
 
         let empty = |key: &'static str, cx: &mut Context<Self>| {
@@ -763,7 +775,11 @@ impl Aside {
                 {
                     window.request_animation_frame();
                 }
+                if std::mem::take(&mut self.swapped) {
+                    self.previous_active_line = active_line;
+                }
                 if self.previous_active_line != active_line {
+                    self.lyrics.update(cx, |lyrics, cx| lyrics.settle(cx));
                     if self.previous_active_line.is_some() {
                         self.departing_line = self.previous_active_line;
                         self.departure = self.departure.wrapping_add(1);


### PR DESCRIPTION
## Summary

- hold a better lyrics sheet back while a verse of the one on screen is being sung, and take it up at the next verse boundary
- gate both paths that could swap: the progressive upgrade as providers answer, and the final application once they all have
- let the panel inherit the line being sung across a swap, so the verse that was already growing does not replay its animation
- carry the panel to the new line instead of placing it there, so a swap no longer snaps the sheet
- apply at once when there is nothing to interrupt: a source picked by hand, a sheet arriving between verses, or playback paused