### PR TITLE
release 0.20.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+[alias]
+prof = "run --release --package sonora --features profiler"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- A better set of lyrics arriving mid-verse no longer takes over the line you are reading. Sonora
+  asks several sources at once and shows the best answer so far, upgrading from plain to synced to
+  word-by-word as they come in, which used to swap the words under you, snap the sheet to a new
+  position and start the highlight over. It now finishes the verse on screen and takes the better
+  sheet up at the next one, keeping the line that was already growing rather than replaying it. A
+  source you pick yourself still applies at once, and so does one that arrives between verses or
+  while playback is paused.
+
 - The word-by-word highlight no longer slips backwards inside a word. Lyrics providers split a word
   where it is sung in two — "nothing" arrives as "no" and "thing" — and the soft trail the highlight
   carries hardened at every one of those boundaries and softened again on the next, which moved the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Lyrics no longer hitch as a track loads or as verses scroll into view. Measuring a line asked the
+  text system to shape every piece of it separately, which on Japanese, Chinese and Korean lyrics is
+  one shaping call per character and, on the frame a sheet first appears, hundreds of them at once.
+  A line is shaped once now, and the widths that come back also account for the kerning between one
+  piece and the next, so the highlight sits exactly where the glyphs do.
+
 ## [0.19.1] - 2026-08-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The word-by-word highlight no longer slips backwards inside a word. Lyrics providers split a word
+  where it is sung in two — "nothing" arrives as "no" and "thing" — and the soft trail the highlight
+  carries hardened at every one of those boundaries and softened again on the next, which moved the
+  visible edge back about half a character. The trail now runs the whole way across a line and only
+  sharpens as the line fills.
+- A verse growing into place no longer costs a dropped frame. It was animated by setting a slightly
+  different text size on every frame, and both the shaped line and every rasterised glyph are keyed
+  by size, so the whole verse was measured and redrawn from scratch each frame. The size now lands
+  on the pixel grid, which asks for two or three sizes across the whole growth.
 - Lyrics no longer hitch as a track loads or as verses scroll into view. Measuring a line asked the
   text system to shape every piece of it separately, which on Japanese, Chinese and Korean lyrics is
   one shaping call per character and, on the frame a sheet first appears, hundreds of them at once.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- A verse growing into place no longer steps through a few sizes, and the sheet no longer settles
+  with a jolt once it has finished. The growth is drawn at the size the verse ends up and scaled into
+  place from its leading edge, so the text is measured and drawn once instead of once per frame, and
+  every line reserves the room the sung one needs, so becoming the sung line moves nothing around it.
+
 - A better set of lyrics arriving mid-verse no longer takes over the line you are reading. Sonora
   asks several sources at once and shows the best answer so far, upgrading from plain to synced to
   word-by-word as they come in, which used to swap the words under you, snap the sheet to a new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-08-27
+
 ### Changed
 
 - Lyrics settle once instead of improving in stages. Sonora asks every source at once, and used to
@@ -917,7 +919,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Initial release: a native Spotify client with playback, an interactive queue, the saved library,
 search, album, playlist, artist and song pages, context menus and adaptive theming.
 
-[unreleased]: https://github.com/nolight132/sonora/compare/v0.19.1...HEAD
+[unreleased]: https://github.com/nolight132/sonora/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/nolight132/sonora/compare/v0.19.1...v0.20.0
 [0.19.1]: https://github.com/nolight132/sonora/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/nolight132/sonora/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/nolight132/sonora/compare/v0.17.1...v0.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- The word-by-word highlight and the melody-break dots ask for at most 125 frames a second rather
+  than one per refresh. On a fast display that was a third of the frames spent advancing a fill by a
+  fraction of a pixel, and anything else drawing a frame still carries the lyrics along with it, so
+  nothing moves any less smoothly.
+
 ## [0.19.1] - 2026-08-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   word-by-word as they come in, which used to swap the words under you, snap the sheet to a new
   position and start the highlight over. It now finishes the verse on screen and takes the better
   sheet up at the next one, keeping the line that was already growing rather than replaying it. A
-  source you pick yourself still applies at once, and so does one that arrives between verses or
-  while playback is paused.
+  source you pick yourself still applies at once, and so does one that arrives while playback is
+  paused. The line being sung stays exactly where it is as the swap lands, and the verse that was
+  already growing is not grown again.
 
 - The word-by-word highlight no longer slips backwards inside a word. Lyrics providers split a word
   where it is sung in two — "nothing" arrives as "no" and "thing" — and the soft trail the highlight

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,29 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Lyrics settle once instead of improving in stages. Sonora asks every source at once, and used to
+  put up each answer that beat the last, so the words could change under you two or three times in
+  the first seconds of a song. It now shows the first answer that has timings, and swaps at most once
+  more: the moment a word-by-word sheet arrives, since nothing beats one, or else when every source
+  has answered and the best of them is known. That one change comes in through a blur and a fade
+  rather than appearing abruptly. Lyrics without timings are not shown at all until the search is
+  over, so a plain sheet no longer flashes up in place of the synced one that was still coming.
+
 ### Fixed
 
+- Lyrics blur and dim smoothly as they move rather than in three visible steps. The depth of field
+  was rounded to whole pixels so neighbouring lines could share a filter, which left a line jumping
+  between a handful of levels instead of following the scroll.
+- Scrubbing a track that is still loading no longer starts it from the beginning. The seek was sent
+  to an engine that was not ready for it and lost, so playback began wherever the track had loaded
+  and the position jumped back a moment later. It is now applied again as soon as playback starts,
+  which matters most on YouTube, where a track can take seconds to come up.
 - A verse growing into place no longer steps through a few sizes, and the sheet no longer settles
   with a jolt once it has finished. The growth is drawn at the size the verse ends up and scaled into
   place from its leading edge, so the text is measured and drawn once instead of once per frame, and
   every line reserves the room the sung one needs, so becoming the sung line moves nothing around it.
-
-- A better set of lyrics arriving mid-verse no longer takes over the line you are reading. Sonora
-  asks several sources at once and shows the best answer so far, upgrading from plain to synced to
-  word-by-word as they come in, which used to swap the words under you, snap the sheet to a new
-  position and start the highlight over. It now finishes the verse on screen and takes the better
-  sheet up at the next one, keeping the line that was already growing rather than replaying it. A
-  source you pick yourself still applies at once, and so does one that arrives while playback is
-  paused. The line being sung stays exactly where it is as the swap lands, and the verse that was
-  already growing is not grown again.
-
 - The word-by-word highlight no longer slips backwards inside a word. Lyrics providers split a word
   where it is sung in two — "nothing" arrives as "no" and "thing" — and the soft trail the highlight
   carries hardened at every one of those boundaries and softened again on the next, which moved the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Changed
