### PR TITLE
feat(state): remember where the queue is playing from

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ partial translation is welcome — pick a language below and fill in what it lac
 
 | Language | Translated | Coverage |
 | --- | --- | --- |
-| English (`en-US`) | 399/399 | 100% |
-| Deutsch (`de`) | 368/399 | 92% |
-| Français (`fr`) | 368/399 | 92% |
-| Русский (`ru`) | 387/399 | 97% |
-| Українська (`uk`) | 387/399 | 97% |
-| Polski (`pl`) | 387/399 | 97% |
+| English (`en-US`) | 413/413 | 100% |
+| Deutsch (`de`) | 369/413 | 89% |
+| Français (`fr`) | 369/413 | 89% |
+| Русский (`ru`) | 388/413 | 94% |
+| Українська (`uk`) | 388/413 | 94% |
+| Polski (`pl`) | 388/413 | 94% |
 
 <!-- i18n:end -->
 

--- a/assets/i18n/de/main.ftl
+++ b/assets/i18n/de/main.ftl
@@ -109,6 +109,7 @@ playlist-again-add = Erneut hinzufügen
 queue-title = Warteschlange
 queue-history = Verlauf
 queue-now-playing = Läuft gerade
+queue-from = Aus
 queue-up-next = Als Nächstes
 queue-reset = Zurücksetzen
 queue-clear = Leeren

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -109,6 +109,7 @@ playlist-again-add = Add again
 queue-title = Queue
 queue-history = History
 queue-now-playing = Now playing
+queue-from = From
 queue-up-next = Up next
 queue-reset = Reset
 queue-clear = Clear

--- a/assets/i18n/fr/main.ftl
+++ b/assets/i18n/fr/main.ftl
@@ -109,6 +109,7 @@ playlist-again-add = Ajouter quand même
 queue-title = File d'attente
 queue-history = Historique
 queue-now-playing = En cours de lecture
+queue-from = Depuis
 queue-up-next = À suivre
 queue-reset = Réinitialiser
 queue-clear = Vider

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -109,6 +109,7 @@ playlist-again-add = Dodaj ponownie
 queue-title = Kolejka
 queue-history = Historia
 queue-now-playing = Teraz odtwarzane
+queue-from = Z
 queue-up-next = Następne
 queue-reset = Resetuj
 queue-clear = Wyczyść

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -109,6 +109,7 @@ playlist-again-add = Добавить ещё раз
 queue-title = Очередь
 queue-history = История
 queue-now-playing = Сейчас играет
+queue-from = Из
 queue-up-next = Далее
 queue-reset = Сбросить
 queue-clear = Очистить

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -109,6 +109,7 @@ playlist-again-add = Додати ще раз
 queue-title = Черга
 queue-history = Історія
 queue-now-playing = Зараз грає
+queue-from = З
 queue-up-next = Далі
 queue-reset = Скинути
 queue-clear = Очистити

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -25,7 +25,7 @@ pub use genre::{GenreDetails, Genres};
 pub use home::Home;
 pub use library::{Library, LibraryEvent, LibraryPart, LibraryState, Problem};
 pub use lyrics::{Lyrics, LyricsState};
