### PR TITLE
fix: settle lyrics once, through a blur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,29 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Lyrics settle once instead of improving in stages. Sonora asks every source at once, and used to
+  put up each answer that beat the last, so the words could change under you two or three times in
+  the first seconds of a song. It now shows the first answer that has timings, and swaps at most once
+  more: the moment a word-by-word sheet arrives, since nothing beats one, or else when every source
+  has answered and the best of them is known. That one change comes in through a blur and a fade
+  rather than appearing abruptly. Lyrics without timings are not shown at all until the search is
+  over, so a plain sheet no longer flashes up in place of the synced one that was still coming.
+
 ### Fixed
 
+- Lyrics blur and dim smoothly as they move rather than in three visible steps. The depth of field
+  was rounded to whole pixels so neighbouring lines could share a filter, which left a line jumping
+  between a handful of levels instead of following the scroll.
+- Scrubbing a track that is still loading no longer starts it from the beginning. The seek was sent
+  to an engine that was not ready for it and lost, so playback began wherever the track had loaded
+  and the position jumped back a moment later. It is now applied again as soon as playback starts,
+  which matters most on YouTube, where a track can take seconds to come up.
 - A verse growing into place no longer steps through a few sizes, and the sheet no longer settles
   with a jolt once it has finished. The growth is drawn at the size the verse ends up and scaled into
   place from its leading edge, so the text is measured and drawn once instead of once per frame, and
   every line reserves the room the sung one needs, so becoming the sung line moves nothing around it.
-
-- A better set of lyrics arriving mid-verse no longer takes over the line you are reading. Sonora
-  asks several sources at once and shows the best answer so far, upgrading from plain to synced to
-  word-by-word as they come in, which used to swap the words under you, snap the sheet to a new
-  position and start the highlight over. It now finishes the verse on screen and takes the better
-  sheet up at the next one, keeping the line that was already growing rather than replaying it. A
-  source you pick yourself still applies at once, and so does one that arrives while playback is
-  paused. The line being sung stays exactly where it is as the swap lands, and the verse that was
-  already growing is not grown again.
-
 - The word-by-word highlight no longer slips backwards inside a word. Lyrics providers split a word
   where it is sung in two — "nothing" arrives as "no" and "thing" — and the soft trail the highlight
   carries hardened at every one of those boundaries and softened again on the next, which moved the

--- a/crates/state/src/lyrics.rs
+++ b/crates/state/src/lyrics.rs
@@ -2,12 +2,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use gpui::{App, Context, Entity, Task};
+use gpui::{Context, Entity, Task};
 use music::{Lyrics as Sheet, LyricsHit, LyricsProvider, LyricsQuery, MusicApi, Track, TrackKey};
 use tokio::task::JoinSet;
 
 use crate::sheets::Sheets;
