### PR TITLE
fix: scale a verse into place, and hold a sheet from the first verse on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- A verse growing into place no longer steps through a few sizes, and the sheet no longer settles
+  with a jolt once it has finished. The growth is drawn at the size the verse ends up and scaled into
+  place from its leading edge, so the text is measured and drawn once instead of once per frame, and
+  every line reserves the room the sung one needs, so becoming the sung line moves nothing around it.
+
 - A better set of lyrics arriving mid-verse no longer takes over the line you are reading. Sonora
   asks several sources at once and shows the best answer so far, upgrading from plain to synced to
   word-by-word as they come in, which used to swap the words under you, snap the sheet to a new

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1642,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2516,7 +2516,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "gpui_apple"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "anyhow",
  "block",
@@ -2610,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -2702,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2713,7 +2713,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "gpui",
  "gpui_linux",
@@ -2724,7 +2724,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "schemars",
  "serde",
@@ -2734,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "anyhow",
  "log",
@@ -2744,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2770,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -3038,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4102,7 +4102,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -5052,7 +5052,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "collections",
  "serde",
@@ -5903,7 +5903,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "derive_refineable",
 ]
@@ -6335,7 +6335,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "async-task",
  "backtrace",
@@ -7001,7 +7001,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "heapless",
  "log",
@@ -8149,7 +8149,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "perf",
  "quote",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9724,7 +9724,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -9735,7 +9735,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ env_logger = "0.11"
 fastrand = "2.5"
 futures = "0.3"
 fluent-bundle = "0.16"