-pub use playback::{Origin, Playback, PlaybackState, Repeat};
+pub use playback::{Origin, Playback, PlaybackState, Repeat, Whence};
 pub use queue::{Named, Queue, Resume, Stub};
 pub use remote::{Remote, attach as attach_remote};
 pub use search::{AlbumHit, ArtistHit, Hit, Kind, PlaylistHit, Search};

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use gpui::{App, Context, Entity, EventEmitter, Task};
+use gpui::{App, Context, Entity, EventEmitter, SharedString, Task};
 use music::{
     MusicApi, PlaybackConfig, PlaybackEvent as BackendEvent, PlaybackEvents, PlaybackFactory,
     Player, Track,
@@ -163,19 +163,82 @@ pub enum Repeat {
     One,
 }
 
-#[derive(Clone, PartialEq, Eq)]
-pub enum Origin {
-    Album(String),
-    Playlist(String),
-    Artist(String),
-    Radio(String),
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Whence {
+    Album,
+    Playlist,
+    Artist,
+    Radio,
+    Saved,
+    Local,
 }
 
+// same thing, same origin
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Origin {
+    pub whence: Whence,
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<SharedString>,
+}
+
+impl PartialEq for Origin {
+    fn eq(&self, other: &Self) -> bool {
+        self.whence == other.whence && self.id == other.id
+    }
+}
+
+impl Eq for Origin {}
+
 impl Origin {
-    fn id(&self) -> &str {
-        match self {
-            Origin::Album(id) | Origin::Playlist(id) | Origin::Artist(id) | Origin::Radio(id) => id,
+    pub fn album(id: impl Into<String>) -> Self {
+        Self::of(Whence::Album, id)
+    }
+
+    pub fn playlist(id: impl Into<String>) -> Self {
+        Self::of(Whence::Playlist, id)
+    }
+
+    pub fn artist(id: impl Into<String>) -> Self {
+        Self::of(Whence::Artist, id)
+    }
+
+    pub fn radio(id: impl Into<String>) -> Self {
+        Self::of(Whence::Radio, id)
+    }
+
+    pub fn saved() -> Self {
+        Self::of(Whence::Saved, String::new())
+    }
+
+    pub fn local() -> Self {
+        Self::of(Whence::Local, String::new())
+    }
+
+    pub fn named(mut self, name: impl Into<SharedString>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    fn of(whence: Whence, id: impl Into<String>) -> Self {
+        Self {
+            whence,
+            id: id.into(),
+            name: None,
         }
+    }
+}
+
+impl From<&Pin> for Origin {
+    fn from(pin: &Pin) -> Self {
+        let origin = match pin.kind {
+            PinKind::Album => Origin::album(pin.id.clone()),
+            PinKind::Playlist => Origin::playlist(pin.id.clone()),
+            PinKind::Artist => Origin::artist(pin.id.clone()),
+            PinKind::Song => Origin::radio(pin.id.clone()),
+        };
+        origin.named(pin.title.clone())
     }
 }
 
@@ -386,9 +449,15 @@ impl Playback {
         }));
     }
 
-    pub fn start(&mut self, tracks: Vec<Track>, index: usize, cx: &mut Context<Self>) {
+    pub fn start(
+        &mut self,
+        tracks: Vec<Track>,
+        index: usize,
+        origin: Option<Origin>,
+        cx: &mut Context<Self>,
+    ) {
         self.fetch = None;
-        self.begin(tracks, index, None, cx);
+        self.begin(tracks, index, origin, cx);
     }
 
     pub fn play_radio(&mut self, seed: &Track, cx: &mut Context<Self>) {
@@ -399,7 +468,7 @@ impl Playback {
             return self.failed(format!("{} is not available to stream", seed.name), cx);
         }
 
-        let origin = Origin::Radio(id.clone());
+        let origin = Origin::radio(id.clone()).named(seed.name.clone());
         let seed = seed.clone();
         self.gather(origin, cx, move |client| {
             Box::pin(async move {
@@ -412,9 +481,8 @@ impl Playback {
         });
     }
 
-    pub fn play_track(&mut self, track_id: &str, cx: &mut Context<Self>) {
-        let origin = Origin::Radio(track_id.to_owned());
-        let id = track_id.to_owned();
+    fn play_radio_of(&mut self, origin: Origin, cx: &mut Context<Self>) {
+        let id = origin.id.clone();
         self.gather(origin, cx, move |client| {
             Box::pin(async move {
                 let mut tracks = client.track_radio(&id).await?;
@@ -530,17 +598,15 @@ impl Playback {
         });
     }
 
-    pub fn play_album(&mut self, album: &str, cx: &mut Context<Self>) {
-        let origin = Origin::Album(album.to_owned());
-        let album = album.to_owned();
+    fn play_album_of(&mut self, origin: Origin, cx: &mut Context<Self>) {
+        let album = origin.id.clone();
         self.gather(origin, cx, move |client| {
             Box::pin(async move { client.album_tracks(&album).await })
         });
     }
 
-    pub fn play_artist(&mut self, artist: &str, cx: &mut Context<Self>) {
-        let origin = Origin::Artist(artist.to_owned());
-        let artist = artist.to_owned();
+    fn play_artist_of(&mut self, origin: Origin, cx: &mut Context<Self>) {
+        let artist = origin.id.clone();
         self.gather(origin, cx, move |client| {
             Box::pin(async move { client.artist(&artist).await.map(|found| found.top_tracks) })
         });
@@ -578,9 +644,8 @@ impl Playback {
         });
     }
 
-    pub fn play_playlist(&mut self, playlist: &str, cx: &mut Context<Self>) {
-        let origin = Origin::Playlist(playlist.to_owned());
-        let playlist = playlist.to_owned();
+    fn play_playlist_of(&mut self, origin: Origin, cx: &mut Context<Self>) {
+        let playlist = origin.id.clone();
         self.gather(origin, cx, move |client| {
             Box::pin(async move { client.playlist_tracks(&playlist).await })
         });
@@ -659,6 +724,9 @@ impl Playback {
             return;
         };
         self.origin = origin;
+        let stored = self.origin.clone();
+        self.settings
+            .update(cx, |settings, cx| settings.set_resume_origin(stored, cx));
         self.play(&track, cx);
     }
 
@@ -666,7 +734,7 @@ impl Playback {
     where
         F: FnOnce(Arc<dyn MusicApi>) -> Fetch + Send + 'static,
     {
-        let Some(client) = self.client_for(origin.id(), cx) else {
+        let Some(client) = self.client_for(&origin.id, cx) else {
             return;
         };
 
@@ -1008,9 +1076,11 @@ impl Playback {
         };
 
         let at = Duration::from_secs_f32(resume.position.max(0.));
+        let origin = resume.origin.clone();
         let Some(track) = self.queue.update(cx, |queue, cx| queue.revive(resume, cx)) else {
             return;
         };
+        self.origin = origin;
         self.track = Some(track);
         self.state = PlaybackState::Paused;
         self.position = at;
@@ -1046,16 +1116,22 @@ impl Playback {
         }
     }
 
+    pub fn play_origin(&mut self, origin: Origin, cx: &mut Context<Self>) {
+        match origin.whence {
+            Whence::Album => self.play_album_of(origin, cx),
+            Whence::Playlist => self.play_playlist_of(origin, cx),
+            Whence::Artist => self.play_artist_of(origin, cx),
+            Whence::Radio => self.play_radio_of(origin, cx),
+            // the table plays these
+            Whence::Saved | Whence::Local => {}
+        }
+    }
+
     pub fn toggle_origin(&mut self, origin: &Origin, cx: &mut Context<Self>) {
         match self.playing_from(origin) {
             Some(PlaybackState::Playing) => self.pause(cx),
             Some(PlaybackState::Paused) => self.resume(cx),
-            _ => match origin {
-                Origin::Album(id) => self.play_album(id, cx),
-                Origin::Playlist(id) => self.play_playlist(id, cx),
-                Origin::Artist(id) => self.play_artist(id, cx),
-                Origin::Radio(id) => self.play_track(id, cx),
-            },
+            _ => self.play_origin(origin.clone(), cx),
         }
     }
 

--- a/crates/state/src/queue.rs
+++ b/crates/state/src/queue.rs
@@ -17,6 +17,8 @@ pub struct Resume {
     pub(crate) provider: String,
     pub(crate) position: f32,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) origin: Option<crate::Origin>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) current: Option<Stub>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub(crate) past: Vec<Stub>,
@@ -109,6 +111,7 @@ fn record<'a>(
     Resume {
         provider: provider.to_owned(),
         position: 0.,
+        origin: None,
         current: current.and_then(stub),
         past: past[past.len().saturating_sub(KEPT_PAST)..]
             .iter()

--- a/crates/state/src/settings.rs
+++ b/crates/state/src/settings.rs
@@ -529,6 +529,17 @@ impl AppSettings {
         self.schedule_save(cx);
     }
 
+    pub fn set_resume_origin(&mut self, origin: Option<crate::Origin>, cx: &mut Context<Self>) {
+        let Some(resume) = self.values.resume.as_mut() else {
+            return;
+        };
+        if resume.origin == origin {
+            return;
+        }
+        resume.origin = origin;
+        self.save_quietly(cx);
+    }
+
     pub fn set_resume_position(&mut self, position: f32, cx: &mut Context<Self>) {
         let Some(resume) = self.values.resume.as_mut() else {
             return;
@@ -799,9 +810,12 @@ fn take(pins: &mut Pins, slug: &str, pin: &Pin) -> bool {
 
 fn carry(previous: Option<&Resume>, next: &mut Resume) {
     let playing = |resume: &Resume| resume.current.as_ref().map(|stub| stub.id.clone());
-    next.position = previous
-        .filter(|old| old.provider == next.provider && playing(old) == playing(next))
+    let same = previous.filter(|old| old.provider == next.provider);
+    next.position = same
+        .filter(|old| playing(old) == playing(next))
         .map_or(0., |old| old.position);
+    // the queue moving on does not change where it came from
+    next.origin = same.and_then(|old| old.origin.clone());
 }
 
 fn place(pinned: &mut Vec<Pin>, pin: Pin, gap: Option<usize>) -> bool {

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -10,9 +10,10 @@ use gpui::{
 };
 use i18n::t;
 use music::{Track, Voice};
+use router::{Destination, LibraryTab, Link as _};
 use state::{
     AppSettings, Lyrics, LyricsState, Playback, PlaybackState, Queue, RomanizationScripts, SideTab,
-    Sonora,
+    Sonora, Whence,
 };
 use ui::{
     ActiveTheme as _, Button, Card, DraggedPin, Edge, Motion, Motioned as _, Pin, Pinnable as _,
@@ -26,6 +27,7 @@ use crate::shared::menu::ItemMenu;
 use crate::shared::pins::Pinned as _;
 
 const QUEUE: &str = "queue";
+const BULLET: SharedString = SharedString::new_static("·");
 const FADE: f32 = 96.;
 const REST: f32 = FADE * 0.75;
 const TAIL_ROWS: usize = 2;
@@ -1277,8 +1279,30 @@ impl Aside {
         self.anchor = false;
     }
 
+    // unnamed origins stay unlabelled
+    fn playing_from(&self, cx: &App) -> Option<(SharedString, Destination)> {
+        let origin = self.playback.read(cx).origin()?;
+        let id = SharedString::from(origin.id.clone());
+        let place = match origin.whence {
+            Whence::Album => Destination::Album(id),
+            Whence::Playlist => Destination::Playlist(id),
+            Whence::Artist => Destination::Artist(id),
+            Whence::Radio => Destination::Song(id),
+            Whence::Saved => Destination::Library(LibraryTab::Songs),
+            Whence::Local => Destination::Library(LibraryTab::Local),
+        };
+        let name = match origin.whence {
+            Whence::Saved => t!("library-liked-songs"),
+            Whence::Local => t!("nav-local"),
+            _ => origin.name.clone()?,
+        };
+
+        Some((name, place))
+    }
+
     fn rows(&self, sections: Sections, cx: &mut Context<Self>) -> gpui::UniformList {
         let queue = self.queue.clone();
+        let from = self.playing_from(cx);
         let drop_gap = self.drop_gap;
         let upcoming = sections.upcoming;
         let audible = matches!(self.playback.read(cx).state(), PlaybackState::Playing);
@@ -1308,7 +1332,25 @@ impl Aside {
                     .map(|(index, slot, found)| match (slot, found) {
                         (None, _) => div().into_any_element(),
                         (Some(Slot::Header(key)), _) => {
-                            section_label(key, window, cx).into_any_element()
+                            let label = section_label(key, window, cx);
+                            match (key, from.clone()) {
+                                ("queue-now-playing", Some((name, place))) => label
+                                    .w_full()
+                                    .min_w_0()
+                                    .overflow_hidden()
+                                    .gap_1()
+                                    .child(
+                                        div()
+                                            .flex_none()
+                                            .text_size(cx.theme().text(Text::Small))
+                                            .text_color(cx.theme().muted_foreground)
+                                            .child(BULLET),
+                                    )
+                                    .child(eyebrow(t!("queue-from"), cx))
+                                    .child(source_link(name, place, cx))
+                                    .into_any_element(),
+                                _ => label.into_any_element(),
+                            }
                         }
                         (Some(Slot::Track(position)), Some(found)) => {
                             let drop_line = match (position.upcoming(), drop_gap) {
@@ -1429,6 +1471,23 @@ impl Render for Aside {
             )
             .children(self.menu(cx))
     }
+}
+
+fn source_link(name: SharedString, to: Destination, cx: &App) -> impl IntoElement {
+    let theme = *cx.theme();
+
+    div()
+        .id("queue-source")
+        .min_w_0()
+        .flex_shrink(1.)
+        .truncate()
+        .text_size(theme.text(Text::Small))
+        .text_color(theme.muted_foreground)
+        .font_weight(FontWeight::SEMIBOLD)
+        .cursor_pointer()
+        .hover(|style| style.text_color(theme.foreground).underline())
+        .link(to)
+        .child(name)
 }
 
 fn fixed_lyrics_lane(rows: &[SharedString], voice: Voice) -> Div {

--- a/crates/views/src/chrome/sidebar_left.rs
+++ b/crates/views/src/chrome/sidebar_left.rs
@@ -1,6 +1,6 @@
 use ui::{
-    ActiveTheme as _, Button, Card, DraggedPin, Edge, Panel, Pin, PinKind, Pinnable as _, Popup,
-    SNUG, Scrollbar, Scroller, Shield, Side, Tabs, Text, drop_gap, drop_marker,
+    ActiveTheme as _, Button, Card, DraggedPin, Edge, Panel, Pin, Pinnable as _, Popup, SNUG,
+    Scrollbar, Scroller, Shield, Side, Tabs, Text, drop_gap, drop_marker,
 };
 
 use gpui::prelude::*;
@@ -227,7 +227,7 @@ impl SidebarLeft {
             _ => None,
         };
 
-        let origin = origin_of(&pin);
+        let origin = Origin::from(&pin);
         let playing = matches!(
             self.playback.read(cx).playing_from(&origin),
             Some(PlaybackState::Playing)
@@ -482,15 +482,6 @@ impl Render for SidebarLeft {
                 .child(panel)
                 .into_any_element(),
         }
-    }
-}
-
-fn origin_of(pin: &Pin) -> Origin {
-    match pin.kind {
-        PinKind::Album => Origin::Album(pin.id.clone()),
-        PinKind::Playlist => Origin::Playlist(pin.id.clone()),
-        PinKind::Artist => Origin::Artist(pin.id.clone()),
-        PinKind::Song => Origin::Radio(pin.id.clone()),
     }
 }
 

--- a/crates/views/src/screens/artist.rs
+++ b/crates/views/src/screens/artist.rs
@@ -11,7 +11,7 @@ use crate::chrome::Chrome;
 use crate::shared::cells;
 use i18n::t;
 use music::{Album, ReleaseType, SavedArtist, Track};
-use state::{AppSettings, ArtistDetail, Playback, Sonora};
+use state::{AppSettings, ArtistDetail, Origin, Playback, Sonora};
 use ui::ActiveTheme as _;
 use ui::Table as _;
 use ui::{
@@ -145,6 +145,14 @@ impl ArtistView {
                 playback.clone(),
                 menu_scrollbar,
             )
+            .from({
+                let detail = detail.clone();
+                move |cx: &App| {
+                    let detail = detail.read(cx);
+                    let name = detail.artist()?.name.clone();
+                    Some(Origin::artist(detail.id()?).named(name))
+                }
+            })
             .with_liked(Sonora::global(cx).library.clone());
             let source = source.table(cx.weak_entity());
             let mut delegate = GridDelegate::new(source, width, cx);
@@ -282,12 +290,15 @@ impl ArtistView {
             .flex()
             .items_center()
             .gap_2()
-            .child(HeroPlayButton::new(
-                "play-artist",
-                t!("artist-play"),
-                self.popular.as_ref().clone(),
-                self.playback.clone(),
-            ))
+            .child(
+                HeroPlayButton::new(
+                    "play-artist",
+                    t!("artist-play"),
+                    self.popular.as_ref().clone(),
+                    self.playback.clone(),
+                )
+                .from(self.playing_from(cx)),
+            )
             .children(self.follow_button(cx))
             .children(overflow);
 
@@ -561,8 +572,16 @@ impl ArtistView {
             .into_any_element()
     }
 
+    fn playing_from(&self, cx: &App) -> Option<Origin> {
+        let detail = self.detail.read(cx);
+        let name = detail.artist()?.name.clone();
+
+        Some(Origin::artist(detail.id()?).named(name))
+    }
+
     fn popular(&self, cx: &mut Context<Self>) -> AnyElement {
         let tracks = self.popular.clone();
+        let from = self.playing_from(cx);
         let pages = Shape::new(self.width, tracks.len()).pages;
         let queued = tracks.clone();
         let playback = self.playback.clone();
@@ -603,7 +622,7 @@ impl ArtistView {
         })
         .on_start(move |place, cx| {
             playback.update(cx, |playback, cx| {
-                playback.start(queued.as_ref().clone(), place, cx)
+                playback.start(queued.as_ref().clone(), place, from.clone(), cx)
             });
         })
         .into_any_element()

--- a/crates/views/src/screens/detail.rs
+++ b/crates/views/src/screens/detail.rs
@@ -6,7 +6,7 @@ use gpui::{
 
 use i18n::t;
 use music::{Album, Playlist, Track};
-use state::{AppSettings, Collection, Detail, LibraryEvent, Playback, Sonora};
+use state::{AppSettings, Collection, Detail, LibraryEvent, Origin, Playback, Sonora};
 use ui::{ActiveTheme as _, Button, Menu, Picker, Popovers, Popup, SortAxis};
 use ui::{
     ColumnSpec, FlagAxis, GridDelegate, GridEvent, GridState, MIN_CONTENT, Pin, PinKind, RangeAxis,
@@ -96,6 +96,21 @@ impl DetailView {
                 true => source.with_album(detail.clone()),
                 false => source,
             };
+            let source = source.from({
+                let detail = detail.clone();
+                move |cx: &App| {
+                    let detail = detail.read(cx);
+                    match (detail.album(), detail.playlist()) {
+                        (Some(album), _) => {
+                            Some(Origin::album(album.id.clone()).named(album.name.clone()))
+                        }
+                        (_, Some(list)) => {
+                            Some(Origin::playlist(list.id.clone()).named(list.name.clone()))
+                        }
+                        _ => None,
+                    }
+                }
+            });
             let source = source.table(cx.weak_entity());
             let mut delegate = GridDelegate::new(source, width, cx);
             delegate.set_layout(saved, cx);

--- a/crates/views/src/screens/library/albums.rs
+++ b/crates/views/src/screens/library/albums.rs
@@ -124,11 +124,11 @@ impl AlbumSource {
     }
 
     fn index_cell(&self, cell: &Cell<AlbumField>, album: &Album, cx: &App) -> AnyElement {
-        let origin = Origin::Album(album.id.clone());
+        let origin = Origin::album(album.id.clone()).named(album.name.clone());
         let state = self.playback.read(cx).playing_from(&origin);
-        let id = album.id.clone();
+        let played = origin.clone();
         let press = cells::toggle(&self.playback, state.clone(), move |playback, cx| {
-            playback.play_album(&id, cx)
+            playback.play_origin(played.clone(), cx)
         });
 
         cells::index(cell, state, true, None, press, cx)
@@ -212,7 +212,7 @@ impl GridSource for AlbumSource {
 
     fn playing(&self, row: usize, cx: &App) -> bool {
         self.albums(cx).get(row).is_some_and(|album| {
-            let origin = Origin::Album(album.id.clone());
+            let origin = Origin::album(album.id.clone());
             self.playback.read(cx).playing_from(&origin).is_some()
         })
     }

--- a/crates/views/src/screens/library/artists.rs
+++ b/crates/views/src/screens/library/artists.rs
@@ -58,11 +58,11 @@ impl ArtistSource {
     }
 
     fn index_cell(&self, cell: &Cell<ArtistField>, artist: &SavedArtist, cx: &App) -> AnyElement {
-        let origin = Origin::Artist(artist.id.clone());
+        let origin = Origin::artist(artist.id.clone()).named(artist.name.clone());
         let state = self.playback.read(cx).playing_from(&origin);
-        let id = artist.id.clone();
+        let played = origin.clone();
         let press = cells::toggle(&self.playback, state.clone(), move |playback, cx| {
-            playback.play_artist(&id, cx)
+            playback.play_origin(played.clone(), cx)
         });
 
         cells::index(cell, state, true, None, press, cx)
@@ -98,7 +98,7 @@ impl GridSource for ArtistSource {
 
     fn playing(&self, row: usize, cx: &App) -> bool {
         self.artists(cx).get(row).is_some_and(|artist| {
-            let origin = Origin::Artist(artist.id.clone());
+            let origin = Origin::artist(artist.id.clone());
             self.playback.read(cx).playing_from(&origin).is_some()
         })
     }

--- a/crates/views/src/screens/library/local.rs
+++ b/crates/views/src/screens/library/local.rs
@@ -5,7 +5,7 @@ use gpui::{
 };
 use i18n::t;
 use music::{Album, Track};
-use state::{AppSettings, Library, LibraryPart, LibraryState, Playback, Sonora};
+use state::{AppSettings, Library, LibraryPart, LibraryState, Origin, Playback, Sonora};
 use ui::{
     ActiveTheme as _, Button, FlagAxis, GridDelegate, GridEvent, GridState, Popovers, Popup,
     RangeAxis, Scrollbar, Scroller, SortAxis, Table as _, Unit, grid, vacant,
@@ -124,7 +124,8 @@ impl LocalView {
                 LocalTracks(library.clone()),
                 playback.clone(),
                 playlist_scrollbar,
-            );
+            )
+            .from(|_| Some(Origin::local()));
             let source = source.table(cx.weak_entity());
             let mut delegate = GridDelegate::new(source, width, cx);
             let (layout, sorting) = stored(Section::Tracks, cx);

--- a/crates/views/src/screens/library/mod.rs
+++ b/crates/views/src/screens/library/mod.rs
@@ -20,7 +20,9 @@ use gpui::{
 use i18n::t;
 use music::Track;
 use router::{Destination, LibraryTab, navigate};
-use state::{AppSettings, Library, LibraryPart, LibraryState, Playback, PlaybackState, Sonora};
+use state::{
+    AppSettings, Library, LibraryPart, LibraryState, Origin, Playback, PlaybackState, Sonora,
+};
 use ui::{
     ActiveTheme as _, Button, Card, Deck, FlagAxis, GridDelegate, GridEvent, GridSource, GridState,
     LEADING, Menu, MenuItem, Mode, Pinnable, Popovers, Popup, RangeAxis, Scrollbar, Scroller, Sort,
@@ -212,7 +214,8 @@ impl LibraryView {
                 LibraryTracks(library.clone()),
                 playback.clone(),
                 playlist_scrollbar,
-            );
+            )
+            .from(|_| Some(Origin::saved()));
             let source = source.table(cx.weak_entity());
             let mut delegate = GridDelegate::new(source, width, cx).with_sort(
                 TrackField::AddedAt,
@@ -484,8 +487,9 @@ impl LibraryView {
 
     fn play(&mut self, display: usize, cx: &mut Context<Self>) {
         let queued = tracks::ordered(&self.tracks, cx);
+        let from = tracks::whence(&self.tracks, cx);
         self.playback
-            .update(cx, |playback, cx| playback.start(queued, display, cx));
+            .update(cx, |playback, cx| playback.start(queued, display, from, cx));
     }
 
     fn open_album(&mut self, display: usize, cx: &mut Context<Self>) {
@@ -804,7 +808,7 @@ impl LibraryView {
         let view = self.me.clone();
 
         Some(
-            cards::artist_card(("library-artist", display), &artist)
+            cards::artist_card(("library-artist", display), &artist, &self.playback, cx)
                 .tile(card)
                 .flat()
                 .menu(move |event, _, cx| {

--- a/crates/views/src/screens/library/playlists.rs
+++ b/crates/views/src/screens/library/playlists.rs
@@ -80,11 +80,11 @@ impl PlaylistSource {
     }
 
     fn index_cell(&self, cell: &Cell<PlaylistField>, playlist: &Playlist, cx: &App) -> AnyElement {
-        let origin = Origin::Playlist(playlist.id.clone());
+        let origin = Origin::playlist(playlist.id.clone()).named(playlist.name.clone());
         let state = self.playback.read(cx).playing_from(&origin);
-        let id = playlist.id.clone();
+        let played = origin.clone();
         let press = cells::toggle(&self.playback, state.clone(), move |playback, cx| {
-            playback.play_playlist(&id, cx)
+            playback.play_origin(played.clone(), cx)
         });
 
         cells::index(cell, state, true, None, press, cx)
@@ -121,7 +121,7 @@ impl GridSource for PlaylistSource {
 
     fn playing(&self, row: usize, cx: &App) -> bool {
         self.playlists(cx).get(row).is_some_and(|playlist| {
-            let origin = Origin::Playlist(playlist.id.clone());
+            let origin = Origin::playlist(playlist.id.clone());
             self.playback.read(cx).playing_from(&origin).is_some()
         })
     }

--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -221,7 +221,10 @@ impl SearchView {
                     .press(pressed(Press::Song(Box::new(track.clone())), me))
             }
             Hit::Artist(artist) => {
-                let origin = artist.id.clone().map(state::Origin::Artist);
+                let origin = artist
+                    .id
+                    .clone()
+                    .map(|id| state::Origin::artist(id).named(artist.name.clone()));
                 let playing = origin.as_ref().is_some_and(|origin| {
                     self.playback.read(cx).playing_from(origin)
                         == Some(state::PlaybackState::Playing)
@@ -249,7 +252,7 @@ impl SearchView {
                 }
             }
             Hit::Album(album) => {
-                let origin = state::Origin::Album(album.id.clone());
+                let origin = state::Origin::album(album.id.clone()).named(album.name.clone());
                 let playing = self.playback.read(cx).playing_from(&origin)
                     == Some(state::PlaybackState::Playing);
                 let toggled = me.clone();
@@ -268,7 +271,7 @@ impl SearchView {
                     .press(pressed(Press::Album(album.id.clone()), me))
             }
             Hit::Playlist(list) => {
-                let origin = state::Origin::Playlist(list.id.clone());
+                let origin = state::Origin::playlist(list.id.clone()).named(list.name.clone());
                 let playing = self.playback.read(cx).playing_from(&origin)
                     == Some(state::PlaybackState::Playing);
                 let toggled = me.clone();

--- a/crates/views/src/shared/cards.rs
+++ b/crates/views/src/shared/cards.rs
@@ -16,7 +16,7 @@ pub(crate) fn album_card(
 ) -> Card {
     let theme = *cx.theme();
     let cover = album.cover_large.clone().or_else(|| album.cover.clone());
-    let origin = Origin::Album(album.id.clone());
+    let origin = Origin::album(album.id.clone()).named(album.name.clone());
     let playing = matches!(
         playback.read(cx).playing_from(&origin),
         Some(PlaybackState::Playing)
@@ -51,7 +51,7 @@ pub(crate) fn playlist_card(
     playback: &Entity<Playback>,
     cx: &App,
 ) -> Card {
-    let origin = Origin::Playlist(playlist.id.clone());
+    let origin = Origin::playlist(playlist.id.clone()).named(playlist.name.clone());
     let playing = matches!(
         playback.read(cx).playing_from(&origin),
         Some(PlaybackState::Playing)
@@ -72,9 +72,20 @@ pub(crate) fn playlist_card(
         .when_some(pin, Pinnable::pin)
 }
 
-pub(crate) fn artist_card(id: impl Into<ElementId>, artist: &SavedArtist) -> Card {
+pub(crate) fn artist_card(
+    id: impl Into<ElementId>,
+    artist: &SavedArtist,
+    playback: &Entity<Playback>,
+    cx: &App,
+) -> Card {
+    let origin = Origin::artist(artist.id.clone()).named(artist.name.clone());
+    let playing = matches!(
+        playback.read(cx).playing_from(&origin),
+        Some(PlaybackState::Playing)
+    );
     let pin = artist.pin();
     let opened = SharedString::from(artist.id.clone());
+    let toggled = playback.clone();
 
     Card::new(id, SharedString::from(artist.name.clone()))
         .cover(artist.cover.clone())
@@ -82,6 +93,9 @@ pub(crate) fn artist_card(id: impl Into<ElementId>, artist: &SavedArtist) -> Car
         .weight(FontWeight::SEMIBOLD)
         .underline()
         .meta(i18n::lookup("artist-eyebrow", None))
+        .play(playing, move |_, _, cx| {
+            toggled.update(cx, |playback, cx| playback.toggle_origin(&origin, cx));
+        })
         .press(move |_, _, cx| navigate(Destination::Artist(opened.clone()), cx))
         .when_some(pin, Pinnable::pin)
 }

--- a/crates/views/src/shared/hero.rs
+++ b/crates/views/src/shared/hero.rs
@@ -7,7 +7,7 @@ use gpui::{
 };
 use i18n::t;
 use music::Track;
-use state::{Playback, PlaybackState};
+use state::{Origin, Playback, PlaybackState};
 use ui::{
     ActiveTheme as _, Artwork, Button, ExplicitBadge, GridState, LEADING, Pin, Pinnable as _, Text,
     upper,
@@ -116,6 +116,13 @@ impl Listing {
             Self::Listed(table) => tracks::ordered(table, cx),
         }
     }
+
+    fn whence(&self, cx: &App) -> Option<Origin> {
+        match self {
+            Self::Owned(_) => None,
+            Self::Listed(table) => tracks::whence(table, cx),
+        }
+    }
 }
 
 #[derive(IntoElement)]
@@ -123,6 +130,7 @@ pub(crate) struct HeroPlayButton {
     id: ElementId,
     label: SharedString,
     listing: Listing,
+    from: Option<Origin>,
     playback: Entity<Playback>,
 }
 
@@ -137,8 +145,14 @@ impl HeroPlayButton {
             id: id.into(),
             label: label.into(),
             listing: Listing::Owned(tracks),
+            from: None,
             playback,
         }
+    }
+
+    pub(crate) fn from(mut self, origin: Option<Origin>) -> Self {
+        self.from = origin;
+        self
     }
 
     pub(crate) fn listed(
@@ -151,6 +165,7 @@ impl HeroPlayButton {
             id: id.into(),
             label: label.into(),
             listing: Listing::Listed(table.clone()),
+            from: None,
             playback,
         }
     }
@@ -175,6 +190,7 @@ impl RenderOnce for HeroPlayButton {
         let disabled = first_playable.is_none() || blocked;
         let first_playable = first_playable.unwrap_or_default();
         let listing = self.listing;
+        let from = self.from;
         let playback = self.playback;
 
         div().flex().child(
@@ -190,7 +206,8 @@ impl RenderOnce for HeroPlayButton {
                         Some(PlaybackState::Loading) => {}
                         _ => {
                             let queued = listing.queue(cx);
-                            playback.start(queued, first_playable, cx)
+                            let from = from.clone().or_else(|| listing.whence(cx));
+                            playback.start(queued, first_playable, from, cx)
                         }
                     });
                 }),

--- a/crates/views/src/shared/menu.rs
+++ b/crates/views/src/shared/menu.rs
@@ -2,7 +2,7 @@ use gpui::{App, ClipboardItem, Entity, Styled as _};
 use i18n::t;
 use music::{Album, MediaKind, Playlist, SavedArtist, Track};
 use router::{Destination, navigate};
-use state::{Detail, LibraryState, Playback, Sonora};
+use state::{Detail, LibraryState, Origin, Playback, Sonora};
 use ui::{Menu, MenuItem, Pin, PinKind, Scrollbar, SubmenuState};
 
 use crate::shared::playlist_editor::{Edit, PlaylistEditor};
@@ -346,7 +346,7 @@ pub(crate) fn album_menu(
 ) -> Menu {
     let album_id = album.id.clone();
     let opened = album_id.clone();
-    let played = album_id.clone();
+    let played = Origin::album(album_id.clone()).named(album.name.clone());
     let next = album_id.clone();
     let queued = album_id.clone();
     let copied = album_id.clone();
@@ -371,7 +371,7 @@ pub(crate) fn album_menu(
                 MenuItem::new("play-album", t!("menu-play-album"))
                     .icon("icons/play.svg")
                     .on_click(move |_, _, cx| {
-                        playing.update(cx, |playback, cx| playback.play_album(&played, cx));
+                        playing.update(cx, |playback, cx| playback.play_origin(played.clone(), cx));
                     }),
                 MenuItem::new("play-album-next", t!("menu-play-next"))
                     .icon("icons/list-plus.svg")
@@ -425,7 +425,7 @@ pub(crate) fn artist_menu(
 ) -> Menu {
     let artist_id = artist.id.clone();
     let opened = artist_id.clone();
-    let played = artist_id.clone();
+    let played = Origin::artist(artist_id.clone()).named(artist.name.clone());
     let next = artist_id.clone();
     let queued = artist_id.clone();
     let copied = artist_id.clone();
@@ -450,7 +450,7 @@ pub(crate) fn artist_menu(
                 MenuItem::new("play-artist", t!("menu-play-artist"))
                     .icon("icons/play.svg")
                     .on_click(move |_, _, cx| {
-                        playing.update(cx, |playback, cx| playback.play_artist(&played, cx));
+                        playing.update(cx, |playback, cx| playback.play_origin(played.clone(), cx));
                     }),
                 MenuItem::new("play-artist-next", t!("menu-play-next"))
                     .icon("icons/list-plus.svg")
@@ -506,7 +506,7 @@ pub(crate) fn playlist_menu(
     cx: &App,
 ) -> Menu {
     let opened = playlist.id.clone();
-    let played = playlist.id.clone();
+    let played = Origin::playlist(playlist.id.clone()).named(playlist.name.clone());
     let next = playlist.id.clone();
     let queued = playlist.id.clone();
     let copied = playlist.id.clone();
@@ -570,7 +570,7 @@ pub(crate) fn playlist_menu(
                 MenuItem::new("play-playlist", t!("menu-play-playlist"))
                     .icon("icons/play.svg")
                     .on_click(move |_, _, cx| {
-                        playing.update(cx, |playback, cx| playback.play_playlist(&played, cx));
+                        playing.update(cx, |playback, cx| playback.play_origin(played.clone(), cx));
                     }),
                 MenuItem::new("play-playlist-next", t!("menu-play-next"))
                     .icon("icons/list-plus.svg")
@@ -674,7 +674,7 @@ fn open_key(kind: PinKind) -> &'static str {
 }
 
 fn transport_items(pin: &Pin, playback: Entity<Playback>) -> Vec<MenuItem> {
-    let played = pin.id.clone();
+    let played = Origin::from(pin);
     let next = pin.id.clone();
     let queued = pin.id.clone();
     let nexting = playback.clone();
@@ -685,7 +685,7 @@ fn transport_items(pin: &Pin, playback: Entity<Playback>) -> Vec<MenuItem> {
             MenuItem::new("play-pin", t!("menu-play-album"))
                 .icon("icons/play.svg")
                 .on_click(move |_, _, cx| {
-                    playback.update(cx, |playback, cx| playback.play_album(&played, cx));
+                    playback.update(cx, |playback, cx| playback.play_origin(played.clone(), cx));
                 }),
             MenuItem::new("play-pin-next", t!("menu-play-next"))
                 .icon("icons/list-plus.svg")
@@ -702,7 +702,7 @@ fn transport_items(pin: &Pin, playback: Entity<Playback>) -> Vec<MenuItem> {
             MenuItem::new("play-pin", t!("menu-play-playlist"))
                 .icon("icons/play.svg")
                 .on_click(move |_, _, cx| {
-                    playback.update(cx, |playback, cx| playback.play_playlist(&played, cx));
+                    playback.update(cx, |playback, cx| playback.play_origin(played.clone(), cx));
                 }),
             MenuItem::new("play-pin-next", t!("menu-play-next"))
                 .icon("icons/list-plus.svg")
@@ -719,7 +719,7 @@ fn transport_items(pin: &Pin, playback: Entity<Playback>) -> Vec<MenuItem> {
             MenuItem::new("play-pin", t!("menu-play-artist"))
                 .icon("icons/play.svg")
                 .on_click(move |_, _, cx| {
-                    playback.update(cx, |playback, cx| playback.play_artist(&played, cx));
+                    playback.update(cx, |playback, cx| playback.play_origin(played.clone(), cx));
                 }),
             MenuItem::new("play-pin-next", t!("menu-play-next"))
                 .icon("icons/list-plus.svg")
@@ -736,7 +736,7 @@ fn transport_items(pin: &Pin, playback: Entity<Playback>) -> Vec<MenuItem> {
             MenuItem::new("play-pin", t!("menu-song-radio"))
                 .icon("icons/radio.svg")
                 .on_click(move |_, _, cx| {
-                    playback.update(cx, |playback, cx| playback.play_track(&played, cx));
+                    playback.update(cx, |playback, cx| playback.play_origin(played.clone(), cx));
                 }),
         ],
     }

--- a/crates/views/src/shared/page.rs
+++ b/crates/views/src/shared/page.rs
@@ -35,7 +35,8 @@ pub(crate) fn play(
     cx: &mut App,
 ) {
     let queued = tracks::ordered(table, cx);
-    playback.update(cx, |playback, cx| playback.start(queued, display, cx));
+    let from = tracks::whence(table, cx);
+    playback.update(cx, |playback, cx| playback.start(queued, display, from, cx));
 }
 
 pub(crate) fn resize(

--- a/crates/views/src/shared/tracks/mod.rs
+++ b/crates/views/src/shared/tracks/mod.rs
@@ -16,7 +16,7 @@ use gpui::{
 use jiff::Timestamp;
 use music::Track;
 use router::Destination;
-use state::{Detail, Library, Playback, PlaybackState, Sonora};
+use state::{Detail, Library, Origin, Playback, PlaybackState, Sonora};
 use ui::{Button, Cell, ColumnSpec, GridSource, GridState, Menu, Pin, ROW_GROUP, Scrollbar, clock};
 
 use crate::shared::cells;
@@ -65,6 +65,10 @@ pub(crate) fn holds(table: &Entity<GridState<TrackSource>>, id: &str, cx: &App) 
     })
 }
 
+pub(crate) fn whence(table: &Entity<GridState<TrackSource>>, cx: &App) -> Option<Origin> {
+    table.read(cx).delegate().source().whence(cx)
+}
+
 pub(crate) fn ordered(table: &Entity<GridState<TrackSource>>, cx: &App) -> Vec<Track> {
     let state = table.read(cx);
     let delegate = state.delegate();
@@ -74,8 +78,11 @@ pub(crate) fn ordered(table: &Entity<GridState<TrackSource>>, cx: &App) -> Vec<T
         .collect()
 }
 
+type Whence = Rc<dyn Fn(&App) -> Option<Origin>>;
+
 pub(crate) struct TrackSource {
     columns: &'static [ColumnSpec<TrackField>],
+    whence: Option<Whence>,
     provider: Rc<dyn Tracks>,
     playback: Entity<Playback>,
     is_liked: Option<Entity<Library>>,
@@ -101,6 +108,7 @@ impl TrackSource {
     ) -> Self {
         Self {
             columns,
+            whence: None,
             provider: Rc::new(provider),
             playback,
             is_liked: None,
@@ -148,6 +156,16 @@ impl TrackSource {
         *self.spread.borrow_mut() = Some(Spread { stamp, extent });
 
         extent
+    }
+
+    // resolved when play starts
+    pub(crate) fn from(mut self, whence: impl Fn(&App) -> Option<Origin> + 'static) -> Self {
+        self.whence = Some(Rc::new(whence));
+        self
+    }
+
+    pub(crate) fn whence(&self, cx: &App) -> Option<Origin> {
+        self.whence.as_ref().and_then(|whence| whence(cx))
     }
 
     pub(crate) fn table(mut self, table: WeakEntity<GridState<TrackSource>>) -> Self {
@@ -209,17 +227,16 @@ impl TrackSource {
                 }));
                 let provider = self.provider.clone();
                 let table = self.table.clone();
+                let whence = self.whence.clone();
                 let row = cell.row;
                 let display = cell.display;
-                let press =
-                    cells::toggle(
-                        &self.playback,
-                        state.clone(),
-                        move |playback, cx| match table.as_ref().and_then(|table| table.upgrade()) {
-                            Some(table) => playback.start(ordered(&table, cx), display, cx),
-                            None => playback.start(provider.tracks(cx).to_vec(), row, cx),
-                        },
-                    );
+                let press = cells::toggle(&self.playback, state.clone(), move |playback, cx| {
+                    let from = whence.as_ref().and_then(|whence| whence(cx));
+                    match table.as_ref().and_then(|table| table.upgrade()) {
+                        Some(table) => playback.start(ordered(&table, cx), display, from, cx),
+                        None => playback.start(provider.tracks(cx).to_vec(), row, from, cx),
+                    }
+                });
                 (preload, press)
             }
         };
@@ -239,13 +256,15 @@ impl TrackSource {
                 let playback = self.playback.clone();
                 let provider = self.provider.clone();
                 let table = self.table.clone();
+                let whence = self.whence.clone();
                 let row = cell.row;
                 let display = cell.display;
                 Some(Box::new(move |cx| {
+                    let from = whence.as_ref().and_then(|whence| whence(cx));
                     playback.update(cx, |playback, cx| {
                         match table.as_ref().and_then(|table| table.upgrade()) {
-                            Some(table) => playback.start(ordered(&table, cx), display, cx),
-                            None => playback.start(provider.tracks(cx).to_vec(), row, cx),
+                            Some(table) => playback.start(ordered(&table, cx), display, from, cx),
+                            None => playback.start(provider.tracks(cx).to_vec(), row, from, cx),
                         }
                     });
                 }))


### PR DESCRIPTION
## Summary

- show what the queue is playing out of next to Now playing, as `NOW PLAYING · FROM <name>`, and open it on click
- carry the source through every way playback starts, including a click on a table row, which kept no origin at all before
- give an origin a name and a kind of its own, matching two origins by what they point at so a card still knows it is the one playing
- add liked songs and imported as origins, and label them from the current language rather than a stored string
- keep the source in the resume record, so a restart says where the music came from
- give the artist card the play button the album and playlist cards already had