-use crate::{Io, Playback, PlaybackState, Queue, Session, join};
+use crate::{Io, Playback, Queue, Session, join};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LyricsState {
@@ -28,15 +28,13 @@ struct Native {
     id: String,
 }
 
-type Waiting = (Vec<LyricsHit>, Option<LyricsHit>);
-
 pub struct Lyrics {
     state: LyricsState,
     hits: Vec<LyricsHit>,
     chosen: usize,
     picked: bool,
+    settled: bool,
     revision: u64,
-    waiting: Option<Waiting>,
     following: Option<String>,
     cache: HashMap<String, Found>,
     store: Sheets,
@@ -76,8 +74,8 @@ impl Lyrics {
             hits: Vec::new(),
             chosen: 0,
             picked: false,
+            settled: false,
             revision: 0,
-            waiting: None,
             following: None,
             cache: HashMap::new(),
             store: Sheets::new(),
@@ -119,7 +117,6 @@ impl Lyrics {
         }
         self.chosen = index;
         self.picked = true;
-        self.waiting = None;
         self.revision = self.revision.wrapping_add(1);
         cx.notify();
     }
@@ -145,11 +142,12 @@ impl Lyrics {
         self.following = Some(id.clone());
         self.chosen = 0;
         self.picked = false;
-        self.waiting = None;
+        self.settled = false;
         self.revision = self.revision.wrapping_add(1);
 
         if let Some(found) = self.remembered(&id, cx) {
             self.task = None;
+            self.settled = true;
             self.hits = found.hits;
             self.state = state_for(&self.hits, found.instrumental);
             cx.notify();
@@ -193,7 +191,7 @@ impl Lyrics {
         self.hits.clear();
         self.chosen = 0;
         self.picked = false;
-        self.waiting = None;
+        self.settled = false;
         self.revision = self.revision.wrapping_add(1);
         self.state = LyricsState::Idle;
         cx.notify();
@@ -318,25 +316,39 @@ impl Lyrics {
         })
     }
 
+    /// Shows an answer that arrived while others are still being looked for.
+    ///
+    /// A word-by-word sheet is the best there is, so it goes up the moment it
+    /// turns up and settles the question rather than waiting for the slowest
+    /// source to answer. Short of that, the first timed answer is put up and
+    /// nothing replaces it until the search is over: the reader is never walked
+    /// through a series of ever better sheets, and an untimed one is not shown at
+    /// all while something better could still arrive.
     fn paint(
         &mut self,
         ranked: Vec<LyricsHit>,
         displayed: Option<&LyricsHit>,
         cx: &mut Context<Self>,
     ) {
-        // A better sheet arriving part-way through a verse would swap the words
-        // under the reader and restart the highlight, so it waits for the line
-        // on screen to be sung.
-        if self.mid_verse(cx) && self.differs(&ranked, displayed) {
-            log::debug!("lyrics: holding a better sheet until the next verse");
-            self.waiting = Some((ranked, displayed.cloned()));
+        if self.settled {
             return;
         }
-        if self.current().is_some() && self.differs(&ranked, displayed) {
-            log::debug!(
-                "lyrics: swapping the sheet at once, playing {:?}",
-                self.playback.read(cx).state()
-            );
+        let kind = self
+            .prospect(&ranked, displayed)
+            .map(|hit| depth(&hit.lyrics));
+        let best = kind == Some(WORDED);
+        if !best && !self.hits.is_empty() {
+            return;
+        }
+        if !best && kind != Some(TIMED) {
+            return;
+        }
+        match best {
+            true => {
+                log::debug!("lyrics: settling on a word-by-word answer as it arrives");
+                self.settled = true;
+            }
+            false => log::debug!("lyrics: showing the first timed answer while the rest arrive"),
         }
         self.apply(ranked, displayed, cx);
     }
@@ -354,38 +366,19 @@ impl Lyrics {
         cx.notify();
     }
 
-    /// Takes up a sheet that was held back, once the verse it would have
-    /// interrupted is over.
-    /// Returns whether a sheet was waiting.
-    pub fn settle(&mut self, cx: &mut Context<Self>) -> bool {
-        let Some((ranked, displayed)) = self.waiting.take() else {
-            return false;
-        };
-        log::debug!("lyrics: taking up the sheet that was held back");
-        self.apply(ranked, displayed.as_ref(), cx);
-        true
-    }
-
-    /// Whether a sheet with verses is on screen and playing, so swapping it
-    /// would interrupt the reader.
-    fn mid_verse(&self, cx: &App) -> bool {
-        if *self.playback.read(cx).state() != PlaybackState::Playing {
-            return false;
-        }
-        self.current()
-            .is_some_and(|hit| matches!(hit.lyrics, music::Lyrics::Synced { .. }))
-    }
-
-    /// Whether taking this ranking up would change the words on screen.
-    fn differs(&self, ranked: &[LyricsHit], displayed: Option<&LyricsHit>) -> bool {
+    /// The hit a ranking would put on screen.
+    fn prospect<'a>(
+        &'a self,
+        ranked: &'a [LyricsHit],
+        displayed: Option<&'a LyricsHit>,
+    ) -> Option<&'a LyricsHit> {
         let anchor = match self.picked {
             true => self.hits.get(self.chosen),
             false => displayed,
         };
-        let next = anchor
+        anchor
             .and_then(|anchor| ranked.iter().find(|hit| same(hit, anchor)))
-            .or_else(|| ranked.first());
-        next.map(|hit| &hit.lyrics) != self.current().map(|hit| &hit.lyrics)
+            .or_else(|| ranked.first())
     }
 
     fn remember(
@@ -411,15 +404,14 @@ impl Lyrics {
             },
         );
         if current {
-            match self.mid_verse(cx) && self.differs(&hits, displayed) {
-                true => {
-                    log::debug!("lyrics: holding the settled sheet until the next verse");
-                    self.waiting = Some((hits, displayed.cloned()));
-                }
-                false => {
-                    self.pin(hits, displayed);
-                    self.state = state_for(&self.hits, instrumental);
-                }
+            // Every source has answered. Unless a word-by-word sheet already
+            // settled the question, this is the best there is and nothing may
+            // replace it afterwards.
+            if !self.settled {
+                log::debug!("lyrics: settling on the best answer");
+                self.settled = true;
+                self.pin(hits, displayed);
+                self.state = state_for(&self.hits, instrumental);
             }
             cx.notify();
             self.prefetch(cx);
@@ -455,10 +447,14 @@ impl Lyrics {
     }
 }
 
+/// What a sheet is worth: word-by-word beats timed, timed beats untimed.
+const WORDED: u8 = 3;
+const TIMED: u8 = 2;
+
 fn depth(lyrics: &Sheet) -> u8 {
     match (lyrics.worded(), lyrics.synced()) {
-        (true, _) => 3,
-        (false, true) => 2,
+        (true, _) => WORDED,
+        (false, true) => TIMED,
         (false, false) => 1,
     }
 }

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -1060,6 +1060,9 @@ impl Playback {
     }
 
     pub fn seek(&mut self, position: Duration, cx: &mut Context<Self>) {
+        if self.state != PlaybackState::Playing {
+            self.seek_on_play = Some(position);
+        }
         if self.resume_at.is_some() {
             self.resume_at = Some(position);
             if self.resume_ready

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -68,8 +68,8 @@ pub use menu::{MENU_CONTEXT, Menu, MenuItem, SubmenuState};
 pub use metrics::{LEADING, Metrics, Rounding, Text, snapped, tucked};
 pub use modal::Modal;
 pub use motion::{
-    Motion, Motioned, Pace, Stillness, ease_in_out_expo, ease_out_cubic, ease_out_expo,
-    ease_out_quad, mix,
+    Motion, Motioned, Pace, Stillness, ease_in_out_cubic, ease_in_out_expo, ease_out_cubic,
+    ease_out_expo, ease_out_quad, mix,
 };
 pub use notice::Notice;
 pub use palette::tint;

--- a/crates/ui/src/motion.rs
+++ b/crates/ui/src/motion.rs
@@ -110,6 +110,10 @@ pub fn ease_out_cubic(progress: f32) -> f32 {
     cubic_bezier(progress.clamp(0., 1.), 0.33, 1., 0.68, 1.)
 }
 
+pub fn ease_in_out_cubic(progress: f32) -> f32 {
+    cubic_bezier(progress.clamp(0., 1.), 0.65, 0., 0.35, 1.)
+}
+
 pub fn ease_in_out_expo(progress: f32) -> f32 {
     cubic_bezier(progress.clamp(0., 1.), 0.87, 0., 0.13, 1.)
 }

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -42,7 +42,12 @@ const LYRICS_HORIZONTAL_INSET_REM: f32 = 1.5;
 const PINNED_SHARE: f32 = 0.25;
 const PIN: f32 = 0.3;
 const SPARE: f32 = 1.;
-const HAZE_STEPS: f32 = 8.;
+// Below this a blur is not worth a layer of its own.
+const HAZE_LEAST: Pixels = px(0.05);
+// What a sheet settling on the best answer comes in through: it blurs and fades
+// on the way, once, on a curve that is the same going in as coming out.
+const RESOLVE_BLUR: f32 = 0.2;
+const RESOLVE_FADE: f32 = 0.5;
 const SETTLE: std::time::Duration = std::time::Duration::from_secs(4);
 const INSTRUMENTAL_BREAK: std::time::Duration = std::time::Duration::from_secs(5);
 const GLYPH: f32 = 0.35;
@@ -225,7 +230,8 @@ pub(crate) struct Aside {
     lyrics_wraps: HashMap<usize, Wrapped>,
     lane_rooms: HashMap<usize, Pixels>,
     row_heights: Vec<Pixels>,
-    swapped: bool,
+    showed: bool,
+    resolving: bool,
 }
 
 impl Aside {
@@ -307,7 +313,8 @@ impl Aside {
             lyrics_wraps: HashMap::new(),
             lane_rooms: HashMap::new(),
             row_heights: Vec::new(),
-            swapped: false,
+            showed: false,
+            resolving: false,
         }
     }
 
@@ -691,9 +698,6 @@ impl Aside {
         let theme = *cx.theme();
         let position = self.playback.read(cx).live_position();
         let singing = matches!(self.playback.read(cx).state(), PlaybackState::Playing);
-        if !singing {
-            self.lyrics.update(cx, |lyrics, cx| lyrics.settle(cx));
-        }
         let lyrics = self.lyrics.read(cx);
         let state = lyrics.state().clone();
         let shown = lyrics.current().map(|hit| hit.lyrics.clone());
@@ -729,10 +733,13 @@ impl Aside {
                 .update(cx, |bar, _| bar.remember_offset(scroll.offset().y));
         } else if self.verse_take != take {
             self.verse_take = take;
+            // Nothing was on screen before, so there is no change to play: the
+            // sheet is simply put up.
+            self.resolving = self.showed;
             self.forget_verse();
             self.anchor_verse();
-            self.swapped = true;
         }
+        self.showed = shown.is_some();
 
         let empty = |key: &'static str, cx: &mut Context<Self>| {
             vacant(i18n::lookup(key, None), cx)
@@ -768,20 +775,6 @@ impl Aside {
                     && active_line.is_some_and(|index| lines[index].worded())
                 {
                     window.request_animation_frame();
-                }
-                let adopted = std::mem::take(&mut self.swapped);
-                if adopted {
-                    self.previous_active_line = active_line;
-                }
-                // A sheet held back comes in as a verse starts, never as one ends.
-                // Without karaoke the panel only draws on the engine's position
-                // reports, so it asks for the next frame rather than letting the
-                // verse grow for half a second before the swap lands.
-                if self.previous_active_line != active_line && active_line.is_some() {
-                    let swap = self.lyrics.update(cx, |lyrics, cx| lyrics.settle(cx));
-                    if swap {
-                        window.request_animation_frame();
-                    }
                 }
                 if self.previous_active_line != active_line {
                     if self.previous_active_line.is_some() {
@@ -841,7 +834,7 @@ impl Aside {
                     let haze = |depth: f32| match (waking, settling) {
                         (true, _) => depth * (1. - sharpen),
                         (false, true) => depth * sharpen,
-                        (false, false) => stepped(depth),
+                        (false, false) => depth,
                     };
                     if has_instrumental {
                         let row = rendered.len();
@@ -875,8 +868,8 @@ impl Aside {
                             this.seek_lyrics(instrumental_start, cx);
                         }))
                         .when(softness > 0., |this| this.opacity(1. - VEIL * softness))
-                        .map(|this| match (blur * softness).round() {
-                            soft if soft > px(0.) => this.blur(soft),
+                        .map(|this| match blur * softness {
+                            soft if soft > HAZE_LEAST => this.blur(soft),
                             _ => this,
                         });
                         rendered.push(notes.into_any_element());
@@ -919,10 +912,8 @@ impl Aside {
                     };
 
                     let dimming = (animations && departing).then_some(self.departure);
-                    let growing = animations
-                        && active
-                        && !adopted
-                        && self.arrived.elapsed() < Motion::Base.span();
+                    let growing =
+                        animations && active && self.arrived.elapsed() < Motion::Base.span();
 
                     let primary = match (primary_karaoke, line.words.as_ref(), wrapped) {
                         (true, Some(words), Some(plan)) => {
@@ -1035,8 +1026,8 @@ impl Aside {
 
                     let verse_line = verse_line
                         .when(softness > 0., |this| this.opacity(1. - VEIL * softness))
-                        .map(|this| match (blur * softness).round() {
-                            soft if soft > px(0.) => this.blur(soft),
+                        .map(|this| match blur * softness {
+                            soft if soft > HAZE_LEAST => this.blur(soft),
                             _ => this,
                         });
                     let shrinking = dimming.is_some();
@@ -1148,7 +1139,7 @@ impl Aside {
             None => (px(REST), px(REST)),
         };
 
-        Scroller::new("lyrics", &self.verse_bar)
+        let sheet = Scroller::new("lyrics", &self.verse_bar)
             .flex()
             .flex_col()
             .gap_1()
@@ -1161,7 +1152,23 @@ impl Aside {
                 let fade = verse * VERSE_FADE;
                 this.fade_edges(fade, fade)
             })
-            .children(body)
+            .children(body);
+
+        // A sheet only ever replaces another once, when every source has
+        // answered, and that is the one change worth showing.
+        match self.resolving && ui::motion::animates(cx) {
+            true => sheet
+                .with_animation(
+                    ("verse-sheet", self.verse_take as usize),
+                    Animation::new(Motion::Base.span()).with_easing(ui::ease_in_out_cubic),
+                    move |this, t| {
+                        this.blur(verse * RESOLVE_BLUR * (1. - t))
+                            .opacity(1. - RESOLVE_FADE * (1. - t))
+                    },
+                )
+                .into_any_element(),
+            false => sheet.into_any_element(),
+        }
     }
 
     fn verse_slack(&self, count: usize, window: &Window, cx: &App) -> (Pixels, Pixels) {
@@ -2153,11 +2160,6 @@ fn spared(scroll: &ScrollHandle, row: usize, view: Bounds<Pixels>, slack: Pixels
     }
     let top = item.origin.y - view.origin.y + scroll.offset().y;
     top + item.size.height + slack < px(0.) || top - slack > height
-}
-
-// bucketed depth keeps neighbouring rows on one filter instead of one each
-fn stepped(depth: f32) -> f32 {
-    (depth * HAZE_STEPS).round() / HAZE_STEPS
 }
 
 fn viewport_haze(scroll: &ScrollHandle, row: usize, view: Bounds<Pixels>, margin: Pixels) -> f32 {


### PR DESCRIPTION
## Summary

- show the first lyrics answer that has timings, then swap at most once more: as soon as a word-by-word sheet arrives, since nothing beats one, or else when every source has answered
- never show untimed lyrics while something better could still arrive
- bring that single change in through a blur and a fade on a symmetrical cubic curve, and drop the wait-for-the-next-verse machinery entirely
- let the lyrics depth of field follow the scroll instead of stepping between three whole-pixel levels
- re-apply a seek made while a track is still loading, so scrubbing during a slow load no longer starts it from the beginning