-gpui = { git = "https://github.com/nolight132/gpui", rev = "f8741c100fe36515d012bd3887dc49854b985b2c" }
-gpui_platform = { git = "https://github.com/nolight132/gpui", rev = "f8741c100fe36515d012bd3887dc49854b985b2c", features = [
+gpui = { git = "https://github.com/nolight132/gpui", rev = "379f4c34619872fccf72c33b3b3b3386af2a9271" }
+gpui_platform = { git = "https://github.com/nolight132/gpui", rev = "379f4c34619872fccf72c33b3b3b3386af2a9271", features = [
   "font-kit",
   "wayland",
   "x11",

--- a/crates/state/src/lyrics.rs
+++ b/crates/state/src/lyrics.rs
@@ -328,8 +328,15 @@ impl Lyrics {
         // under the reader and restart the highlight, so it waits for the line
         // on screen to be sung.
         if self.mid_verse(cx) && self.differs(&ranked, displayed) {
+            log::debug!("lyrics: holding a better sheet until the next verse");
             self.waiting = Some((ranked, displayed.cloned()));
             return;
+        }
+        if self.current().is_some() && self.differs(&ranked, displayed) {
+            log::debug!(
+                "lyrics: swapping the sheet at once, playing {:?}",
+                self.playback.read(cx).state()
+            );
         }
         self.apply(ranked, displayed, cx);
     }
@@ -353,22 +360,18 @@ impl Lyrics {
         let Some((ranked, displayed)) = self.waiting.take() else {
             return;
         };
+        log::debug!("lyrics: taking up the sheet that was held back");
         self.apply(ranked, displayed.as_ref(), cx);
     }
 
-    /// Whether a verse of the sheet on screen is being sung right now.
+    /// Whether a sheet with verses is on screen and playing, so swapping it
+    /// would interrupt the reader.
     fn mid_verse(&self, cx: &App) -> bool {
-        let playback = self.playback.read(cx);
-        if *playback.state() != PlaybackState::Playing {
+        if *self.playback.read(cx).state() != PlaybackState::Playing {
             return false;
         }
-        let Some(hit) = self.current() else {
-            return false;
-        };
-        let music::Lyrics::Synced { lines } = &hit.lyrics else {
-            return false;
-        };
-        music::lyrics::active(lines, playback.live_position()).is_some()
+        self.current()
+            .is_some_and(|hit| matches!(hit.lyrics, music::Lyrics::Synced { .. }))
     }
 
     /// Whether taking this ranking up would change the words on screen.
@@ -407,7 +410,10 @@ impl Lyrics {
         );
         if current {
             match self.mid_verse(cx) && self.differs(&hits, displayed) {
-                true => self.waiting = Some((hits, displayed.cloned())),
+                true => {
+                    log::debug!("lyrics: holding the settled sheet until the next verse");
+                    self.waiting = Some((hits, displayed.cloned()));
+                }
                 false => {
                     self.pin(hits, displayed);
                     self.state = state_for(&self.hits, instrumental);

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -778,8 +778,11 @@ impl Aside {
                 if std::mem::take(&mut self.swapped) {
                     self.previous_active_line = active_line;
                 }
-                if self.previous_active_line != active_line {
+                // A sheet held back comes in as a verse starts, never as one ends
+                if self.previous_active_line != active_line && active_line.is_some() {
                     self.lyrics.update(cx, |lyrics, cx| lyrics.settle(cx));
+                }
+                if self.previous_active_line != active_line {
                     if self.previous_active_line.is_some() {
                         self.departing_line = self.previous_active_line;
                         self.departure = self.departure.wrapping_add(1);
@@ -818,7 +821,6 @@ impl Aside {
                     }
                 }
                 let slack = view.size.height * SPARE;
-                let grid = window.scale_factor();
                 let mut rendered = Vec::with_capacity(count);
 
                 for (index, line) in lines.iter().enumerate() {
@@ -1017,6 +1019,7 @@ impl Aside {
                         .cursor_pointer()
                         .hover(|style| style.bg(theme.table_hover))
                         .text_size(verse)
+                        .line_height(active_verse_size(verse) * ui::LEADING)
                         .text_color(tint)
                         .font_weight(FontWeight::SEMIBOLD)
                         .on_hover(cx.listener(move |this, over: &bool, _, cx| {
@@ -1037,14 +1040,24 @@ impl Aside {
                     let active_size = active_verse_size(verse);
                     let unsung = theme.muted_foreground.opacity(AHEAD);
                     let lit = theme.foreground;
+                    // The verse is drawn at the size it ends up and scaled into place,
+                    // so the text system is asked for one size rather than one per
+                    // frame, and nothing around it has to move.
+                    let small = verse / active_size;
+                    let from = match line.voice.lead() {
+                        true => gpui::point(0., 0.5),
+                        false => gpui::point(1., 0.5),
+                    };
                     let verse_line = match (growing, shrinking) {
                         (true, _) => verse_line
+                            .text_size(active_size)
                             .with_animation(
                                 ("verse-grow", self.arrival as usize),
                                 Animation::new(Motion::Base.span()).with_easing(ease_out_expo),
                                 move |this, t| {
                                     let this = this
-                                        .text_size(gridded(verse + ACTIVE_VERSE_GROWTH * t, grid));
+                                        .layer_scale(small + (1. - small) * t)
+                                        .layer_scale_origin(from);
                                     match karaoke {
                                         true => this,
                                         false => this.text_color(mix(unsung, lit, t)),
@@ -1053,15 +1066,14 @@ impl Aside {
                             )
                             .into_any_element(),
                         (_, true) => verse_line
+                            .text_size(active_size)
                             .with_animation(
                                 ("verse-shrink", self.departure as usize),
                                 Animation::new(Motion::Base.span()).with_easing(ease_out_expo),
                                 move |this, t| {
-                                    this.text_size(gridded(
-                                        active_size - ACTIVE_VERSE_GROWTH * t,
-                                        grid,
-                                    ))
-                                    .text_color(mix(lit, tint, t))
+                                    this.layer_scale(1. - (1. - small) * t)
+                                        .layer_scale_origin(from)
+                                        .text_color(mix(lit, tint, t))
                                 },
                             )
                             .into_any_element(),
@@ -1778,13 +1790,6 @@ fn needs_space(left: &str, right: &str) -> bool {
             first,
             ')' | ']' | '}' | ',' | '.' | '!' | '?' | ';' | ':' | '%' | '\'' | '’' | '-' | '—'
         )
-}
-
-// A text size lands on the device pixel grid, so growing a verse asks the text
-// system for two or three sizes rather than one per frame: both the shaped line
-// and every rasterised glyph are keyed by size.
-fn gridded(size: Pixels, grid: f32) -> Pixels {
-    px((size / px(1.) * grid).round() / grid)
 }
 
 fn active_verse_size(verse: Pixels) -> Pixels {


### PR DESCRIPTION
## Summary

- draw a growing verse at the size it ends up and scale it into place from its leading edge, so the text system is asked for one size rather than one per frame and the growth is smooth again rather than stepping through a few sizes
- give every verse the room the sung one needs, so becoming the sung verse moves nothing around it and the sheet no longer settles with a jolt
- bump gpui for `layer_scale_origin`, since a layer scale grew from the centre and would have dragged a left-aligned line sideways
- hold a better sheet from the moment a synced one is on screen, rather than only while a line is being sung, so one arriving in the gap between verses waits too
- take a held sheet up as a verse starts, never as one ends
- log each hold, each take-up and any swap that goes straight in, under `RUST_LOG=state=debug`