### PR TITLE
fix: hand a swapped lyrics sheet over without moving the sung line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   word-by-word as they come in, which used to swap the words under you, snap the sheet to a new
   position and start the highlight over. It now finishes the verse on screen and takes the better
   sheet up at the next one, keeping the line that was already growing rather than replaying it. A
-  source you pick yourself still applies at once, and so does one that arrives between verses or
-  while playback is paused.
+  source you pick yourself still applies at once, and so does one that arrives while playback is
+  paused. The line being sung stays exactly where it is as the swap lands, and the verse that was
+  already growing is not grown again.
 
 - The word-by-word highlight no longer slips backwards inside a word. Lyrics providers split a word
   where it is sung in two — "nothing" arrives as "no" and "thing" — and the soft trail the highlight

--- a/crates/state/src/lyrics.rs
+++ b/crates/state/src/lyrics.rs
@@ -356,12 +356,14 @@ impl Lyrics {
 
     /// Takes up a sheet that was held back, once the verse it would have
     /// interrupted is over.
-    pub fn settle(&mut self, cx: &mut Context<Self>) {
+    /// Returns whether a sheet was waiting.
+    pub fn settle(&mut self, cx: &mut Context<Self>) -> bool {
         let Some((ranked, displayed)) = self.waiting.take() else {
-            return;
+            return false;
         };
         log::debug!("lyrics: taking up the sheet that was held back");
         self.apply(ranked, displayed.as_ref(), cx);
+        true
     }
 
     /// Whether a sheet with verses is on screen and playing, so swapping it

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -345,15 +345,9 @@ impl Aside {
     }
 
     fn forget_verse(&mut self) {
-        self.reset_verse();
-        self.placing = true;
-    }
-
-    /// Drops what was measured and which line was sung, leaving the panel to
-    /// carry itself to the new line rather than jump there.
-    fn reset_verse(&mut self) {
         self.previous_active_line = None;
         self.departing_line = None;
+        self.placing = true;
         self.forget_measurements();
     }
 
@@ -735,7 +729,7 @@ impl Aside {
                 .update(cx, |bar, _| bar.remember_offset(scroll.offset().y));
         } else if self.verse_take != take {
             self.verse_take = take;
-            self.reset_verse();
+            self.forget_verse();
             self.anchor_verse();
             self.swapped = true;
         }
@@ -775,12 +769,19 @@ impl Aside {
                 {
                     window.request_animation_frame();
                 }
-                if std::mem::take(&mut self.swapped) {
+                let adopted = std::mem::take(&mut self.swapped);
+                if adopted {
                     self.previous_active_line = active_line;
                 }
-                // A sheet held back comes in as a verse starts, never as one ends
+                // A sheet held back comes in as a verse starts, never as one ends.
+                // Without karaoke the panel only draws on the engine's position
+                // reports, so it asks for the next frame rather than letting the
+                // verse grow for half a second before the swap lands.
                 if self.previous_active_line != active_line && active_line.is_some() {
-                    self.lyrics.update(cx, |lyrics, cx| lyrics.settle(cx));
+                    let swap = self.lyrics.update(cx, |lyrics, cx| lyrics.settle(cx));
+                    if swap {
+                        window.request_animation_frame();
+                    }
                 }
                 if self.previous_active_line != active_line {
                     if self.previous_active_line.is_some() {
@@ -918,8 +919,10 @@ impl Aside {
                     };
 
                     let dimming = (animations && departing).then_some(self.departure);
-                    let growing =
-                        animations && active && self.arrived.elapsed() < Motion::Base.span();
+                    let growing = animations
+                        && active
+                        && !adopted
+                        && self.arrived.elapsed() < Motion::Base.span();
 
                     let primary = match (primary_karaoke, line.words.as_ref(), wrapped) {
                         (true, Some(words), Some(plan)) => {


### PR DESCRIPTION
## Summary

- place the panel at the sung line when a sheet is swapped instead of carrying it there: the line sits at the same spot in either sheet, so placing is the only move that leaves it still, and the glide was the slide that showed up as pop-in
- suppress the arrival growth on a swapped-in sheet, so the verse that was already growing is not grown a second time
- ask for a frame as soon as a held sheet is taken up, since without karaoke the panel only draws on the engine's twice-a-second position reports and the swap could otherwise land half a second into the verse