-
-- The word-by-word highlight and the melody-break dots ask for at most 125 frames a second rather
-  than one per refresh. On a fast display that was a third of the frames spent advancing a fill by a
-  fraction of a pixel, and anything else drawing a frame still carries the lyrics along with it, so
-  nothing moves any less smoothly.
-
 ## [0.19.1] - 2026-08-27
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,7 @@ to please the lint.
 pay nothing:
 
 ```sh
+cargo prof                             # alias for run --release --features profiler
 cargo run --features profiler          # then set any of:
 GPUI_DEBUG_OVERLAY=minimal|full        # frame time, phase split, cache hits, dirty count
 GPUI_SHOW_REPAINTS=1                   # wash every view a notify named, fading over 160ms

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "i18n"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "fluent-bundle",
  "gpui",
@@ -3383,7 +3383,7 @@ dependencies = [
 
 [[package]]
 name = "input"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "gpui",
  "ui",
@@ -4217,7 +4217,7 @@ dependencies = [
 
 [[package]]
 name = "music"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6053,7 +6053,7 @@ dependencies = [
 
 [[package]]
 name = "router"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "gpui",
  "ui",
@@ -6799,7 +6799,7 @@ dependencies = [
 
 [[package]]
 name = "sonora"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -6928,7 +6928,7 @@ dependencies = [
 
 [[package]]
 name = "state"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7949,7 +7949,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "gpui",
  "i18n",
@@ -8274,7 +8274,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "views"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "gpui",
  "i18n",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1642,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2516,7 +2516,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "gpui_apple"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "anyhow",
  "block",
@@ -2610,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -2702,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2713,7 +2713,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "gpui",
  "gpui_linux",
@@ -2724,7 +2724,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "schemars",
  "serde",
@@ -2734,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "anyhow",
  "log",
@@ -2744,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2770,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -3038,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4102,7 +4102,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -5052,7 +5052,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "collections",
  "serde",
@@ -5903,7 +5903,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "derive_refineable",
 ]
@@ -6335,7 +6335,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "async-task",
  "backtrace",
@@ -7001,7 +7001,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "heapless",
  "log",
@@ -8149,7 +8149,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "perf",
  "quote",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9724,7 +9724,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -9735,7 +9735,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=f8741c100fe36515d012bd3887dc49854b985b2c#f8741c100fe36515d012bd3887dc49854b985b2c"
+source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.19.1"
+version = "0.20.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/nolight132/sonora"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ env_logger = "0.11"
 fastrand = "2.5"
 futures = "0.3"
 fluent-bundle = "0.16"
-gpui = { git = "https://github.com/nolight132/gpui", rev = "f8741c100fe36515d012bd3887dc49854b985b2c" }
-gpui_platform = { git = "https://github.com/nolight132/gpui", rev = "f8741c100fe36515d012bd3887dc49854b985b2c", features = [
+gpui = { git = "https://github.com/nolight132/gpui", rev = "379f4c34619872fccf72c33b3b3b3386af2a9271" }
+gpui_platform = { git = "https://github.com/nolight132/gpui", rev = "379f4c34619872fccf72c33b3b3b3386af2a9271", features = [
   "font-kit",
   "wayland",
   "x11",

--- a/crates/state/src/lyrics.rs
+++ b/crates/state/src/lyrics.rs
@@ -328,8 +328,15 @@ impl Lyrics {
         // under the reader and restart the highlight, so it waits for the line
         // on screen to be sung.
         if self.mid_verse(cx) && self.differs(&ranked, displayed) {
+            log::debug!("lyrics: holding a better sheet until the next verse");
             self.waiting = Some((ranked, displayed.cloned()));
             return;
+        }
+        if self.current().is_some() && self.differs(&ranked, displayed) {
+            log::debug!(
+                "lyrics: swapping the sheet at once, playing {:?}",
+                self.playback.read(cx).state()
+            );
         }
         self.apply(ranked, displayed, cx);
     }
@@ -353,22 +360,18 @@ impl Lyrics {
         let Some((ranked, displayed)) = self.waiting.take() else {
             return;
         };
+        log::debug!("lyrics: taking up the sheet that was held back");
         self.apply(ranked, displayed.as_ref(), cx);
     }
 
-    /// Whether a verse of the sheet on screen is being sung right now.
+    /// Whether a sheet with verses is on screen and playing, so swapping it
+    /// would interrupt the reader.
     fn mid_verse(&self, cx: &App) -> bool {
-        let playback = self.playback.read(cx);
-        if *playback.state() != PlaybackState::Playing {
+        if *self.playback.read(cx).state() != PlaybackState::Playing {
             return false;
         }
-        let Some(hit) = self.current() else {
-            return false;
-        };
-        let music::Lyrics::Synced { lines } = &hit.lyrics else {
-            return false;
-        };
-        music::lyrics::active(lines, playback.live_position()).is_some()
+        self.current()
+            .is_some_and(|hit| matches!(hit.lyrics, music::Lyrics::Synced { .. }))
     }
 
     /// Whether taking this ranking up would change the words on screen.
@@ -407,7 +410,10 @@ impl Lyrics {
         );
         if current {
             match self.mid_verse(cx) && self.differs(&hits, displayed) {
-                true => self.waiting = Some((hits, displayed.cloned())),
+                true => {
+                    log::debug!("lyrics: holding the settled sheet until the next verse");
+                    self.waiting = Some((hits, displayed.cloned()));
+                }
                 false => {
                     self.pin(hits, displayed);
                     self.state = state_for(&self.hits, instrumental);

--- a/crates/state/src/lyrics.rs
+++ b/crates/state/src/lyrics.rs
@@ -2,12 +2,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use gpui::{Context, Entity, Task};
+use gpui::{App, Context, Entity, Task};
 use music::{Lyrics as Sheet, LyricsHit, LyricsProvider, LyricsQuery, MusicApi, Track, TrackKey};
 use tokio::task::JoinSet;
 
 use crate::sheets::Sheets;
-use crate::{Io, Playback, Queue, Session, join};
+use crate::{Io, Playback, PlaybackState, Queue, Session, join};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LyricsState {
@@ -28,12 +28,15 @@ struct Native {
     id: String,
 }
 
+type Waiting = (Vec<LyricsHit>, Option<LyricsHit>);
+
 pub struct Lyrics {
     state: LyricsState,
     hits: Vec<LyricsHit>,
     chosen: usize,
     picked: bool,
     revision: u64,
+    waiting: Option<Waiting>,
     following: Option<String>,
     cache: HashMap<String, Found>,
     store: Sheets,
@@ -74,6 +77,7 @@ impl Lyrics {
             chosen: 0,
             picked: false,
             revision: 0,
+            waiting: None,
             following: None,
             cache: HashMap::new(),
             store: Sheets::new(),
@@ -115,6 +119,7 @@ impl Lyrics {
         }
         self.chosen = index;
         self.picked = true;
+        self.waiting = None;
         self.revision = self.revision.wrapping_add(1);
         cx.notify();
     }
@@ -140,6 +145,7 @@ impl Lyrics {
         self.following = Some(id.clone());
         self.chosen = 0;
         self.picked = false;
+        self.waiting = None;
         self.revision = self.revision.wrapping_add(1);
 
         if let Some(found) = self.remembered(&id, cx) {
@@ -187,6 +193,7 @@ impl Lyrics {
         self.hits.clear();
         self.chosen = 0;
         self.picked = false;
+        self.waiting = None;
         self.revision = self.revision.wrapping_add(1);
         self.state = LyricsState::Idle;
         cx.notify();
@@ -317,11 +324,63 @@ impl Lyrics {
         displayed: Option<&LyricsHit>,
         cx: &mut Context<Self>,
     ) {
+        // A better sheet arriving part-way through a verse would swap the words
+        // under the reader and restart the highlight, so it waits for the line
+        // on screen to be sung.
+        if self.mid_verse(cx) && self.differs(&ranked, displayed) {
+            self.waiting = Some((ranked, displayed.cloned()));
+            return;
+        }
+        self.apply(ranked, displayed, cx);
+    }
+
+    fn apply(
+        &mut self,
+        ranked: Vec<LyricsHit>,
+        displayed: Option<&LyricsHit>,
+        cx: &mut Context<Self>,
+    ) {
         self.pin(ranked, displayed);
         if !self.hits.is_empty() {
             self.state = LyricsState::Ready;
         }
         cx.notify();
+    }
+
+    /// Takes up a sheet that was held back, once the verse it would have
+    /// interrupted is over.
+    pub fn settle(&mut self, cx: &mut Context<Self>) {
+        let Some((ranked, displayed)) = self.waiting.take() else {
+            return;
+        };
+        self.apply(ranked, displayed.as_ref(), cx);
+    }
+
+    /// Whether a verse of the sheet on screen is being sung right now.
+    fn mid_verse(&self, cx: &App) -> bool {
+        let playback = self.playback.read(cx);
+        if *playback.state() != PlaybackState::Playing {
+            return false;
+        }
+        let Some(hit) = self.current() else {
+            return false;
+        };
+        let music::Lyrics::Synced { lines } = &hit.lyrics else {
+            return false;
+        };
+        music::lyrics::active(lines, playback.live_position()).is_some()
+    }
+
+    /// Whether taking this ranking up would change the words on screen.
+    fn differs(&self, ranked: &[LyricsHit], displayed: Option<&LyricsHit>) -> bool {
+        let anchor = match self.picked {
+            true => self.hits.get(self.chosen),
+            false => displayed,
+        };
+        let next = anchor
+            .and_then(|anchor| ranked.iter().find(|hit| same(hit, anchor)))
+            .or_else(|| ranked.first());
+        next.map(|hit| &hit.lyrics) != self.current().map(|hit| &hit.lyrics)
     }
 
     fn remember(
@@ -347,8 +406,13 @@ impl Lyrics {
             },
         );
         if current {
-            self.pin(hits, displayed);
-            self.state = state_for(&self.hits, instrumental);
+            match self.mid_verse(cx) && self.differs(&hits, displayed) {
+                true => self.waiting = Some((hits, displayed.cloned())),
+                false => {
+                    self.pin(hits, displayed);
+                    self.state = state_for(&self.hits, instrumental);
+                }
+            }
             cx.notify();
             self.prefetch(cx);
         }

--- a/crates/state/src/lyrics.rs
+++ b/crates/state/src/lyrics.rs
@@ -2,12 +2,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use gpui::{App, Context, Entity, Task};
+use gpui::{Context, Entity, Task};
 use music::{Lyrics as Sheet, LyricsHit, LyricsProvider, LyricsQuery, MusicApi, Track, TrackKey};
 use tokio::task::JoinSet;
 
 use crate::sheets::Sheets;
-use crate::{Io, Playback, PlaybackState, Queue, Session, join};
+use crate::{Io, Playback, Queue, Session, join};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LyricsState {
@@ -28,15 +28,13 @@ struct Native {
     id: String,
 }
 
-type Waiting = (Vec<LyricsHit>, Option<LyricsHit>);
-
 pub struct Lyrics {
     state: LyricsState,
     hits: Vec<LyricsHit>,
     chosen: usize,
     picked: bool,
+    settled: bool,
     revision: u64,
-    waiting: Option<Waiting>,
     following: Option<String>,
     cache: HashMap<String, Found>,
     store: Sheets,
@@ -76,8 +74,8 @@ impl Lyrics {
             hits: Vec::new(),
             chosen: 0,
             picked: false,
+            settled: false,
             revision: 0,
-            waiting: None,
             following: None,
             cache: HashMap::new(),
             store: Sheets::new(),
@@ -119,7 +117,6 @@ impl Lyrics {
         }
         self.chosen = index;
         self.picked = true;
-        self.waiting = None;
         self.revision = self.revision.wrapping_add(1);
         cx.notify();
     }
@@ -145,11 +142,12 @@ impl Lyrics {
         self.following = Some(id.clone());
         self.chosen = 0;
         self.picked = false;
-        self.waiting = None;
+        self.settled = false;
         self.revision = self.revision.wrapping_add(1);
 
         if let Some(found) = self.remembered(&id, cx) {
             self.task = None;
+            self.settled = true;
             self.hits = found.hits;
             self.state = state_for(&self.hits, found.instrumental);
             cx.notify();
@@ -193,7 +191,7 @@ impl Lyrics {
         self.hits.clear();
         self.chosen = 0;
         self.picked = false;
-        self.waiting = None;
+        self.settled = false;
         self.revision = self.revision.wrapping_add(1);
         self.state = LyricsState::Idle;
         cx.notify();
@@ -318,25 +316,39 @@ impl Lyrics {
         })
     }
 
+    /// Shows an answer that arrived while others are still being looked for.
+    ///
+    /// A word-by-word sheet is the best there is, so it goes up the moment it
+    /// turns up and settles the question rather than waiting for the slowest
+    /// source to answer. Short of that, the first timed answer is put up and
+    /// nothing replaces it until the search is over: the reader is never walked
+    /// through a series of ever better sheets, and an untimed one is not shown at
+    /// all while something better could still arrive.
     fn paint(
         &mut self,
         ranked: Vec<LyricsHit>,
         displayed: Option<&LyricsHit>,
         cx: &mut Context<Self>,
     ) {
-        // A better sheet arriving part-way through a verse would swap the words
-        // under the reader and restart the highlight, so it waits for the line
-        // on screen to be sung.
-        if self.mid_verse(cx) && self.differs(&ranked, displayed) {
-            log::debug!("lyrics: holding a better sheet until the next verse");
-            self.waiting = Some((ranked, displayed.cloned()));
+        if self.settled {
             return;
         }
-        if self.current().is_some() && self.differs(&ranked, displayed) {
-            log::debug!(
-                "lyrics: swapping the sheet at once, playing {:?}",
-                self.playback.read(cx).state()
-            );
+        let kind = self
+            .prospect(&ranked, displayed)
+            .map(|hit| depth(&hit.lyrics));
+        let best = kind == Some(WORDED);
+        if !best && !self.hits.is_empty() {
+            return;
+        }
+        if !best && kind != Some(TIMED) {
+            return;
+        }
+        match best {
+            true => {
+                log::debug!("lyrics: settling on a word-by-word answer as it arrives");
+                self.settled = true;
+            }
+            false => log::debug!("lyrics: showing the first timed answer while the rest arrive"),
         }
         self.apply(ranked, displayed, cx);
     }
@@ -354,38 +366,19 @@ impl Lyrics {
         cx.notify();
     }
 
-    /// Takes up a sheet that was held back, once the verse it would have
-    /// interrupted is over.
-    /// Returns whether a sheet was waiting.
-    pub fn settle(&mut self, cx: &mut Context<Self>) -> bool {
-        let Some((ranked, displayed)) = self.waiting.take() else {
-            return false;
-        };
-        log::debug!("lyrics: taking up the sheet that was held back");
-        self.apply(ranked, displayed.as_ref(), cx);
-        true
-    }
-
-    /// Whether a sheet with verses is on screen and playing, so swapping it
-    /// would interrupt the reader.
-    fn mid_verse(&self, cx: &App) -> bool {
-        if *self.playback.read(cx).state() != PlaybackState::Playing {
-            return false;
-        }
-        self.current()
-            .is_some_and(|hit| matches!(hit.lyrics, music::Lyrics::Synced { .. }))
-    }
-
-    /// Whether taking this ranking up would change the words on screen.
-    fn differs(&self, ranked: &[LyricsHit], displayed: Option<&LyricsHit>) -> bool {
+    /// The hit a ranking would put on screen.
+    fn prospect<'a>(
+        &'a self,
+        ranked: &'a [LyricsHit],
+        displayed: Option<&'a LyricsHit>,
+    ) -> Option<&'a LyricsHit> {
         let anchor = match self.picked {
             true => self.hits.get(self.chosen),
             false => displayed,
         };
-        let next = anchor
+        anchor
             .and_then(|anchor| ranked.iter().find(|hit| same(hit, anchor)))
-            .or_else(|| ranked.first());
-        next.map(|hit| &hit.lyrics) != self.current().map(|hit| &hit.lyrics)
+            .or_else(|| ranked.first())
     }
 
     fn remember(
@@ -411,15 +404,14 @@ impl Lyrics {
             },
         );
         if current {
-            match self.mid_verse(cx) && self.differs(&hits, displayed) {
-                true => {
-                    log::debug!("lyrics: holding the settled sheet until the next verse");
-                    self.waiting = Some((hits, displayed.cloned()));
-                }
-                false => {
-                    self.pin(hits, displayed);
-                    self.state = state_for(&self.hits, instrumental);
-                }
+            // Every source has answered. Unless a word-by-word sheet already
+            // settled the question, this is the best there is and nothing may
+            // replace it afterwards.
+            if !self.settled {
+                log::debug!("lyrics: settling on the best answer");
+                self.settled = true;
+                self.pin(hits, displayed);
+                self.state = state_for(&self.hits, instrumental);
             }
             cx.notify();
             self.prefetch(cx);
@@ -455,10 +447,14 @@ impl Lyrics {
     }
 }
 
+/// What a sheet is worth: word-by-word beats timed, timed beats untimed.
+const WORDED: u8 = 3;
+const TIMED: u8 = 2;
+
 fn depth(lyrics: &Sheet) -> u8 {
     match (lyrics.worded(), lyrics.synced()) {
-        (true, _) => 3,
-        (false, true) => 2,
+        (true, _) => WORDED,
+        (false, true) => TIMED,
         (false, false) => 1,
     }
 }

--- a/crates/state/src/lyrics.rs
+++ b/crates/state/src/lyrics.rs
@@ -356,12 +356,14 @@ impl Lyrics {
 
     /// Takes up a sheet that was held back, once the verse it would have
     /// interrupted is over.
-    pub fn settle(&mut self, cx: &mut Context<Self>) {
+    /// Returns whether a sheet was waiting.
+    pub fn settle(&mut self, cx: &mut Context<Self>) -> bool {
         let Some((ranked, displayed)) = self.waiting.take() else {
-            return;
+            return false;
         };
         log::debug!("lyrics: taking up the sheet that was held back");
         self.apply(ranked, displayed.as_ref(), cx);
+        true
     }
 
     /// Whether a sheet with verses is on screen and playing, so swapping it

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -1060,6 +1060,9 @@ impl Playback {
     }
 
     pub fn seek(&mut self, position: Duration, cx: &mut Context<Self>) {
+        if self.state != PlaybackState::Playing {
+            self.seek_on_play = Some(position);
+        }
         if self.resume_at.is_some() {
             self.resume_at = Some(position);
             if self.resume_ready

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -68,8 +68,8 @@ pub use menu::{MENU_CONTEXT, Menu, MenuItem, SubmenuState};
 pub use metrics::{LEADING, Metrics, Rounding, Text, snapped, tucked};
 pub use modal::Modal;
 pub use motion::{
-    Motion, Motioned, Pace, Stillness, ease_in_out_expo, ease_out_cubic, ease_out_expo,
-    ease_out_quad, mix,
+    Motion, Motioned, Pace, Stillness, ease_in_out_cubic, ease_in_out_expo, ease_out_cubic,
+    ease_out_expo, ease_out_quad, mix,
 };
 pub use notice::Notice;
 pub use palette::tint;

--- a/crates/ui/src/motion.rs
+++ b/crates/ui/src/motion.rs
@@ -110,6 +110,10 @@ pub fn ease_out_cubic(progress: f32) -> f32 {
     cubic_bezier(progress.clamp(0., 1.), 0.33, 1., 0.68, 1.)
 }
 
+pub fn ease_in_out_cubic(progress: f32) -> f32 {
+    cubic_bezier(progress.clamp(0., 1.), 0.65, 0., 0.35, 1.)
+}
+
 pub fn ease_in_out_expo(progress: f32) -> f32 {
     cubic_bezier(progress.clamp(0., 1.), 0.87, 0., 0.13, 1.)
 }

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -802,6 +802,7 @@ impl Aside {
                     }
                 }
                 let slack = view.size.height * SPARE;
+                let grid = window.scale_factor();
                 let mut rendered = Vec::with_capacity(count);
 
                 for (index, line) in lines.iter().enumerate() {
@@ -1026,7 +1027,8 @@ impl Aside {
                                 ("verse-grow", self.arrival as usize),
                                 Animation::new(Motion::Base.span()).with_easing(ease_out_expo),
                                 move |this, t| {
-                                    let this = this.text_size(verse + ACTIVE_VERSE_GROWTH * t);
+                                    let this = this
+                                        .text_size(gridded(verse + ACTIVE_VERSE_GROWTH * t, grid));
                                     match karaoke {
                                         true => this,
                                         false => this.text_color(mix(unsung, lit, t)),
@@ -1039,8 +1041,11 @@ impl Aside {
                                 ("verse-shrink", self.departure as usize),
                                 Animation::new(Motion::Base.span()).with_easing(ease_out_expo),
                                 move |this, t| {
-                                    this.text_size(active_size - ACTIVE_VERSE_GROWTH * t)
-                                        .text_color(mix(lit, tint, t))
+                                    this.text_size(gridded(
+                                        active_size - ACTIVE_VERSE_GROWTH * t,
+                                        grid,
+                                    ))
+                                    .text_color(mix(lit, tint, t))
                                 },
                             )
                             .into_any_element(),
@@ -1520,9 +1525,7 @@ fn revealed(
     fade: Pixels,
 ) -> Reveal {
     let mut front = px(0.);
-    let mut landing = 0.;
     let mut offset = px(0.);
-    let mut soft = false;
     for index in plan.rows[row].clone() {
         let mine = plan.widths.get(index).copied().unwrap_or(px(0.));
         let word = plan.spoken.get(index).copied().unwrap_or(index);
@@ -1534,7 +1537,6 @@ fn revealed(
         // a wide character or a phrase timed as one word fills at an even pace;
         // the eased curve only reads as a flourish across Latin letters
         let even = plan.evenly.get(word).copied().unwrap_or(false);
-        soft |= even;
         let share = match even {
             true => progress_between(start, end, position),
             false => swept(start, end, position, last),
@@ -1550,20 +1552,19 @@ fn revealed(
             let reach = offset + mine * part;
             if part > 0. && reach > front {
                 front = reach;
-                landing = match share < 1. {
-                    true => ((1. - share) / LANDING).min(1.),
-                    false => 0.,
-                };
             }
         }
         offset += mine;
     }
 
-    // an even fill holds one soft edge, never wider than the text left to
-    // reveal: hardening it on every character would drag the edge back each time
-    if soft && fade > px(0.) {
-        landing = ((offset - front) / fade).min(1.);
-    }
+    // The edge keeps one soft trail the whole way across a row, no wider than
+    // the text left to reveal. Letting it harden at every word would drag the
+    // visible edge back each time, and a word can end mid-word: providers split
+    // "nothing" into "no" and "thing".
+    let landing = match fade > px(0.) {
+        true => ((offset - front) / fade).min(1.),
+        false => 0.,
+    };
 
     Reveal {
         shown: front > px(0.),
@@ -1761,6 +1762,13 @@ fn needs_space(left: &str, right: &str) -> bool {
             first,
             ')' | ']' | '}' | ',' | '.' | '!' | '?' | ';' | ':' | '%' | '\'' | '’' | '-' | '—'
         )
+}
+
+// A text size lands on the device pixel grid, so growing a verse asks the text
+// system for two or three sizes rather than one per frame: both the shaped line
+// and every rasterised glyph are keyed by size.
+fn gridded(size: Pixels, grid: f32) -> Pixels {
+    px((size / px(1.) * grid).round() / grid)
 }
 
 fn active_verse_size(verse: Pixels) -> Pixels {

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -1828,16 +1828,28 @@ fn lyrics_wrap_rows(
         .map(|(text, _)| SharedString::from(text.clone()))
         .collect::<Vec<_>>();
     let spoken = parts.iter().map(|(_, word)| *word).collect::<Vec<_>>();
-    let widths = fragments
-        .iter()
-        .map(|fragment| {
-            let run = style.to_run(fragment.len());
-            window
-                .text_system()
-                .shape_line(fragment.clone(), font_size, &[run], None)
-                .width
-        })
-        .collect::<Vec<_>>();
+    // one shaped line per verse rather than one per fragment: a line of wide
+    // characters is a shaping call each otherwise, and the widths that come back
+    // this way also carry the kerning across a boundary
+    let whole = SharedString::from(
+        parts
+            .iter()
+            .map(|(text, _)| text.as_str())
+            .collect::<String>(),
+    );
+    let run = style.to_run(whole.len());
+    let shaped = window
+        .text_system()
+        .shape_line(whole, font_size, &[run], None);
+    let mut widths = Vec::with_capacity(parts.len());
+    let mut at = 0;
+    let mut left = shaped.x_for_index(0);
+    for (text, _) in parts {
+        at += text.len();
+        let right = shaped.x_for_index(at);
+        widths.push(right - left);
+        left = right;
+    }
     let breaks = fragments
         .iter()
         .enumerate()

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -42,6 +42,9 @@ const LYRICS_HORIZONTAL_INSET_REM: f32 = 1.5;
 const PINNED_SHARE: f32 = 0.25;
 const PIN: f32 = 0.3;
 const SPARE: f32 = 1.;
+// a sweep or a set of dots has nothing to say to a display running faster than
+// this, so frames past it are work with no picture to show for it
+const TICK: std::time::Duration = std::time::Duration::from_millis(8);
 const HAZE_STEPS: f32 = 8.;
 const SETTLE: std::time::Duration = std::time::Duration::from_secs(4);
 const INSTRUMENTAL_BREAK: std::time::Duration = std::time::Duration::from_secs(5);
@@ -225,6 +228,8 @@ pub(crate) struct Aside {
     lyrics_wraps: HashMap<usize, Wrapped>,
     lane_rooms: HashMap<usize, Pixels>,
     row_heights: Vec<Pixels>,
+    ticked: std::time::Instant,
+    tick: Option<Task<()>>,
 }
 
 impl Aside {
@@ -306,6 +311,8 @@ impl Aside {
             lyrics_wraps: HashMap::new(),
             lane_rooms: HashMap::new(),
             row_heights: Vec::new(),
+            ticked: std::time::Instant::now(),
+            tick: None,
         }
     }
 
@@ -347,6 +354,32 @@ impl Aside {
         self.departing_line = None;
         self.placing = true;
         self.forget_measurements();
+    }
+
+    /// Asks for the next frame of a continuous animation, no sooner than TICK
+    /// after the last one. Anything else drawing a frame carries it along, so
+    /// this only ever removes frames nobody would have seen.
+    fn tick(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let waited = self.ticked.elapsed();
+        if waited >= TICK {
+            self.ticked = std::time::Instant::now();
+            self.tick = None;
+            window.request_animation_frame();
+            return;
+        }
+        if self.tick.is_some() {
+            return;
+        }
+        let rest = TICK - waited;
+        self.tick = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor().timer(rest).await;
+            this.update(cx, |this, cx| {
+                this.tick = None;
+                this.ticked = std::time::Instant::now();
+                cx.notify();
+            })
+            .ok();
+        }));
     }
 
     fn forget_measurements(&mut self) {
@@ -761,7 +794,7 @@ impl Aside {
                     && karaoke_effects
                     && active_line.is_some_and(|index| lines[index].worded())
                 {
-                    window.request_animation_frame();
+                    self.tick(window, cx);
                 }
                 if self.previous_active_line != active_line {
                     if self.previous_active_line.is_some() {
@@ -834,7 +867,7 @@ impl Aside {
                             continue;
                         }
                         if singing && instrumental_line == Some(index) {
-                            window.request_animation_frame();
+                            self.tick(window, cx);
                         }
                         let softness = match hazing && instrumental_line != Some(index) {
                             true => haze(viewport_haze(&scroll, rendered.len(), view, blur)),

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -778,8 +778,11 @@ impl Aside {
                 if std::mem::take(&mut self.swapped) {
                     self.previous_active_line = active_line;
                 }
-                if self.previous_active_line != active_line {
+                // A sheet held back comes in as a verse starts, never as one ends
+                if self.previous_active_line != active_line && active_line.is_some() {
                     self.lyrics.update(cx, |lyrics, cx| lyrics.settle(cx));
+                }
+                if self.previous_active_line != active_line {
                     if self.previous_active_line.is_some() {
                         self.departing_line = self.previous_active_line;
                         self.departure = self.departure.wrapping_add(1);
@@ -818,7 +821,6 @@ impl Aside {
                     }
                 }
                 let slack = view.size.height * SPARE;
-                let grid = window.scale_factor();
                 let mut rendered = Vec::with_capacity(count);
 
                 for (index, line) in lines.iter().enumerate() {
@@ -1017,6 +1019,7 @@ impl Aside {
                         .cursor_pointer()
                         .hover(|style| style.bg(theme.table_hover))
                         .text_size(verse)
+                        .line_height(active_verse_size(verse) * ui::LEADING)
                         .text_color(tint)
                         .font_weight(FontWeight::SEMIBOLD)
                         .on_hover(cx.listener(move |this, over: &bool, _, cx| {
@@ -1037,14 +1040,24 @@ impl Aside {
                     let active_size = active_verse_size(verse);
                     let unsung = theme.muted_foreground.opacity(AHEAD);
                     let lit = theme.foreground;
+                    // The verse is drawn at the size it ends up and scaled into place,
+                    // so the text system is asked for one size rather than one per
+                    // frame, and nothing around it has to move.
+                    let small = verse / active_size;
+                    let from = match line.voice.lead() {
+                        true => gpui::point(0., 0.5),
+                        false => gpui::point(1., 0.5),
+                    };
                     let verse_line = match (growing, shrinking) {
                         (true, _) => verse_line
+                            .text_size(active_size)
                             .with_animation(
                                 ("verse-grow", self.arrival as usize),
                                 Animation::new(Motion::Base.span()).with_easing(ease_out_expo),
                                 move |this, t| {
                                     let this = this
-                                        .text_size(gridded(verse + ACTIVE_VERSE_GROWTH * t, grid));
+                                        .layer_scale(small + (1. - small) * t)
+                                        .layer_scale_origin(from);
                                     match karaoke {
                                         true => this,
                                         false => this.text_color(mix(unsung, lit, t)),
@@ -1053,15 +1066,14 @@ impl Aside {
                             )
                             .into_any_element(),
                         (_, true) => verse_line
+                            .text_size(active_size)
                             .with_animation(
                                 ("verse-shrink", self.departure as usize),
                                 Animation::new(Motion::Base.span()).with_easing(ease_out_expo),
                                 move |this, t| {
-                                    this.text_size(gridded(
-                                        active_size - ACTIVE_VERSE_GROWTH * t,
-                                        grid,
-                                    ))
-                                    .text_color(mix(lit, tint, t))
+                                    this.layer_scale(1. - (1. - small) * t)
+                                        .layer_scale_origin(from)
+                                        .text_color(mix(lit, tint, t))
                                 },
                             )
                             .into_any_element(),
@@ -1778,13 +1790,6 @@ fn needs_space(left: &str, right: &str) -> bool {
             first,
             ')' | ']' | '}' | ',' | '.' | '!' | '?' | ';' | ':' | '%' | '\'' | '’' | '-' | '—'
         )
-}
-
-// A text size lands on the device pixel grid, so growing a verse asks the text
-// system for two or three sizes rather than one per frame: both the shaped line
-// and every rasterised glyph are keyed by size.
-fn gridded(size: Pixels, grid: f32) -> Pixels {
-    px((size / px(1.) * grid).round() / grid)
 }
 
 fn active_verse_size(verse: Pixels) -> Pixels {

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -345,15 +345,9 @@ impl Aside {
     }
 
     fn forget_verse(&mut self) {
-        self.reset_verse();
-        self.placing = true;
-    }
-
-    /// Drops what was measured and which line was sung, leaving the panel to
-    /// carry itself to the new line rather than jump there.
-    fn reset_verse(&mut self) {
         self.previous_active_line = None;
         self.departing_line = None;
+        self.placing = true;
         self.forget_measurements();
     }
 
@@ -735,7 +729,7 @@ impl Aside {
                 .update(cx, |bar, _| bar.remember_offset(scroll.offset().y));
         } else if self.verse_take != take {
             self.verse_take = take;
-            self.reset_verse();
+            self.forget_verse();
             self.anchor_verse();
             self.swapped = true;
         }
@@ -775,12 +769,19 @@ impl Aside {
                 {
                     window.request_animation_frame();
                 }
-                if std::mem::take(&mut self.swapped) {
+                let adopted = std::mem::take(&mut self.swapped);
+                if adopted {
                     self.previous_active_line = active_line;
                 }
-                // A sheet held back comes in as a verse starts, never as one ends
+                // A sheet held back comes in as a verse starts, never as one ends.
+                // Without karaoke the panel only draws on the engine's position
+                // reports, so it asks for the next frame rather than letting the
+                // verse grow for half a second before the swap lands.
                 if self.previous_active_line != active_line && active_line.is_some() {
-                    self.lyrics.update(cx, |lyrics, cx| lyrics.settle(cx));
+                    let swap = self.lyrics.update(cx, |lyrics, cx| lyrics.settle(cx));
+                    if swap {
+                        window.request_animation_frame();
+                    }
                 }
                 if self.previous_active_line != active_line {
                     if self.previous_active_line.is_some() {
@@ -918,8 +919,10 @@ impl Aside {
                     };
 
                     let dimming = (animations && departing).then_some(self.departure);
-                    let growing =
-                        animations && active && self.arrived.elapsed() < Motion::Base.span();
+                    let growing = animations
+                        && active
+                        && !adopted
+                        && self.arrived.elapsed() < Motion::Base.span();
 
                     let primary = match (primary_karaoke, line.words.as_ref(), wrapped) {
                         (true, Some(words), Some(plan)) => {

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -225,6 +225,7 @@ pub(crate) struct Aside {
     lyrics_wraps: HashMap<usize, Wrapped>,
     lane_rooms: HashMap<usize, Pixels>,
     row_heights: Vec<Pixels>,
+    swapped: bool,
 }
 
 impl Aside {
@@ -306,6 +307,7 @@ impl Aside {
             lyrics_wraps: HashMap::new(),
             lane_rooms: HashMap::new(),
             row_heights: Vec::new(),
+            swapped: false,
         }
     }
 
@@ -343,9 +345,15 @@ impl Aside {
     }
 
     fn forget_verse(&mut self) {
+        self.reset_verse();
+        self.placing = true;
+    }
+
+    /// Drops what was measured and which line was sung, leaving the panel to
+    /// carry itself to the new line rather than jump there.
+    fn reset_verse(&mut self) {
         self.previous_active_line = None;
         self.departing_line = None;
-        self.placing = true;
         self.forget_measurements();
     }
 
@@ -689,6 +697,9 @@ impl Aside {
         let theme = *cx.theme();
         let position = self.playback.read(cx).live_position();
         let singing = matches!(self.playback.read(cx).state(), PlaybackState::Playing);
+        if !singing {
+            self.lyrics.update(cx, |lyrics, cx| lyrics.settle(cx));
+        }
         let lyrics = self.lyrics.read(cx);
         let state = lyrics.state().clone();
         let shown = lyrics.current().map(|hit| hit.lyrics.clone());
@@ -724,8 +735,9 @@ impl Aside {
                 .update(cx, |bar, _| bar.remember_offset(scroll.offset().y));
         } else if self.verse_take != take {
             self.verse_take = take;
-            self.forget_verse();
+            self.reset_verse();
             self.anchor_verse();
+            self.swapped = true;
         }
 
         let empty = |key: &'static str, cx: &mut Context<Self>| {
@@ -763,7 +775,11 @@ impl Aside {
                 {
                     window.request_animation_frame();
                 }
+                if std::mem::take(&mut self.swapped) {
+                    self.previous_active_line = active_line;
+                }
                 if self.previous_active_line != active_line {
+                    self.lyrics.update(cx, |lyrics, cx| lyrics.settle(cx));
                     if self.previous_active_line.is_some() {
                         self.departing_line = self.previous_active_line;
                         self.departure = self.departure.wrapping_add(1);

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -42,7 +42,12 @@ const LYRICS_HORIZONTAL_INSET_REM: f32 = 1.5;
 const PINNED_SHARE: f32 = 0.25;
 const PIN: f32 = 0.3;
 const SPARE: f32 = 1.;
-const HAZE_STEPS: f32 = 8.;
+// Below this a blur is not worth a layer of its own.
+const HAZE_LEAST: Pixels = px(0.05);
+// What a sheet settling on the best answer comes in through: it blurs and fades
+// on the way, once, on a curve that is the same going in as coming out.
+const RESOLVE_BLUR: f32 = 0.2;
+const RESOLVE_FADE: f32 = 0.5;
 const SETTLE: std::time::Duration = std::time::Duration::from_secs(4);
 const INSTRUMENTAL_BREAK: std::time::Duration = std::time::Duration::from_secs(5);
 const GLYPH: f32 = 0.35;
@@ -225,7 +230,8 @@ pub(crate) struct Aside {
     lyrics_wraps: HashMap<usize, Wrapped>,
     lane_rooms: HashMap<usize, Pixels>,
     row_heights: Vec<Pixels>,
-    swapped: bool,
+    showed: bool,
+    resolving: bool,
 }
 
 impl Aside {
@@ -307,7 +313,8 @@ impl Aside {
             lyrics_wraps: HashMap::new(),
             lane_rooms: HashMap::new(),
             row_heights: Vec::new(),
-            swapped: false,
+            showed: false,
+            resolving: false,
         }
     }
 
@@ -691,9 +698,6 @@ impl Aside {
         let theme = *cx.theme();
         let position = self.playback.read(cx).live_position();
         let singing = matches!(self.playback.read(cx).state(), PlaybackState::Playing);
-        if !singing {
-            self.lyrics.update(cx, |lyrics, cx| lyrics.settle(cx));
-        }
         let lyrics = self.lyrics.read(cx);
         let state = lyrics.state().clone();
         let shown = lyrics.current().map(|hit| hit.lyrics.clone());
@@ -729,10 +733,13 @@ impl Aside {
                 .update(cx, |bar, _| bar.remember_offset(scroll.offset().y));
         } else if self.verse_take != take {
             self.verse_take = take;
+            // Nothing was on screen before, so there is no change to play: the
+            // sheet is simply put up.
+            self.resolving = self.showed;
             self.forget_verse();
             self.anchor_verse();
-            self.swapped = true;
         }
+        self.showed = shown.is_some();
 
         let empty = |key: &'static str, cx: &mut Context<Self>| {
             vacant(i18n::lookup(key, None), cx)
@@ -768,20 +775,6 @@ impl Aside {
                     && active_line.is_some_and(|index| lines[index].worded())
                 {
                     window.request_animation_frame();
-                }
-                let adopted = std::mem::take(&mut self.swapped);
-                if adopted {
-                    self.previous_active_line = active_line;
-                }
-                // A sheet held back comes in as a verse starts, never as one ends.
-                // Without karaoke the panel only draws on the engine's position
-                // reports, so it asks for the next frame rather than letting the
-                // verse grow for half a second before the swap lands.
-                if self.previous_active_line != active_line && active_line.is_some() {
-                    let swap = self.lyrics.update(cx, |lyrics, cx| lyrics.settle(cx));
-                    if swap {
-                        window.request_animation_frame();
-                    }
                 }
                 if self.previous_active_line != active_line {
                     if self.previous_active_line.is_some() {
@@ -841,7 +834,7 @@ impl Aside {
                     let haze = |depth: f32| match (waking, settling) {
                         (true, _) => depth * (1. - sharpen),
                         (false, true) => depth * sharpen,
-                        (false, false) => stepped(depth),
+                        (false, false) => depth,
                     };
                     if has_instrumental {
                         let row = rendered.len();
@@ -875,8 +868,8 @@ impl Aside {
                             this.seek_lyrics(instrumental_start, cx);
                         }))
                         .when(softness > 0., |this| this.opacity(1. - VEIL * softness))
-                        .map(|this| match (blur * softness).round() {
-                            soft if soft > px(0.) => this.blur(soft),
+                        .map(|this| match blur * softness {
+                            soft if soft > HAZE_LEAST => this.blur(soft),
                             _ => this,
                         });
                         rendered.push(notes.into_any_element());
@@ -919,10 +912,8 @@ impl Aside {
                     };
 
                     let dimming = (animations && departing).then_some(self.departure);
-                    let growing = animations
-                        && active
-                        && !adopted
-                        && self.arrived.elapsed() < Motion::Base.span();
+                    let growing =
+                        animations && active && self.arrived.elapsed() < Motion::Base.span();
 
                     let primary = match (primary_karaoke, line.words.as_ref(), wrapped) {
                         (true, Some(words), Some(plan)) => {
@@ -1035,8 +1026,8 @@ impl Aside {
 
                     let verse_line = verse_line
                         .when(softness > 0., |this| this.opacity(1. - VEIL * softness))
-                        .map(|this| match (blur * softness).round() {
-                            soft if soft > px(0.) => this.blur(soft),
+                        .map(|this| match blur * softness {
+                            soft if soft > HAZE_LEAST => this.blur(soft),
                             _ => this,
                         });
                     let shrinking = dimming.is_some();
@@ -1148,7 +1139,7 @@ impl Aside {
             None => (px(REST), px(REST)),
         };
 
-        Scroller::new("lyrics", &self.verse_bar)
+        let sheet = Scroller::new("lyrics", &self.verse_bar)
             .flex()
             .flex_col()
             .gap_1()
@@ -1161,7 +1152,23 @@ impl Aside {
                 let fade = verse * VERSE_FADE;
                 this.fade_edges(fade, fade)
             })
-            .children(body)
+            .children(body);
+
+        // A sheet only ever replaces another once, when every source has
+        // answered, and that is the one change worth showing.
+        match self.resolving && ui::motion::animates(cx) {
+            true => sheet
+                .with_animation(
+                    ("verse-sheet", self.verse_take as usize),
+                    Animation::new(Motion::Base.span()).with_easing(ui::ease_in_out_cubic),
+                    move |this, t| {
+                        this.blur(verse * RESOLVE_BLUR * (1. - t))
+                            .opacity(1. - RESOLVE_FADE * (1. - t))
+                    },
+                )
+                .into_any_element(),
+            false => sheet.into_any_element(),
+        }
     }
 
     fn verse_slack(&self, count: usize, window: &Window, cx: &App) -> (Pixels, Pixels) {
@@ -2153,11 +2160,6 @@ fn spared(scroll: &ScrollHandle, row: usize, view: Bounds<Pixels>, slack: Pixels
     }
     let top = item.origin.y - view.origin.y + scroll.offset().y;
     top + item.size.height + slack < px(0.) || top - slack > height
-}
-
-// bucketed depth keeps neighbouring rows on one filter instead of one each
-fn stepped(depth: f32) -> f32 {
-    (depth * HAZE_STEPS).round() / HAZE_STEPS
 }
 
 fn viewport_haze(scroll: &ScrollHandle, row: usize, view: Bounds<Pixels>, margin: Pixels) -> f32 {

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -42,9 +42,6 @@ const LYRICS_HORIZONTAL_INSET_REM: f32 = 1.5;
 const PINNED_SHARE: f32 = 0.25;
 const PIN: f32 = 0.3;
 const SPARE: f32 = 1.;
-// a sweep or a set of dots has nothing to say to a display running faster than
-// this, so frames past it are work with no picture to show for it
-const TICK: std::time::Duration = std::time::Duration::from_millis(8);
 const HAZE_STEPS: f32 = 8.;
 const SETTLE: std::time::Duration = std::time::Duration::from_secs(4);
 const INSTRUMENTAL_BREAK: std::time::Duration = std::time::Duration::from_secs(5);
@@ -228,8 +225,6 @@ pub(crate) struct Aside {
     lyrics_wraps: HashMap<usize, Wrapped>,
     lane_rooms: HashMap<usize, Pixels>,
     row_heights: Vec<Pixels>,
-    ticked: std::time::Instant,
-    tick: Option<Task<()>>,
 }
 
 impl Aside {
@@ -311,8 +306,6 @@ impl Aside {
             lyrics_wraps: HashMap::new(),
             lane_rooms: HashMap::new(),
             row_heights: Vec::new(),
-            ticked: std::time::Instant::now(),
-            tick: None,
         }
     }
 
@@ -354,32 +347,6 @@ impl Aside {
         self.departing_line = None;
         self.placing = true;
         self.forget_measurements();
-    }
-
-    /// Asks for the next frame of a continuous animation, no sooner than TICK
-    /// after the last one. Anything else drawing a frame carries it along, so
-    /// this only ever removes frames nobody would have seen.
-    fn tick(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let waited = self.ticked.elapsed();
-        if waited >= TICK {
-            self.ticked = std::time::Instant::now();
-            self.tick = None;
-            window.request_animation_frame();
-            return;
-        }
-        if self.tick.is_some() {
-            return;
-        }
-        let rest = TICK - waited;
-        self.tick = Some(cx.spawn(async move |this, cx| {
-            cx.background_executor().timer(rest).await;
-            this.update(cx, |this, cx| {
-                this.tick = None;
-                this.ticked = std::time::Instant::now();
-                cx.notify();
-            })
-            .ok();
-        }));
     }
 
     fn forget_measurements(&mut self) {
@@ -794,7 +761,7 @@ impl Aside {
                     && karaoke_effects
                     && active_line.is_some_and(|index| lines[index].worded())
                 {
-                    self.tick(window, cx);
+                    window.request_animation_frame();
                 }
                 if self.previous_active_line != active_line {
                     if self.previous_active_line.is_some() {
@@ -867,7 +834,7 @@ impl Aside {
                             continue;
                         }
                         if singing && instrumental_line == Some(index) {
-                            self.tick(window, cx);
+                            window.request_animation_frame();
                         }
                         let softness = match hazing && instrumental_line != Some(index) {
                             true => haze(viewport_haze(&scroll, rendered.len(), view, blur)),


### PR DESCRIPTION
## Summary

- settle lyrics once instead of improving in stages, and bring that change in through a blur and a fade
- never show untimed lyrics while a timed sheet could still arrive
- scale a verse into place rather than resizing its text, so the growth is smooth and costs no dropped frame
- keep the word-by-word highlight from slipping backwards inside a word
- let the lyrics depth of field follow the scroll
- keep a seek made while a track is still loading
- shrink what a frame redraws across the chrome, and profile it with the gpui repaint overlay
- release 0.20.0