### PR TITLE
release 0.21.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,4 @@ rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 
 [alias]
 prof = "run --release --package sonora --features profiler"
+prober = "run --package music --example lyrics-prober --"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-08-27
+
+### Added
+
+- The queue now says where the music is coming from, next to Now playing, and the name opens that
+  album, playlist or artist, your liked songs or the imported tab. Starting a track from a table row
+  used to leave no source recorded at all, so there was nothing to show; every way of starting
+  playback now carries one, and it is kept with the queue across a restart.
+- Artist cards have the play button album and playlist cards already had.
+
+### Changed
+
+- The lyrics sheet drags its rows along when it scrolls itself, on a verse change or after clicking
+  a verse. Each row is held back on a spring of its own, so they come to rest one after another
+  instead of the sheet arriving all at once. Scrolling the lyrics yourself is left alone: the rows
+  stay exactly where you put them.
+- Cover art is cached on disk, so images come back without fetching them again after a restart.
+- The track title in fullscreen is set semibold, both in the large view and in the strip.
+- Lines in the lyrics sheet sit a little further apart.
+
+### Fixed
+
+- Scrolling the "Add to playlist" list no longer closes it. Every row reported hover on its own
+  account, so as the list glided under a still cursor the row being left behind could have the last
+  word and start the close timer. The submenu now tracks hover for the panel as a whole, and it
+  stays open while the pointer is anywhere over it, the gap beside it, its scrollbar, or the row it
+  hangs off.
+- Moving back from a submenu onto the row that opened it no longer closes the submenu and leaves it
+  stuck shut until the pointer has been away and returned.
+- A submenu that would run off the right of the window now opens to the left of the menu instead of
+  sliding over it.
+- Turning the left sidebar off no longer leaves its width behind as empty space. A cached view is
+  laid out from the style the cache is given and never consults its own, so hiding itself was not
+  enough to give the room back.
+- Lyrics no longer jerk at the end of a verse change. Rows are drawn at the exact offset they are
+  given rather than rounded to whole pixels, which forced a slowing row either to sit on its last
+  pixel for several frames and then hop, or to stop while it was still visibly moving.
+- A verse no longer shifts sideways the frame its growth or fade finishes. Both animations now end
+  at the size the line is actually set in, so shaping it at one size and scaling it to another can
+  no longer disagree by a pixel, which a right-aligned background verse showed as a jump.
+- The lyrics blur keeps up with a long jump, such as scrubbing from the end of a track back to the
+  start. It is worked out from where a row is drawn instead of where it was laid out, so it no
+  longer goes missing at the edge the sheet is coming from.
+- A background lane no longer jumps as it finishes opening. The room it needs is measured from the
+  line height it inherits and counts the gaps between lanes, so nothing is left clipped until the
+  last frame.
+- Scrolling the lyrics with a trackpad stops the panel following the sung verse, the same as a mouse
+  wheel already did.
+- The wider gap above a change of voice no longer stretches that row.
+
 ## [0.20.0] - 2026-08-27
 
 ### Changed
@@ -919,7 +969,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Initial release: a native Spotify client with playback, an interactive queue, the saved library,
 search, album, playlist, artist and song pages, context menus and adaptive theming.
 
-[unreleased]: https://github.com/nolight132/sonora/compare/v0.20.0...HEAD
+[unreleased]: https://github.com/nolight132/sonora/compare/v0.21.0...HEAD
+[0.21.0]: https://github.com/nolight132/sonora/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/nolight132/sonora/compare/v0.19.1...v0.20.0
 [0.19.1]: https://github.com/nolight132/sonora/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/nolight132/sonora/compare/v0.18.0...v0.19.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "i18n"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "fluent-bundle",
  "gpui",
@@ -3383,7 +3383,7 @@ dependencies = [
 
 [[package]]
 name = "input"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "gpui",
  "ui",
@@ -4217,7 +4217,7 @@ dependencies = [
 
 [[package]]
 name = "music"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6053,7 +6053,7 @@ dependencies = [
 
 [[package]]
 name = "router"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "gpui",
  "ui",
@@ -6799,7 +6799,7 @@ dependencies = [
 
 [[package]]
 name = "sonora"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -6929,7 +6929,7 @@ dependencies = [
 
 [[package]]
 name = "state"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7950,7 +7950,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "gpui",
  "i18n",
@@ -8275,7 +8275,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "views"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "gpui",
  "i18n",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6815,6 +6815,7 @@ dependencies = [
  "raw-window-handle",
  "reqwest",
  "router",
+ "sha2",
  "state",
  "tokio",
  "ui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1642,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2516,7 +2516,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "gpui_apple"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "anyhow",
  "block",
@@ -2610,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -2702,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2713,7 +2713,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "gpui",
  "gpui_linux",
@@ -2724,7 +2724,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "schemars",
  "serde",
@@ -2734,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "anyhow",
  "log",
@@ -2744,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2770,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -3038,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4102,7 +4102,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -5052,7 +5052,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "collections",
  "serde",
@@ -5903,7 +5903,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "derive_refineable",
 ]
@@ -6335,7 +6335,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "async-task",
  "backtrace",
@@ -7002,7 +7002,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "heapless",
  "log",
@@ -8150,7 +8150,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "perf",
  "quote",
@@ -9708,7 +9708,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9725,7 +9725,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -9736,7 +9736,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=379f4c34619872fccf72c33b3b3b3386af2a9271#379f4c34619872fccf72c33b3b3b3386af2a9271"
+source = "git+https://github.com/nolight132/gpui?rev=cb1238e494c29cec8a87dae674a7cee70e9100a7#cb1238e494c29cec8a87dae674a7cee70e9100a7"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ env_logger = "0.11"
 fastrand = "2.5"
 futures = "0.3"
 fluent-bundle = "0.16"
-gpui = { git = "https://github.com/nolight132/gpui", rev = "379f4c34619872fccf72c33b3b3b3386af2a9271" }
-gpui_platform = { git = "https://github.com/nolight132/gpui", rev = "379f4c34619872fccf72c33b3b3b3386af2a9271", features = [
+gpui = { git = "https://github.com/nolight132/gpui", rev = "cb1238e494c29cec8a87dae674a7cee70e9100a7" }
+gpui_platform = { git = "https://github.com/nolight132/gpui", rev = "cb1238e494c29cec8a87dae674a7cee70e9100a7", features = [
   "font-kit",
   "wayland",
   "x11",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.20.0"
+version = "0.21.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/nolight132/sonora"

--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ Stream Spotify, YouTube Music, and local files all in one **native** app.
     <table>
       <tr>
         <td colspan="2">
-          <img width="1762" height="1087" alt="image" src="https://github.com/user-attachments/assets/356b17e6-45dd-461c-89bb-96ee660fed5e" />
+          <img width="1602" height="992" alt="image" src="https://github.com/user-attachments/assets/d0357517-a28d-4c90-abd1-4f3e8d8cdedc" />
         </td>
       </tr>
       <tr>
         <td width="50%">
-          <img width="1496" height="936" alt="image" src="https://github.com/user-attachments/assets/58f88aaa-ce1f-4796-94eb-144d0ae9d677" />
+          <img width="1576" height="945" alt="image" src="https://github.com/user-attachments/assets/70979e4c-261f-4561-b671-04d28a9971a9" />
         </td>
         <td width="50%">
-          <img width="1496" height="936" alt="image" src="https://github.com/user-attachments/assets/df1e3792-245b-4b8b-83de-103c59219f74" />
+          <img width="1576" height="945" alt="image" src="https://github.com/user-attachments/assets/ff3b4284-25e2-4487-bf9b-60d8f56dc44d" />
         </td>
       </tr>
     </table>

--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ partial translation is welcome — pick a language below and fill in what it lac
 
 | Language | Translated | Coverage |
 | --- | --- | --- |
-| English (`en-US`) | 399/399 | 100% |
-| Deutsch (`de`) | 368/399 | 92% |
-| Français (`fr`) | 368/399 | 92% |
-| Русский (`ru`) | 387/399 | 97% |
-| Українська (`uk`) | 387/399 | 97% |
-| Polski (`pl`) | 387/399 | 97% |
+| English (`en-US`) | 413/413 | 100% |
+| Deutsch (`de`) | 369/413 | 89% |
+| Français (`fr`) | 369/413 | 89% |
+| Русский (`ru`) | 388/413 | 94% |
+| Українська (`uk`) | 388/413 | 94% |
+| Polski (`pl`) | 388/413 | 94% |
 
 <!-- i18n:end -->
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Stream Spotify, YouTube Music, and local files all in one **native** app.
 
 ### macOS
 
+Install with [Brew](https://brew.sh/).
+
 ```sh
 brew install --cask nolight132/tap/sonora
 ```
@@ -57,9 +59,17 @@ xattr -dr com.apple.quarantine /Applications/Sonora.app
 
 ### Linux
 
-```sh
-AUR, COPR, .deb coming soon.
+#### Arch
+
+Install from the AUR with your AUR helper of choice.
+
 ```
+yay -S sonora
+```
+
+#### Other
+
+Flatpak coming soon.
 
 ### Nix
 Just use the flake in the project root.
@@ -71,7 +81,14 @@ inputs.sonora.packages.${system}.default
 The flake installs the latest tagged release binary.
 
 ### Windows
-Download the latest `.exe` for your architecture from [Releases](https://github.com/nolight132/sonora/releases/latest). There isn't a proper Windows installer yet.
+
+#### Installer
+
+Download and run the [installer](https://github.com/nolight132/sonora/releases/latest/download/Sonora-Setup.exe).
+
+#### Portable
+
+Download the latest `windows-msvc.exe` for your architecture from [Releases](https://github.com/nolight132/sonora/releases/latest).
 
 ## Translations
 

--- a/assets/i18n/de/main.ftl
+++ b/assets/i18n/de/main.ftl
@@ -109,6 +109,7 @@ playlist-again-add = Erneut hinzufügen
 queue-title = Warteschlange
 queue-history = Verlauf
 queue-now-playing = Läuft gerade
+queue-from = Aus
 queue-up-next = Als Nächstes
 queue-reset = Zurücksetzen
 queue-clear = Leeren

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -109,6 +109,7 @@ playlist-again-add = Add again
 queue-title = Queue
 queue-history = History
 queue-now-playing = Now playing
+queue-from = From
 queue-up-next = Up next
 queue-reset = Reset
 queue-clear = Clear

--- a/assets/i18n/fr/main.ftl
+++ b/assets/i18n/fr/main.ftl
@@ -109,6 +109,7 @@ playlist-again-add = Ajouter quand même
 queue-title = File d'attente
 queue-history = Historique
 queue-now-playing = En cours de lecture
+queue-from = Depuis
 queue-up-next = À suivre
 queue-reset = Réinitialiser
 queue-clear = Vider

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -109,6 +109,7 @@ playlist-again-add = Dodaj ponownie
 queue-title = Kolejka
 queue-history = Historia
 queue-now-playing = Teraz odtwarzane
+queue-from = Z
 queue-up-next = Następne
 queue-reset = Resetuj
 queue-clear = Wyczyść

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -109,6 +109,7 @@ playlist-again-add = Добавить ещё раз
 queue-title = Очередь
 queue-history = История
 queue-now-playing = Сейчас играет
+queue-from = Из
 queue-up-next = Далее
 queue-reset = Сбросить
 queue-clear = Очистить

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -109,6 +109,7 @@ playlist-again-add = Додати ще раз
 queue-title = Черга
 queue-history = Історія
 queue-now-playing = Зараз грає
+queue-from = З
 queue-up-next = Далі
 queue-reset = Скинути
 queue-clear = Очистити

--- a/crates/music/examples/lyrics-prober.rs
+++ b/crates/music/examples/lyrics-prober.rs
@@ -1,0 +1,314 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context as _, Result, bail};
+use music::spotify::{AuthConfig, LibrespotClient, auth};
+use music::youtube::YouTubeClient;
+use music::{
+    Lyrics, LyricsHit, LyricsProvider, LyricsQuery, MusicApi, Track, TrackKey, binimum, kugou,
+    lrclib, musixmatch, netease,
+};
+use ytmusic::YtMusic;
+
+const NATIVE: &str = "Spotify";
+const OWN_TRUST: u32 = 25;
+const LISTED: usize = 4;
+
+struct Probe {
+    source: &'static str,
+    elapsed: Duration,
+    hits: Vec<LyricsHit>,
+    error: Option<String>,
+}
+
+fn providers() -> Vec<Arc<dyn LyricsProvider>> {
+    vec![
+        Arc::new(binimum::Binimum::new()),
+        Arc::new(musixmatch::Musixmatch::new()),
+        Arc::new(lrclib::LrcLib::new()),
+        Arc::new(kugou::Kugou::new()),
+        Arc::new(netease::NetEase::new()),
+    ]
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<()> {
+    let Some(link) = std::env::args().nth(1) else {
+        bail!("usage: lyrics-prober <spotify or youtube link, or a search query>");
+    };
+
+    let (track, provider, native) = resolve(&link).await?;
+    let query = LyricsQuery {
+        title: track.name.clone(),
+        artist: track.artists.clone(),
+        album: (!track.album.is_empty()).then(|| track.album.clone()),
+        duration: track.duration,
+        track: track.id.clone().map(|id| TrackKey { provider, id }),
+    };
+
+    println!(
+        "{} — {} [{}] {} ({})",
+        track.name,
+        track.artists,
+        track.album,
+        clock(track.duration),
+        track
+            .id
+            .as_deref()
+            .map(|id| format!("{provider}:{id}"))
+            .unwrap_or_else(|| "no id".to_owned()),
+    );
+    println!();
+
+    let mut probes = probe(&query, native).await;
+    probes.sort_by_key(|probe| probe.elapsed);
+
+    println!(
+        "{:<12} {:>6} {:>5}  {:>6} {:>4} {:<8} matched title / artist",
+        "provider", "ms", "hits", "score", "keep", "kind"
+    );
+    for found in &probes {
+        report(&query, found);
+    }
+    println!();
+
+    let all: Vec<LyricsHit> = probes
+        .iter()
+        .flat_map(|found| found.hits.iter().cloned())
+        .collect();
+    let ranked = music::lyrics::rank(&query, all);
+    match ranked.is_empty() {
+        true => println!(
+            "nothing survived ranking{}",
+            match music::lyrics::instrumental(&query, &ranked) {
+                true => ", the track reads as instrumental",
+                false => "",
+            }
+        ),
+        false => {
+            println!("ranked:");
+            for (place, hit) in ranked.iter().enumerate() {
+                println!(
+                    "  {:>2}. {:<12} {:>6} {:<8} {}",
+                    place + 1,
+                    hit.source,
+                    music::lyrics::score(&query, hit),
+                    kind(&hit.lyrics),
+                    shape(&hit.lyrics),
+                );
+            }
+
+            let mut reshaped = ranked.clone();
+            music::lyrics::reshape(&mut reshaped);
+            let winner = &reshaped[0];
+            println!();
+            println!(
+                "winner: {} ({}, {}){}",
+                winner.source,
+                kind(&winner.lyrics),
+                shape(&winner.lyrics),
+                match winner.lyrics == ranked[0].lyrics {
+                    true => String::new(),
+                    false => format!(" reshaped onto {}", ranked[0].source),
+                }
+            );
+        }
+    }
+
+    Ok(())
+}
+
+async fn resolve(link: &str) -> Result<(Track, &'static str, Option<Arc<LibrespotClient>>)> {
+    if let Some(id) = youtube_id(link) {
+        let api = Arc::new(YtMusic::anonymous());
+        let track = YouTubeClient::new(api)
+            .track(&id)
+            .await
+            .context("cannot look the video up as a guest")?;
+        return Ok((track, "youtube", None));
+    }
+
+    let session = auth::restore(&AuthConfig::from_env())
+        .await
+        .context("cannot restore the cached session")?
+        .context("no cached credentials; sign in with sonora first")?;
+    let client = Arc::new(LibrespotClient::new(session));
+
+    let track = match spotify_id(link) {
+        Some(id) => client
+            .track(&id)
+            .await
+            .context("cannot look the track up")?,
+        None => client
+            .search(link)
+            .await
+            .context("cannot search for the track")?
+            .into_iter()
+            .next()
+            .context("nothing found for that query")?,
+    };
+
+    Ok((track, "spotify", Some(client)))
+}
+
+async fn probe(query: &LyricsQuery, native: Option<Arc<LibrespotClient>>) -> Vec<Probe> {
+    let mut tasks = tokio::task::JoinSet::new();
+    for provider in providers() {
+        let query = query.clone();
+        tasks.spawn(async move {
+            let started = Instant::now();
+            let found = provider.search(&query).await;
+            Probe {
+                source: provider.name(),
+                elapsed: started.elapsed(),
+                hits: found.as_ref().map(Vec::clone).unwrap_or_default(),
+                error: found.err().map(|error| format!("{error:#}")),
+            }
+        });
+    }
+
+    if let Some(client) = native
+        && let Some(id) = query.track.as_ref().map(|key| key.id.clone())
+    {
+        let query = query.clone();
+        tasks.spawn(async move {
+            let started = Instant::now();
+            let found = client.track_lyrics(&id).await;
+            let elapsed = started.elapsed();
+            let (hits, error) = match found {
+                Ok(Some(lyrics)) if !lyrics.is_empty() => (vec![own(lyrics, &query)], None),
+                Ok(_) => (Vec::new(), None),
+                Err(error) => (Vec::new(), Some(format!("{error:#}"))),
+            };
+            Probe {
+                source: NATIVE,
+                elapsed,
+                hits,
+                error,
+            }
+        });
+    }
+
+    let mut probes = Vec::new();
+    while let Some(found) = tasks.join_next().await {
+        if let Ok(found) = found {
+            probes.push(found);
+        }
+    }
+    probes
+}
+
+fn report(query: &LyricsQuery, found: &Probe) {
+    let millis = found.elapsed.as_millis();
+    if let Some(error) = &found.error {
+        println!("{:<12} {millis:>6} {:>5}  {error}", found.source, "—");
+        return;
+    }
+    if found.hits.is_empty() {
+        println!("{:<12} {millis:>6} {:>5}", found.source, 0);
+        return;
+    }
+
+    let mut scored: Vec<(i64, &LyricsHit)> = found
+        .hits
+        .iter()
+        .map(|hit| (music::lyrics::score(query, hit), hit))
+        .collect();
+    scored.sort_by(|(left, _), (right, _)| right.cmp(left));
+
+    for (place, (score, hit)) in scored.iter().take(LISTED).enumerate() {
+        let head = match place {
+            0 => format!("{:<12} {millis:>6} {:>5}", found.source, found.hits.len()),
+            _ => format!("{:<12} {:>6} {:>5}", "", "", ""),
+        };
+        println!(
+            "{head}  {score:>6} {:>4} {:<8} {} — {}{}",
+            match music::lyrics::eligible(query, hit) {
+                true => "yes",
+                false => "no",
+            },
+            kind(&hit.lyrics),
+            hit.title,
+            hit.artist,
+            hit.duration
+                .map(|duration| format!(" ({})", clock(duration)))
+                .unwrap_or_default(),
+        );
+    }
+    if let Some(rest) = scored.len().checked_sub(LISTED).filter(|rest| *rest > 0) {
+        println!("{:<12} {:>6} {:>5}  {rest:>6} more", "", "", "");
+    }
+}
+
+fn own(lyrics: Lyrics, query: &LyricsQuery) -> LyricsHit {
+    LyricsHit {
+        source: NATIVE,
+        trust: OWN_TRUST,
+        lyrics,
+        instrumental: false,
+        title: query.title.clone(),
+        artist: query.artist.clone(),
+        album: query.album.clone(),
+        duration: (!query.duration.is_zero()).then_some(query.duration),
+        writers: Vec::new(),
+    }
+}
+
+fn kind(lyrics: &Lyrics) -> &'static str {
+    match (lyrics.worded(), lyrics.synced()) {
+        (true, _) => "worded",
+        (false, true) => "synced",
+        (false, false) => "plain",
+    }
+}
+
+fn shape(lyrics: &Lyrics) -> String {
+    let Lyrics::Synced { lines } = lyrics else {
+        return "unsynced".to_owned();
+    };
+    let words: usize = lines
+        .iter()
+        .map(|line| line.words.as_ref().map_or(0, Vec::len))
+        .sum();
+    let voices = lines.iter().filter(|line| !line.voice.lead()).count();
+    let secondary: usize = lines.iter().map(|line| line.secondary.len()).sum();
+
+    format!(
+        "{} lines, {words} words, {voices} background, {secondary} lanes, spans {}",
+        lines.len(),
+        lyrics.span().map(clock).unwrap_or_else(|| "—".to_owned()),
+    )
+}
+
+fn clock(duration: Duration) -> String {
+    let seconds = duration.as_secs();
+    format!("{}:{:02}", seconds / 60, seconds % 60)
+}
+
+fn spotify_id(link: &str) -> Option<String> {
+    if let Some(rest) = link.strip_prefix("spotify:track:") {
+        return Some(rest.to_owned());
+    }
+    if let Some(rest) = link.split("open.spotify.com/track/").nth(1) {
+        return Some(cut(rest));
+    }
+    let bare = link.len() == 22 && link.chars().all(|letter| letter.is_ascii_alphanumeric());
+    bare.then(|| link.to_owned())
+}
+
+fn youtube_id(link: &str) -> Option<String> {
+    if let Some(rest) = link.split("youtu.be/").nth(1) {
+        return Some(cut(rest));
+    }
+    if !link.contains("youtube.com") && !link.contains("music.youtube.com") {
+        return None;
+    }
+    link.split("v=").nth(1).map(cut)
+}
+
+fn cut(rest: &str) -> String {
+    rest.split(['?', '&', '/', '#'])
+        .next()
+        .unwrap_or(rest)
+        .to_owned()
+}

--- a/crates/music/src/lyrics/mod.rs
+++ b/crates/music/src/lyrics/mod.rs
@@ -69,7 +69,7 @@ fn layered(lyrics: &Lyrics) -> bool {
         .any(|line| !line.secondary.is_empty() || !line.voice.lead())
 }
 
-fn eligible(query: &LyricsQuery, hit: &LyricsHit) -> bool {
+pub fn eligible(query: &LyricsQuery, hit: &LyricsHit) -> bool {
     matched(query, hit) && !hit.lyrics.is_empty() && !low_quality(&hit.lyrics)
 }
 
@@ -87,7 +87,7 @@ fn matched(query: &LyricsQuery, hit: &LyricsHit) -> bool {
     })
 }
 
-fn score(query: &LyricsQuery, hit: &LyricsHit) -> i64 {
+pub fn score(query: &LyricsQuery, hit: &LyricsHit) -> i64 {
     let mut score: i64 = i64::from(hit.trust);
     if let Some(duration) = hit.duration {
         let drift = duration.as_secs().abs_diff(query.duration.as_secs());

--- a/crates/sonora/Cargo.toml
+++ b/crates/sonora/Cargo.toml
@@ -23,6 +23,7 @@ router.workspace = true
 ui.workspace = true
 views.workspace = true
 reqwest.workspace = true
+sha2.workspace = true
 tokio = { workspace = true, features = ["rt"] }
 interprocess.workspace = true
 

--- a/crates/sonora/src/http.rs
+++ b/crates/sonora/src/http.rs
@@ -1,13 +1,25 @@
+use std::fs::{self, FileTimes, OpenOptions};
 use std::future::Future;
 use std::io::Read as _;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime};
 
 use anyhow::{Result, anyhow};
-use gpui::http_client::http::HeaderValue;
+use gpui::http_client::http::header::{AUTHORIZATION, CACHE_CONTROL, CONTENT_TYPE, COOKIE, RANGE};
+use gpui::http_client::http::{HeaderValue, Method};
 use gpui::http_client::{AsyncBody, HttpClient, Inner, Request, Response, Url};
+use sha2::{Digest, Sha256};
 use tokio::runtime::Handle;
 
 const USER_AGENT: &str = "sonora";
+const CACHE_BYTES: u64 = 128 * 1024 * 1024;
+const CACHE_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+const CACHE_SWEEP: Duration = Duration::from_secs(60 * 60);
+
+static TEMP_FILE: AtomicU64 = AtomicU64::new(0);
 
 type Sent = Pin<Box<dyn Future<Output = Result<Response<AsyncBody>>> + Send>>;
 
@@ -15,11 +27,24 @@ pub struct Client {
     inner: reqwest::Client,
     handle: Handle,
     user_agent: HeaderValue,
+    cache: Option<Arc<Mutex<DiskCache>>>,
 }
 
 impl Client {
     pub fn new(handle: Handle) -> Self {
         let _guard = handle.enter();
+        let cache = dirs::cache_dir()
+            .map(|root| root.join("sonora").join("images"))
+            .and_then(|root| match DiskCache::new(root, CACHE_BYTES, CACHE_AGE) {
+                Ok(cache) => Some(Arc::new(Mutex::new(cache))),
+                Err(error) => {
+                    log::warn!("artwork: cannot initialize the disk cache: {error}");
+                    None
+                }
+            });
+        if let Some(cache) = cache.clone() {
+            handle.spawn_blocking(move || with_cache(&cache, |cache| cache.sweep()));
+        }
         Self {
             inner: reqwest::Client::builder()
                 .user_agent(USER_AGENT)
@@ -27,6 +52,7 @@ impl Client {
                 .unwrap_or_default(),
             handle: handle.clone(),
             user_agent: HeaderValue::from_static(USER_AGENT),
+            cache,
         }
     }
 }
@@ -43,15 +69,38 @@ impl HttpClient for Client {
     fn send(&self, request: Request<AsyncBody>) -> Sent {
         let client = self.inner.clone();
         let handle = self.handle.clone();
+        let cache = self.cache.clone();
 
         Box::pin(async move {
             let (parts, body) = request.into_parts();
             let body = read(body)?;
 
             let fetch = handle.spawn(async move {
-                let mut outgoing = client
-                    .request(parts.method, parts.uri.to_string())
-                    .headers(parts.headers);
+                let uri = parts.uri.to_string();
+                let cacheable = parts.method == Method::GET
+                    && !parts.headers.contains_key(AUTHORIZATION)
+                    && !parts.headers.contains_key(COOKIE)
+                    && !parts.headers.contains_key(RANGE);
+                let cached = match (cacheable, cache.as_ref()) {
+                    (true, Some(cache)) => {
+                        let cache = cache.clone();
+                        let uri = uri.clone();
+                        tokio::task::spawn_blocking(move || {
+                            with_cache(&cache, |cache| cache.get(&uri)).flatten()
+                        })
+                        .await
+                        .unwrap_or_else(|error| {
+                            log::warn!("artwork: cannot read the disk cache: {error}");
+                            None
+                        })
+                    }
+                    _ => None,
+                };
+                if let Some(bytes) = cached {
+                    return Ok::<_, anyhow::Error>((reqwest::StatusCode::OK, bytes));
+                }
+
+                let mut outgoing = client.request(parts.method, &uri).headers(parts.headers);
 
                 if let Some(body) = body {
                     outgoing = outgoing.body(body);
@@ -59,7 +108,34 @@ impl HttpClient for Client {
 
                 let incoming = outgoing.send().await?;
                 let status = incoming.status();
+                let is_image = incoming
+                    .headers()
+                    .get(CONTENT_TYPE)
+                    .and_then(|value| value.to_str().ok())
+                    .is_some_and(|value| value.to_ascii_lowercase().starts_with("image/"));
+                let private = incoming
+                    .headers()
+                    .get(CACHE_CONTROL)
+                    .and_then(|value| value.to_str().ok())
+                    .is_some_and(|value| {
+                        value.split(',').map(str::trim).any(|value| {
+                            value.eq_ignore_ascii_case("no-store")
+                                || value.eq_ignore_ascii_case("private")
+                        })
+                    });
                 let bytes = incoming.bytes().await?.to_vec();
+                if cacheable
+                    && status == reqwest::StatusCode::OK
+                    && is_image
+                    && !private
+                    && let Some(cache) = cache.as_ref()
+                {
+                    let cache = cache.clone();
+                    let stored = bytes.clone();
+                    drop(tokio::task::spawn_blocking(move || {
+                        with_cache(&cache, |cache| cache.put(&uri, &stored));
+                    }));
+                }
                 Ok::<_, anyhow::Error>((status, bytes))
             });
 
@@ -71,6 +147,159 @@ impl HttpClient for Client {
     }
 }
 
+fn with_cache<T>(
+    cache: &Mutex<DiskCache>,
+    operation: impl FnOnce(&mut DiskCache) -> T,
+) -> Option<T> {
+    match cache.lock() {
+        Ok(mut cache) => Some(operation(&mut cache)),
+        Err(_) => {
+            log::warn!("artwork: disk cache lock is poisoned");
+            None
+        }
+    }
+}
+
+struct DiskCache {
+    root: PathBuf,
+    max_bytes: u64,
+    max_age: Duration,
+    bytes: Option<u64>,
+    swept: Instant,
+}
+
+impl DiskCache {
+    fn new(root: PathBuf, max_bytes: u64, max_age: Duration) -> std::io::Result<Self> {
+        fs::create_dir_all(&root)?;
+        Ok(Self {
+            root,
+            max_bytes,
+            max_age,
+            bytes: None,
+            swept: Instant::now(),
+        })
+    }
+
+    fn get(&mut self, url: &str) -> Option<Vec<u8>> {
+        let path = self.path(url);
+        let metadata = fs::metadata(&path).ok()?;
+        let used = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+        if used.elapsed().is_ok_and(|age| age > self.max_age) {
+            self.remove(&path, metadata.len());
+            return None;
+        }
+
+        match fs::read(&path) {
+            Ok(bytes) => {
+                if let Ok(file) = OpenOptions::new().write(true).open(&path) {
+                    let now = SystemTime::now();
+                    file.set_times(FileTimes::new().set_accessed(now).set_modified(now))
+                        .ok();
+                }
+                Some(bytes)
+            }
+            Err(_) => {
+                self.remove(&path, metadata.len());
+                None
+            }
+        }
+    }
+
+    fn put(&mut self, url: &str, bytes: &[u8]) {
+        if bytes.len() as u64 > self.max_bytes {
+            return;
+        }
+        if self.bytes.is_none() && self.sweep().is_none() {
+            return;
+        }
+
+        let path = self.path(url);
+        let previous = fs::metadata(&path).map_or(0, |metadata| metadata.len());
+        let key = key(url);
+        let temporary = self.root.join(format!(
+            ".{key}.tmp-{}-{}",
+            std::process::id(),
+            TEMP_FILE.fetch_add(1, Ordering::Relaxed)
+        ));
+        let written = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)
+            .and_then(|mut file| std::io::Write::write_all(&mut file, bytes))
+            .and_then(|()| fs::rename(&temporary, &path));
+        if let Err(error) = written {
+            fs::remove_file(&temporary).ok();
+            log::debug!("artwork: cannot write a disk cache entry: {error}");
+            return;
+        }
+
+        self.bytes = self.bytes.map(|total| {
+            total
+                .saturating_sub(previous)
+                .saturating_add(bytes.len() as u64)
+        });
+        if self.bytes.is_some_and(|total| total > self.max_bytes)
+            || self.swept.elapsed() >= CACHE_SWEEP
+        {
+            self.sweep();
+        }
+    }
+
+    fn sweep(&mut self) -> Option<()> {
+        let now = SystemTime::now();
+        let mut entries = Vec::new();
+        for item in fs::read_dir(&self.root).ok()?.flatten() {
+            let path = item.path();
+            if !cache_entry(&path) {
+                continue;
+            }
+            let Ok(metadata) = item.metadata() else {
+                continue;
+            };
+            let used = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+            if now.duration_since(used).is_ok_and(|age| age > self.max_age) {
+                fs::remove_file(path).ok();
+            } else {
+                entries.push((path, used, metadata.len()));
+            }
+        }
+
+        entries.sort_unstable_by_key(|(_, used, _)| *used);
+        let mut bytes = entries.iter().map(|(_, _, size)| size).sum::<u64>();
+        for (path, _, size) in entries {
+            if bytes <= self.max_bytes {
+                break;
+            }
+            if fs::remove_file(path).is_ok() {
+                bytes = bytes.saturating_sub(size);
+            }
+        }
+        self.bytes = Some(bytes);
+        self.swept = Instant::now();
+        Some(())
+    }
+
+    fn path(&self, url: &str) -> PathBuf {
+        self.root.join(key(url))
+    }
+
+    fn remove(&mut self, path: &Path, size: u64) {
+        if fs::remove_file(path).is_ok() {
+            self.bytes = self.bytes.map(|bytes| bytes.saturating_sub(size));
+        }
+    }
+}
+
+fn key(url: &str) -> String {
+    format!("{:x}", Sha256::digest(url.as_bytes()))
+}
+
+fn cache_entry(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.len() == 64 && name.bytes().all(|byte| byte.is_ascii_hexdigit()))
+}
+
 fn read(body: AsyncBody) -> Result<Option<Vec<u8>>> {
     match body.0 {
         Inner::Empty => Ok(None),
@@ -80,5 +309,88 @@ fn read(body: AsyncBody) -> Result<Option<Vec<u8>>> {
             Ok(Some(bytes))
         }
         Inner::AsyncReader(_) => Err(anyhow!("streaming request bodies are not supported")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Temporary(PathBuf);
+
+    impl Temporary {
+        fn new() -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "sonora-image-cache-test-{}-{}",
+                std::process::id(),
+                TEMP_FILE.fetch_add(1, Ordering::Relaxed)
+            ));
+            fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for Temporary {
+        fn drop(&mut self) {
+            fs::remove_dir_all(&self.0).ok();
+        }
+    }
+
+    #[test]
+    fn reads_a_cached_image_and_refreshes_its_age() {
+        let root = Temporary::new();
+        let mut cache = DiskCache::new(root.0.clone(), 32, Duration::from_secs(60)).unwrap();
+        cache.put("https://example.com/cover", b"image");
+
+        let path = cache.path("https://example.com/cover");
+        let old = SystemTime::now() - Duration::from_secs(30);
+        OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(old))
+            .unwrap();
+
+        assert_eq!(
+            cache.get("https://example.com/cover"),
+            Some(b"image".to_vec())
+        );
+        assert!(fs::metadata(path).unwrap().modified().unwrap() > old);
+    }
+
+    #[test]
+    fn removes_expired_images() {
+        let root = Temporary::new();
+        let mut cache = DiskCache::new(root.0.clone(), 32, Duration::from_secs(60)).unwrap();
+        cache.put("expired", b"old");
+        let expired = cache.path("expired");
+        OpenOptions::new()
+            .write(true)
+            .open(&expired)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(SystemTime::now() - Duration::from_secs(120)))
+            .unwrap();
+        cache.sweep();
+
+        assert!(!expired.exists());
+    }
+
+    #[test]
+    fn evicts_the_least_recently_used_image_at_the_size_limit() {
+        let root = Temporary::new();
+        let mut cache = DiskCache::new(root.0.clone(), 5, Duration::from_secs(60)).unwrap();
+        cache.put("old", b"old");
+        let old = cache.path("old");
+        OpenOptions::new()
+            .write(true)
+            .open(&old)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(SystemTime::now() - Duration::from_secs(30)))
+            .unwrap();
+        cache.put("new", b"fresh");
+
+        assert!(!old.exists());
+        assert_eq!(cache.get("new"), Some(b"fresh".to_vec()));
+        assert!(cache.bytes.unwrap() <= 5);
     }
 }

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -25,7 +25,7 @@ pub use genre::{GenreDetails, Genres};
 pub use home::Home;
 pub use library::{Library, LibraryEvent, LibraryPart, LibraryState, Problem};
 pub use lyrics::{Lyrics, LyricsState};
-pub use playback::{Origin, Playback, PlaybackState, Repeat};
+pub use playback::{Origin, Playback, PlaybackState, Repeat, Whence};
 pub use queue::{Named, Queue, Resume, Stub};
 pub use remote::{Remote, attach as attach_remote};
 pub use search::{AlbumHit, ArtistHit, Hit, Kind, PlaylistHit, Search};

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use gpui::{App, Context, Entity, EventEmitter, Task};
+use gpui::{App, Context, Entity, EventEmitter, SharedString, Task};
 use music::{
     MusicApi, PlaybackConfig, PlaybackEvent as BackendEvent, PlaybackEvents, PlaybackFactory,
     Player, Track,
@@ -163,19 +163,82 @@ pub enum Repeat {
     One,
 }
 
-#[derive(Clone, PartialEq, Eq)]
-pub enum Origin {
-    Album(String),
-    Playlist(String),
-    Artist(String),
-    Radio(String),
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Whence {
+    Album,
+    Playlist,
+    Artist,
+    Radio,
+    Saved,
+    Local,
 }
 
+// same thing, same origin
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Origin {
+    pub whence: Whence,
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<SharedString>,
+}
+
+impl PartialEq for Origin {
+    fn eq(&self, other: &Self) -> bool {
+        self.whence == other.whence && self.id == other.id
+    }
+}
+
+impl Eq for Origin {}
+
 impl Origin {
-    fn id(&self) -> &str {
-        match self {
-            Origin::Album(id) | Origin::Playlist(id) | Origin::Artist(id) | Origin::Radio(id) => id,
+    pub fn album(id: impl Into<String>) -> Self {
+        Self::of(Whence::Album, id)
+    }
+
+    pub fn playlist(id: impl Into<String>) -> Self {
+        Self::of(Whence::Playlist, id)
+    }
+
+    pub fn artist(id: impl Into<String>) -> Self {
+        Self::of(Whence::Artist, id)
+    }
+
+    pub fn radio(id: impl Into<String>) -> Self {
+        Self::of(Whence::Radio, id)
+    }
+
+    pub fn saved() -> Self {
+        Self::of(Whence::Saved, String::new())
+    }
+
+    pub fn local() -> Self {
+        Self::of(Whence::Local, String::new())
+    }
+
+    pub fn named(mut self, name: impl Into<SharedString>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    fn of(whence: Whence, id: impl Into<String>) -> Self {
+        Self {
+            whence,
+            id: id.into(),
+            name: None,
         }
+    }
+}
+
+impl From<&Pin> for Origin {
+    fn from(pin: &Pin) -> Self {
+        let origin = match pin.kind {
+            PinKind::Album => Origin::album(pin.id.clone()),
+            PinKind::Playlist => Origin::playlist(pin.id.clone()),
+            PinKind::Artist => Origin::artist(pin.id.clone()),
+            PinKind::Song => Origin::radio(pin.id.clone()),
+        };
+        origin.named(pin.title.clone())
     }
 }
 
@@ -386,9 +449,15 @@ impl Playback {
         }));
     }
 
-    pub fn start(&mut self, tracks: Vec<Track>, index: usize, cx: &mut Context<Self>) {
+    pub fn start(
+        &mut self,
+        tracks: Vec<Track>,
+        index: usize,
+        origin: Option<Origin>,
+        cx: &mut Context<Self>,
+    ) {
         self.fetch = None;
-        self.begin(tracks, index, None, cx);
+        self.begin(tracks, index, origin, cx);
     }
 
     pub fn play_radio(&mut self, seed: &Track, cx: &mut Context<Self>) {
@@ -399,7 +468,7 @@ impl Playback {
             return self.failed(format!("{} is not available to stream", seed.name), cx);
         }
 
-        let origin = Origin::Radio(id.clone());
+        let origin = Origin::radio(id.clone()).named(seed.name.clone());
         let seed = seed.clone();
         self.gather(origin, cx, move |client| {
             Box::pin(async move {
@@ -412,9 +481,8 @@ impl Playback {
         });
     }
 
-    pub fn play_track(&mut self, track_id: &str, cx: &mut Context<Self>) {
-        let origin = Origin::Radio(track_id.to_owned());
-        let id = track_id.to_owned();
+    fn play_radio_of(&mut self, origin: Origin, cx: &mut Context<Self>) {
+        let id = origin.id.clone();
         self.gather(origin, cx, move |client| {
             Box::pin(async move {
                 let mut tracks = client.track_radio(&id).await?;
@@ -530,17 +598,15 @@ impl Playback {
         });
     }
 
-    pub fn play_album(&mut self, album: &str, cx: &mut Context<Self>) {
-        let origin = Origin::Album(album.to_owned());
-        let album = album.to_owned();
+    fn play_album_of(&mut self, origin: Origin, cx: &mut Context<Self>) {
+        let album = origin.id.clone();
         self.gather(origin, cx, move |client| {
             Box::pin(async move { client.album_tracks(&album).await })
         });
     }
 
-    pub fn play_artist(&mut self, artist: &str, cx: &mut Context<Self>) {
-        let origin = Origin::Artist(artist.to_owned());
-        let artist = artist.to_owned();
+    fn play_artist_of(&mut self, origin: Origin, cx: &mut Context<Self>) {
+        let artist = origin.id.clone();
         self.gather(origin, cx, move |client| {
             Box::pin(async move { client.artist(&artist).await.map(|found| found.top_tracks) })
         });
@@ -578,9 +644,8 @@ impl Playback {
         });
     }
 
-    pub fn play_playlist(&mut self, playlist: &str, cx: &mut Context<Self>) {
-        let origin = Origin::Playlist(playlist.to_owned());
-        let playlist = playlist.to_owned();
+    fn play_playlist_of(&mut self, origin: Origin, cx: &mut Context<Self>) {
+        let playlist = origin.id.clone();
         self.gather(origin, cx, move |client| {
             Box::pin(async move { client.playlist_tracks(&playlist).await })
         });
@@ -659,6 +724,9 @@ impl Playback {
             return;
         };
         self.origin = origin;
+        let stored = self.origin.clone();
+        self.settings
+            .update(cx, |settings, cx| settings.set_resume_origin(stored, cx));
         self.play(&track, cx);
     }
 
@@ -666,7 +734,7 @@ impl Playback {
     where
         F: FnOnce(Arc<dyn MusicApi>) -> Fetch + Send + 'static,
     {
-        let Some(client) = self.client_for(origin.id(), cx) else {
+        let Some(client) = self.client_for(&origin.id, cx) else {
             return;
         };
 
@@ -1008,9 +1076,11 @@ impl Playback {
         };
 
         let at = Duration::from_secs_f32(resume.position.max(0.));
+        let origin = resume.origin.clone();
         let Some(track) = self.queue.update(cx, |queue, cx| queue.revive(resume, cx)) else {
             return;
         };
+        self.origin = origin;
         self.track = Some(track);
         self.state = PlaybackState::Paused;
         self.position = at;
@@ -1046,16 +1116,22 @@ impl Playback {
         }
     }
 
+    pub fn play_origin(&mut self, origin: Origin, cx: &mut Context<Self>) {
+        match origin.whence {
+            Whence::Album => self.play_album_of(origin, cx),
+            Whence::Playlist => self.play_playlist_of(origin, cx),
+            Whence::Artist => self.play_artist_of(origin, cx),
+            Whence::Radio => self.play_radio_of(origin, cx),
+            // the table plays these
+            Whence::Saved | Whence::Local => {}
+        }
+    }
+
     pub fn toggle_origin(&mut self, origin: &Origin, cx: &mut Context<Self>) {
         match self.playing_from(origin) {
             Some(PlaybackState::Playing) => self.pause(cx),
             Some(PlaybackState::Paused) => self.resume(cx),
-            _ => match origin {
-                Origin::Album(id) => self.play_album(id, cx),
-                Origin::Playlist(id) => self.play_playlist(id, cx),
-                Origin::Artist(id) => self.play_artist(id, cx),
-                Origin::Radio(id) => self.play_track(id, cx),
-            },
+            _ => self.play_origin(origin.clone(), cx),
         }
     }
 

--- a/crates/state/src/queue.rs
+++ b/crates/state/src/queue.rs
@@ -17,6 +17,8 @@ pub struct Resume {
     pub(crate) provider: String,
     pub(crate) position: f32,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) origin: Option<crate::Origin>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) current: Option<Stub>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub(crate) past: Vec<Stub>,
@@ -109,6 +111,7 @@ fn record<'a>(
     Resume {
         provider: provider.to_owned(),
         position: 0.,
+        origin: None,
         current: current.and_then(stub),
         past: past[past.len().saturating_sub(KEPT_PAST)..]
             .iter()

--- a/crates/state/src/settings.rs
+++ b/crates/state/src/settings.rs
@@ -529,6 +529,17 @@ impl AppSettings {
         self.schedule_save(cx);
     }
 
+    pub fn set_resume_origin(&mut self, origin: Option<crate::Origin>, cx: &mut Context<Self>) {
+        let Some(resume) = self.values.resume.as_mut() else {
+            return;
+        };
+        if resume.origin == origin {
+            return;
+        }
+        resume.origin = origin;
+        self.save_quietly(cx);
+    }
+
     pub fn set_resume_position(&mut self, position: f32, cx: &mut Context<Self>) {
         let Some(resume) = self.values.resume.as_mut() else {
             return;
@@ -799,9 +810,12 @@ fn take(pins: &mut Pins, slug: &str, pin: &Pin) -> bool {
 
 fn carry(previous: Option<&Resume>, next: &mut Resume) {
     let playing = |resume: &Resume| resume.current.as_ref().map(|stub| stub.id.clone());
-    next.position = previous
-        .filter(|old| old.provider == next.provider && playing(old) == playing(next))
+    let same = previous.filter(|old| old.provider == next.provider);
+    next.position = same
+        .filter(|old| playing(old) == playing(next))
         .map_or(0., |old| old.position);
+    // the queue moving on does not change where it came from
+    next.origin = same.and_then(|old| old.origin.clone());
 }
 
 fn place(pinned: &mut Vec<Pin>, pin: Pin, gap: Option<usize>) -> bool {

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -31,6 +31,7 @@ mod scrubber;
 mod separator;
 mod shield;
 mod skeleton;
+mod slip;
 mod switch;
 mod tabs;
 mod theme;
@@ -84,6 +85,7 @@ pub use scrubber::{Scrubber, ScrubberState};
 pub use separator::Separator;
 pub use shield::Shield;
 pub use skeleton::{Initials, Skeleton};
+pub use slip::slip;
 pub use switch::Switch;
 pub use tabs::Tabs;
 pub use theme::{

--- a/crates/ui/src/menu.rs
+++ b/crates/ui/src/menu.rs
@@ -23,6 +23,9 @@ const SUBMENU_FALLBACK_WIDTH: Pixels = px(236.);
 const SUBMENU_TOP: Pixels = px(-14.);
 const WINDOW_MARGIN: Pixels = px(8.);
 const PANEL_SLACK: Pixels = px(6.);
+const SAFE_X: Pixels = px(6.);
+const SAFE_Y: Pixels = px(12.);
+const NEAR: usize = Near::Bar as usize + 1;
 
 type Press = Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>;
 type Dismiss = Box<dyn Fn(&(), &mut Window, &mut App) + 'static>;
@@ -38,28 +41,27 @@ impl Trigger {
     }
 
     fn contains(&self, position: Point<Pixels>, slack: Pixels) -> bool {
-        self.0.get().is_some_and(|bounds| {
-            Bounds {
-                origin: Point {
-                    x: bounds.origin.x - slack,
-                    y: bounds.origin.y - slack,
-                },
-                size: Size {
-                    width: bounds.size.width + slack * 2.,
-                    height: bounds.size.height + slack * 2.,
-                },
-            }
-            .contains(&position)
-        })
+        self.0
+            .get()
+            .is_some_and(|bounds| grown(bounds, slack, slack).contains(&position))
     }
+}
+
+#[derive(Clone, Copy)]
+enum Near {
+    Item,
+    Gap,
+    Panel,
+    Bar,
 }
 
 #[derive(Clone, Default)]
 pub struct SubmenuState {
     open: Rc<Cell<bool>>,
     generation: Rc<Cell<u64>>,
-    parent_bounds: Rc<Cell<Option<Bounds<Pixels>>>>,
-    safe_bounds: Rc<Cell<Option<Bounds<Pixels>>>>,
+    near: Rc<Cell<[bool; NEAR]>>,
+    menu_bounds: Rc<Cell<Option<Bounds<Pixels>>>>,
+    panel_bounds: Rc<Cell<Option<Bounds<Pixels>>>>,
 }
 
 impl SubmenuState {
@@ -67,11 +69,22 @@ impl SubmenuState {
         self.open.get()
     }
 
-    fn hover(&self, hovered: bool, window: AnyWindowHandle, cx: &mut App) {
+    fn touched(&self) -> bool {
+        self.near.get().iter().any(|there| *there)
+    }
+
+    fn near(&self, place: Near, hovered: bool, window: AnyWindowHandle, cx: &mut App) {
+        let mut near = self.near.get();
+        if near[place as usize] == hovered {
+            return;
+        }
+        near[place as usize] = hovered;
+        self.near.set(near);
+
         let generation = self.generation.get().wrapping_add(1);
         self.generation.set(generation);
 
-        if hovered {
+        if self.touched() {
             if !self.open.replace(true) {
                 cx.refresh_windows();
             }
@@ -82,16 +95,15 @@ impl SubmenuState {
         cx.spawn(async move |cx| {
             cx.background_executor().timer(SUBMENU_CLOSE_DELAY).await;
             let inside = cx.update(|cx| {
-                cx.update_window(window, |_, window, _| {
-                    state
-                        .safe_bounds
-                        .get()
-                        .is_some_and(|bounds| bounds.contains(&window.mouse_position()))
-                })
-                .unwrap_or(false)
+                cx.update_window(window, |_, window, _| state.covers(window.mouse_position()))
+                    .unwrap_or(false)
             });
             cx.update(|cx| {
-                if state.generation.get() == generation && !inside && state.open.replace(false) {
+                if state.generation.get() == generation
+                    && !state.touched()
+                    && !inside
+                    && state.open.replace(false)
+                {
                     cx.refresh_windows();
                 }
             });
@@ -99,48 +111,42 @@ impl SubmenuState {
         .detach();
     }
 
-    fn observe_panel(&self, bounds: Bounds<Pixels>) {
-        self.safe_bounds.set(Some(Bounds {
-            origin: Point {
-                x: bounds.origin.x - px(4.),
-                y: bounds.origin.y - px(12.),
-            },
-            size: Size {
-                width: bounds.size.width + px(16.),
-                height: bounds.size.height + px(24.),
-            },
-        }));
+    fn measure_panel(&self, bounds: Bounds<Pixels>) {
+        self.panel_bounds.set(Some(grown(bounds, SAFE_X, SAFE_Y)));
     }
 
-    fn observe_parent(&self, bounds: Bounds<Pixels>) {
-        self.parent_bounds.set(Some(bounds));
+    fn measure_menu(&self, bounds: Bounds<Pixels>) {
+        self.menu_bounds.set(Some(bounds));
     }
 
     fn should_flip(&self, viewport_width: Pixels) -> bool {
-        let Some(parent) = self.parent_bounds.get() else {
+        let Some(menu) = self.menu_bounds.get() else {
             return false;
         };
         let submenu_width = self
-            .safe_bounds
+            .panel_bounds
             .get()
             .map(|bounds| bounds.size.width)
             .unwrap_or(SUBMENU_FALLBACK_WIDTH);
-        parent.right() + submenu_width + WINDOW_MARGIN > viewport_width
+        menu.right() + submenu_width + WINDOW_MARGIN > viewport_width
+    }
+
+    fn covers(&self, position: Point<Pixels>) -> bool {
+        self.panel_bounds
+            .get()
+            .is_some_and(|bounds| bounds.contains(&position))
     }
 
     fn contains(&self, position: Point<Pixels>) -> bool {
-        self.is_open()
-            && self
-                .safe_bounds
-                .get()
-                .is_some_and(|bounds| bounds.contains(&position))
+        self.is_open() && self.covers(position)
     }
 
     pub fn reset(&self) {
         self.generation.set(self.generation.get().wrapping_add(1));
         self.open.set(false);
-        self.parent_bounds.set(None);
-        self.safe_bounds.set(None);
+        self.near.set([false; NEAR]);
+        self.menu_bounds.set(None);
+        self.panel_bounds.set(None);
     }
 }
 
@@ -367,8 +373,9 @@ impl RenderOnce for Menu {
 
         if let (Some(scrollbar), Some(guard)) = (scrollbar.as_ref(), hover_guard.clone()) {
             scrollbar.update(cx, |scrollbar, _| {
-                scrollbar
-                    .set_hover_guard(move |hovered, window, cx| guard.hover(hovered, window, cx));
+                scrollbar.set_hover_guard(move |hovered, window, cx| {
+                    guard.near(Near::Bar, hovered, window, cx)
+                });
             });
         }
 
@@ -418,7 +425,6 @@ impl RenderOnce for Menu {
             let action = action.clone();
             let press_action = action.clone();
             let submenu_state = submenu.as_ref().map(|submenu| submenu.state.clone());
-            let item_hover_guard = hover_guard.clone();
             let has_artwork = artwork.is_some();
 
             div()
@@ -470,12 +476,7 @@ impl RenderOnce for Menu {
                 .when(submenu.is_some(), |this| this.child("›"))
                 .when_some(submenu_state, |this, state| {
                     this.on_hover(move |hovered, window, cx| {
-                        state.hover(*hovered, window.window_handle(), cx)
-                    })
-                })
-                .when_some(item_hover_guard, |this, state| {
-                    this.on_hover(move |hovered, window, cx| {
-                        state.hover(*hovered, window.window_handle(), cx)
+                        state.near(Near::Item, *hovered, window.window_handle(), cx)
                     })
                 })
                 .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
@@ -491,60 +492,44 @@ impl RenderOnce for Menu {
                     if submenu.menu.action.is_none() {
                         submenu.menu.action = action.clone();
                     }
-                    let open = submenu.state.is_open();
-                    let panel_state = submenu.state.clone();
-                    let safe_state = submenu.state.clone();
-                    let bounds_state = submenu.state.clone();
+                    let gap_state = submenu.state.clone();
                     let flip_left = submenu.state.should_flip(viewport_width);
-                    this.child(
-                        div()
-                            .absolute()
-                            .top(SUBMENU_TOP)
-                            .when(flip_left, |this| this.right_full())
-                            .when(!flip_left, |this| this.left_full())
-                            .when(!open, |this| this.invisible())
-                            .child(
-                                anchored()
-                                    .anchor(if flip_left {
-                                        Anchor::TopRight
-                                    } else {
-                                        Anchor::TopLeft
-                                    })
-                                    .snap_to_window_with_margin(WINDOW_MARGIN)
-                                    .child(
-                                        div()
-                                            .on_children_prepainted(move |bounds, _, _| {
-                                                if let Some(bounds) =
-                                                    bounds.into_iter().reduce(|a, b| a.union(&b))
-                                                {
-                                                    bounds_state.observe_panel(bounds);
-                                                }
-                                            })
-                                            .id("submenu-safe-area")
-                                            .occlude()
-                                            .pt_3()
-                                            .pb_3()
-                                            .when(flip_left, |this| this.pl_3().pr_1())
-                                            .when(!flip_left, |this| this.pl_1().pr_3())
-                                            .on_hover(move |hovered, window, cx| {
-                                                safe_state.hover(
-                                                    *hovered,
-                                                    window.window_handle(),
-                                                    cx,
-                                                )
-                                            })
-                                            .child(submenu.menu.inline().relative().on_hover(
-                                                move |hovered, window, cx| {
-                                                    panel_state.hover(
+                    match submenu.state.is_open() {
+                        false => this,
+                        true => this.child(
+                            div()
+                                .absolute()
+                                .top(SUBMENU_TOP)
+                                .when(flip_left, |this| this.right_full())
+                                .when(!flip_left, |this| this.left_full())
+                                .child(
+                                    anchored()
+                                        .anchor(match flip_left {
+                                            true => Anchor::TopRight,
+                                            false => Anchor::TopLeft,
+                                        })
+                                        .snap_to_window_with_margin(WINDOW_MARGIN)
+                                        .child(
+                                            div()
+                                                .id("submenu-safe-area")
+                                                .occlude()
+                                                .pt_3()
+                                                .pb_3()
+                                                .when(flip_left, |this| this.pl_3().pr_1())
+                                                .when(!flip_left, |this| this.pl_1().pr_3())
+                                                .on_hover(move |hovered, window, cx| {
+                                                    gap_state.near(
+                                                        Near::Gap,
                                                         *hovered,
                                                         window.window_handle(),
                                                         cx,
                                                     )
-                                                },
-                                            )),
-                                    ),
-                            ),
-                    )
+                                                })
+                                                .child(submenu.menu.inline().relative()),
+                                        ),
+                                ),
+                        ),
+                    }
                 })
                 .into_any_element()
         });
@@ -582,7 +567,7 @@ impl RenderOnce for Menu {
                         panel.observe(bounds.clone());
                         if let Some(bounds) = bounds.into_iter().reduce(|a, b| a.union(&b)) {
                             for guard in &bounds_guards {
-                                guard.observe_parent(bounds);
+                                guard.measure_menu(bounds);
                             }
                         }
                     }
@@ -636,6 +621,14 @@ impl RenderOnce for Menu {
             _ => Anchor::TopLeft,
         };
         let panel_looks = div()
+            .when_some(hover_guard.clone(), |this, guard| {
+                this.on_children_prepainted(move |bounds, _, _| {
+                    if let Some(bounds) = bounds.into_iter().reduce(|a, b| a.union(&b)) {
+                        guard.measure_panel(bounds);
+                    }
+                })
+            })
+            .id("menu-panel")
             .flex()
             .flex_col()
             .p_1()
@@ -648,6 +641,11 @@ impl RenderOnce for Menu {
             .key_context(MENU_CONTEXT)
             .when_some(width, |this, width| this.w(width))
             .when_some(ceiling, |this, ceiling| this.max_h(ceiling))
+            .when_some(hover_guard, |this, guard| {
+                this.on_hover(move |hovered, window, cx| {
+                    guard.near(Near::Panel, *hovered, window.window_handle(), cx)
+                })
+            })
             .occlude()
             .child(body);
         let mut menu = base
@@ -694,5 +692,18 @@ impl RenderOnce for Menu {
         } else {
             menu.into_any_element()
         }
+    }
+}
+
+fn grown(bounds: Bounds<Pixels>, x: Pixels, y: Pixels) -> Bounds<Pixels> {
+    Bounds {
+        origin: Point {
+            x: bounds.origin.x - x,
+            y: bounds.origin.y - y,
+        },
+        size: Size {
+            width: bounds.size.width + x * 2.,
+            height: bounds.size.height + y * 2.,
+        },
     }
 }

--- a/crates/ui/src/scrollbar.rs
+++ b/crates/ui/src/scrollbar.rs
@@ -182,6 +182,13 @@ impl Scrollbar {
         self.nudges
     }
 
+    /// Records that the reader moved the view themselves. A precise scroll needs
+    /// no smoothing, but it is still theirs, and anything following the view has
+    /// to know to stop.
+    pub fn stirred(&mut self) {
+        self.nudges = self.nudges.wrapping_add(1);
+    }
+
     pub fn nudge(&mut self, window: &mut Window) {
         self.following = false;
         self.nudges = self.nudges.wrapping_add(1);

--- a/crates/ui/src/scroller.rs
+++ b/crates/ui/src/scroller.rs
@@ -65,10 +65,10 @@ impl RenderOnce for Scroller {
             .restrict_scroll_to_axis()
             .track_scroll(&scroll)
             .on_scroll_wheel(move |event: &ScrollWheelEvent, window, cx| {
-                if event.delta.precise() {
-                    return;
+                match event.delta.precise() {
+                    true => gliding.update(cx, |bar, _| bar.stirred()),
+                    false => gliding.update(cx, |bar, _| bar.nudge(window)),
                 }
-                gliding.update(cx, |bar, _| bar.nudge(window));
             })
             .children(children);
 

--- a/crates/ui/src/slip.rs
+++ b/crates/ui/src/slip.rs
@@ -1,0 +1,79 @@
+use gpui::prelude::*;
+use gpui::{
+    AnyElement, App, Bounds, Element, ElementId, GlobalElementId, InspectorElementId, LayoutId,
+    Pixels, Window, point, px,
+};
+
+// paints off layout
+pub struct Slip {
+    child: AnyElement,
+    by: Pixels,
+}
+
+pub fn slip(child: impl IntoElement, by: Pixels) -> Slip {
+    Slip {
+        child: child.into_any_element(),
+        by,
+    }
+}
+
+impl IntoElement for Slip {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for Slip {
+    type RequestLayoutState = ();
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        None
+    }
+
+    fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _: Option<&GlobalElementId>,
+        _: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        (self.child.request_layout(window, cx), ())
+    }
+
+    fn prepaint(
+        &mut self,
+        _: Option<&GlobalElementId>,
+        _: Option<&InspectorElementId>,
+        _: Bounds<Pixels>,
+        _: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Self::PrepaintState {
+        // never rounded, or a slowing offset steps and stalls
+        window.with_pixel_snapping(false, |window| {
+            window.with_element_offset(point(px(0.), self.by), |window| {
+                self.child.prepaint(window, cx);
+            });
+        });
+    }
+
+    fn paint(
+        &mut self,
+        _: Option<&GlobalElementId>,
+        _: Option<&InspectorElementId>,
+        _: Bounds<Pixels>,
+        _: &mut Self::RequestLayoutState,
+        _: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        self.child.paint(window, cx);
+    }
+}

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -10,9 +10,10 @@ use gpui::{
 };
 use i18n::t;
 use music::{Track, Voice};
+use router::{Destination, LibraryTab, Link as _};
 use state::{
     AppSettings, Lyrics, LyricsState, Playback, PlaybackState, Queue, RomanizationScripts, SideTab,
-    Sonora,
+    Sonora, Whence,
 };
 use ui::{
     ActiveTheme as _, Button, Card, DraggedPin, Edge, Motion, Motioned as _, Pin, Pinnable as _,
@@ -26,6 +27,7 @@ use crate::shared::menu::ItemMenu;
 use crate::shared::pins::Pinned as _;
 
 const QUEUE: &str = "queue";
+const BULLET: SharedString = SharedString::new_static("·");
 const FADE: f32 = 96.;
 const REST: f32 = FADE * 0.75;
 const TAIL_ROWS: usize = 2;
@@ -1277,8 +1279,30 @@ impl Aside {
         self.anchor = false;
     }
 
+    // unnamed origins stay unlabelled
+    fn playing_from(&self, cx: &App) -> Option<(SharedString, Destination)> {
+        let origin = self.playback.read(cx).origin()?;
+        let id = SharedString::from(origin.id.clone());
+        let place = match origin.whence {
+            Whence::Album => Destination::Album(id),
+            Whence::Playlist => Destination::Playlist(id),
+            Whence::Artist => Destination::Artist(id),
+            Whence::Radio => Destination::Song(id),
+            Whence::Saved => Destination::Library(LibraryTab::Songs),
+            Whence::Local => Destination::Library(LibraryTab::Local),
+        };
+        let name = match origin.whence {
+            Whence::Saved => t!("library-liked-songs"),
+            Whence::Local => t!("nav-local"),
+            _ => origin.name.clone()?,
+        };
+
+        Some((name, place))
+    }
+
     fn rows(&self, sections: Sections, cx: &mut Context<Self>) -> gpui::UniformList {
         let queue = self.queue.clone();
+        let from = self.playing_from(cx);
         let drop_gap = self.drop_gap;
         let upcoming = sections.upcoming;
         let audible = matches!(self.playback.read(cx).state(), PlaybackState::Playing);
@@ -1308,7 +1332,25 @@ impl Aside {
                     .map(|(index, slot, found)| match (slot, found) {
                         (None, _) => div().into_any_element(),
                         (Some(Slot::Header(key)), _) => {
-                            section_label(key, window, cx).into_any_element()
+                            let label = section_label(key, window, cx);
+                            match (key, from.clone()) {
+                                ("queue-now-playing", Some((name, place))) => label
+                                    .w_full()
+                                    .min_w_0()
+                                    .overflow_hidden()
+                                    .gap_1()
+                                    .child(
+                                        div()
+                                            .flex_none()
+                                            .text_size(cx.theme().text(Text::Small))
+                                            .text_color(cx.theme().muted_foreground)
+                                            .child(BULLET),
+                                    )
+                                    .child(eyebrow(t!("queue-from"), cx))
+                                    .child(source_link(name, place, cx))
+                                    .into_any_element(),
+                                _ => label.into_any_element(),
+                            }
                         }
                         (Some(Slot::Track(position)), Some(found)) => {
                             let drop_line = match (position.upcoming(), drop_gap) {
@@ -1429,6 +1471,23 @@ impl Render for Aside {
             )
             .children(self.menu(cx))
     }
+}
+
+fn source_link(name: SharedString, to: Destination, cx: &App) -> impl IntoElement {
+    let theme = *cx.theme();
+
+    div()
+        .id("queue-source")
+        .min_w_0()
+        .flex_shrink(1.)
+        .truncate()
+        .text_size(theme.text(Text::Small))
+        .text_color(theme.muted_foreground)
+        .font_weight(FontWeight::SEMIBOLD)
+        .cursor_pointer()
+        .hover(|style| style.text_color(theme.foreground).underline())
+        .link(to)
+        .child(name)
 }
 
 fn fixed_lyrics_lane(rows: &[SharedString], voice: Voice) -> Div {

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -18,7 +18,7 @@ use state::{
 use ui::{
     ActiveTheme as _, Button, Card, DraggedPin, Edge, Motion, Motioned as _, Pin, Pinnable as _,
     Popup, Scrollbar, Scroller, Spot, Text, drop_gap, drop_marker, ease_out_cubic, ease_out_expo,
-    eyebrow, mix, snapped, vacant,
+    eyebrow, mix, slip, snapped, vacant,
 };
 
 use crate::chrome::{Chrome, section_label};
@@ -43,9 +43,27 @@ const ACTIVE_VERSE_GROWTH: Pixels = px(2.);
 const LYRICS_HORIZONTAL_INSET_REM: f32 = 1.5;
 const PINNED_SHARE: f32 = 0.25;
 const PIN: f32 = 0.3;
-const SPARE: f32 = 1.;
+// how far a row falls behind, in verse sizes
+const LAG: f32 = 24.;
+// never past this share
+const LAG_SHARE: f32 = 0.28;
+// movement the last row skips
+const LAG_TRAIL: f32 = 0.9;
+// how fast the first row catches up
+const LAG_EASE: f32 = 0.08;
+// how much slower the last one is
+const LAG_STAGGER: f32 = 0.6;
+// how hard it lands
+const LAG_LAND: f32 = 24.;
+const LAG_LEAST: Pixels = px(0.05);
+const LAG_STALL: f32 = 0.064;
 // Below this a blur is not worth a layer of its own.
 const HAZE_LEAST: Pixels = px(0.05);
+// How far a verse sinks while it is held.
+const PRESSED: f32 = 0.955;
+// The widest a line of lyrics is set, in multiples of its own size. Left to fill
+// a fullscreen panel, a lead verse and a background one end up at opposite edges.
+const REACH: f32 = 24.;
 // What a sheet settling on the best answer comes in through: it blurs and fades
 // on the way, once, on a curve that is the same going in as coming out.
 const RESOLVE_BLUR: f32 = 0.2;
@@ -58,7 +76,9 @@ const SWEEP_LEAST: std::time::Duration = std::time::Duration::from_millis(180);
 const SWEEP_STRETCH: f32 = 1.4;
 const SWEPT: f32 = 0.98;
 const LANDING: f32 = 0.2;
-const LANE_LEADING: f32 = 1.7;
+// what a lane row actually takes, plus the gaps between lanes
+const LANE_GAP_REM: f32 = 0.25;
+const LANE_SLACK: f32 = 0.25;
 
 fn track(queue: &Queue, position: QueuePosition) -> Option<Track> {
     match position {
@@ -149,11 +169,30 @@ impl Sections {
     }
 }
 
+/// A place in the sheet the pointer can be over: a verse, or the melody break
+/// above it. They share a line index, so they need telling apart.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Warm {
+    Verse(usize),
+    Break(usize),
+}
+
+/// How near the pointer a spot is, and how far it has been pressed.
+#[derive(Clone, Copy, Default)]
+struct Touch {
+    warmth: f32,
+    depth: f32,
+    waking: bool,
+    settling: bool,
+}
+
 #[derive(Clone, Copy)]
 struct Sung {
     karaoke: bool,
     scripts: Option<RomanizationScripts>,
     theme: ui::Theme,
+    lift: f32,
+    from: gpui::Point<f32>,
 }
 
 #[derive(Clone, Copy)]
@@ -217,9 +256,9 @@ pub(crate) struct Aside {
     aiming: bool,
     rested: Option<Pixels>,
     since: std::time::Instant,
-    over: Option<usize>,
-    hovered: Option<usize>,
-    fading: Option<usize>,
+    over: Option<Warm>,
+    hovered: Option<Warm>,
+    fading: Option<Warm>,
     linger: Option<Task<()>>,
     previous_active_line: Option<usize>,
     departing_line: Option<usize>,
@@ -231,7 +270,16 @@ pub(crate) struct Aside {
     lyrics_wrap_size: Option<Pixels>,
     lyrics_wraps: HashMap<usize, Wrapped>,
     lane_rooms: HashMap<usize, Pixels>,
-    row_heights: Vec<Pixels>,
+    seen: Pixels,
+    flying: bool,
+    flew: bool,
+    slid: std::time::Instant,
+    drifts: HashMap<usize, Pixels>,
+    pinning: Option<usize>,
+    held: Option<Warm>,
+    rising: Option<Warm>,
+    sank: std::time::Instant,
+    sinking: Option<Task<()>>,
     showed: bool,
     resolving: bool,
 }
@@ -314,7 +362,16 @@ impl Aside {
             lyrics_wrap_size: None,
             lyrics_wraps: HashMap::new(),
             lane_rooms: HashMap::new(),
-            row_heights: Vec::new(),
+            seen: px(0.),
+            flying: false,
+            flew: true,
+            slid: std::time::Instant::now(),
+            drifts: HashMap::new(),
+            pinning: None,
+            held: None,
+            rising: None,
+            sank: std::time::Instant::now(),
+            sinking: None,
             showed: false,
             resolving: false,
         }
@@ -344,6 +401,70 @@ impl Aside {
         cx.notify();
     }
 
+    /// How far a verse has sunk under the pointer, or risen back after being let
+    /// go of.
+    fn sink_progress(&self, window: &mut Window) -> f32 {
+        let span = Motion::Quick.span().as_secs_f32().max(f32::EPSILON);
+        let progress = (self.sank.elapsed().as_secs_f32() / span).clamp(0., 1.);
+        if progress < 1. {
+            window.request_animation_frame();
+        }
+        ease_in_out(progress)
+    }
+
+    fn touch(&self, spot: Warm, sharpen: f32, sink: f32) -> Touch {
+        let waking = self.hovered == Some(spot);
+        let settling = self.fading == Some(spot);
+        Touch {
+            warmth: match (waking, settling) {
+                (true, _) => sharpen,
+                (_, true) => 1. - sharpen,
+                _ => 0.,
+            },
+            depth: match (self.held == Some(spot), self.rising == Some(spot)) {
+                (true, _) => sink,
+                (_, true) => 1. - sink,
+                _ => 0.,
+            },
+            waking,
+            settling,
+        }
+    }
+
+    fn press_verse(&mut self, spot: Warm, down: bool, cx: &mut Context<Self>) {
+        match down {
+            true => {
+                if self.held == Some(spot) {
+                    return;
+                }
+                self.held = Some(spot);
+                self.rising = None;
+                self.sinking = None;
+                self.sank = std::time::Instant::now();
+            }
+            false => {
+                if self.held != Some(spot) {
+                    return;
+                }
+                self.held = None;
+                self.rising = Some(spot);
+                self.sank = std::time::Instant::now();
+                self.sinking = Some(cx.spawn(async move |this, cx| {
+                    cx.background_executor().timer(Motion::Quick.span()).await;
+                    this.update(cx, |this, cx| {
+                        if this.rising != Some(spot) {
+                            return;
+                        }
+                        this.rising = None;
+                        cx.notify();
+                    })
+                    .ok();
+                }));
+            }
+        }
+        cx.notify();
+    }
+
     fn sharpen_progress(&self, window: &mut Window) -> f32 {
         let span = Motion::Quick.span().as_secs_f32().max(f32::EPSILON);
         let progress = (self.since.elapsed().as_secs_f32() / span).clamp(0., 1.);
@@ -354,6 +475,8 @@ impl Aside {
     }
 
     fn forget_verse(&mut self) {
+        self.flying = false;
+        self.pinning = None;
         self.previous_active_line = None;
         self.departing_line = None;
         self.placing = true;
@@ -363,22 +486,77 @@ impl Aside {
     fn forget_measurements(&mut self) {
         self.lyrics_wraps.clear();
         self.lane_rooms.clear();
-        self.row_heights.clear();
+        self.drifts.clear();
     }
 
-    fn set_hovered(&mut self, index: usize, over: bool, cx: &mut Context<Self>) {
+    // the panel took the wheel
+    fn flown(&mut self, goal: Pixels, from: Pixels) {
+        self.flying = true;
+        self.flew = goal <= from;
+    }
+
+    // only automatic scrolls
+    fn lagged(&mut self, scroll: &ScrollHandle, verse: Pixels, nudges: u64) -> Drag {
+        let now = std::time::Instant::now();
+        let beat = now.duration_since(self.slid).as_secs_f32().min(LAG_STALL);
+        self.slid = now;
+
+        let offset = scroll.offset().y;
+        let step = offset - self.seen;
+        self.seen = offset;
+        if nudges != self.nudges {
+            self.flying = false;
+        }
+
+        Drag {
+            step: match self.flying {
+                true => step,
+                false => px(0.),
+            },
+            beat,
+            downward: self.flew,
+            most: (verse * LAG).min(scroll.bounds().size.height * LAG_SHARE),
+        }
+    }
+
+    // a spring per row
+    fn dragged(&mut self, row: usize, along: f32, drag: Drag, window: &mut Window) -> Pixels {
+        let held = self.drifts.get(&row).copied();
+        if held.is_none() && drag.step == px(0.) {
+            return px(0.);
+        }
+        let rate = LAG_EASE * (1. - LAG_STAGGER * along);
+        let ease = 1. - (1. - rate).powf(drag.beat * 60.);
+        let fed = held.unwrap_or(px(0.)) - drag.step * (LAG_TRAIL * along);
+        let eased = (fed * (1. - ease)).clamp(-drag.most, drag.most);
+        let land = px(LAG_LAND * (eased.abs() / px(1.)).sqrt() * drag.beat);
+        let closer = (eased.abs() - land).max(px(0.));
+        let shown = match eased < px(0.) {
+            true => -closer,
+            false => closer,
+        };
+        if shown.abs() < LAG_LEAST {
+            self.drifts.remove(&row);
+            return px(0.);
+        }
+        self.drifts.insert(row, shown);
+        window.request_animation_frame();
+        shown
+    }
+
+    fn set_hovered(&mut self, spot: Warm, over: bool, cx: &mut Context<Self>) {
         if !over {
-            if self.over == Some(index) {
+            if self.over == Some(spot) {
                 self.over = None;
             }
-            if self.hovered == Some(index) {
+            if self.hovered == Some(spot) {
                 self.hovered = None;
-                self.fading = Some(index);
+                self.fading = Some(spot);
                 self.since = std::time::Instant::now();
                 self.linger = Some(cx.spawn(async move |this, cx| {
                     cx.background_executor().timer(Motion::Quick.span()).await;
                     this.update(cx, |this, cx| {
-                        if this.fading != Some(index) {
+                        if this.fading != Some(spot) {
                             return;
                         }
                         this.fading = None;
@@ -391,17 +569,17 @@ impl Aside {
             return;
         }
 
-        self.over = Some(index);
-        if self.hovered == Some(index) {
+        self.over = Some(spot);
+        if self.hovered == Some(spot) {
             return;
         }
         self.fading = None;
         self.linger = Some(cx.spawn(async move |this, cx| {
             this.update(cx, |this, cx| {
-                if this.over != Some(index) {
+                if this.over != Some(spot) {
                     return;
                 }
-                this.hovered = Some(index);
+                this.hovered = Some(spot);
                 cx.notify();
             })
             .ok();
@@ -722,6 +900,8 @@ impl Aside {
             karaoke: karaoke_effects,
             scripts: romanization_scripts,
             theme,
+            lift: 1.,
+            from: gpui::point(0., 0.5),
         };
 
         if self.verse_of != following {
@@ -757,10 +937,17 @@ impl Aside {
             true => theme.text(Text::Large),
             false => theme.text(Text::Title),
         };
+        let reach = verse * REACH;
         let wrap_size = active_verse_size(verse);
         let scroll = self.verse_bar.read(cx).scroll().clone();
-        let wrap_width = (scroll.bounds().size.width
-            - window.rem_size() * LYRICS_HORIZONTAL_INSET_REM)
+        let nudges = self.verse_bar.read(cx).nudges();
+        let drag = match (lines.is_some(), ui::motion::animates(cx)) {
+            (true, true) => self.lagged(&scroll, verse, nudges),
+            _ => Drag::default(),
+        };
+        let inset = window.rem_size() * LYRICS_HORIZONTAL_INSET_REM;
+        let wrap_width = (scroll.bounds().size.width - inset)
+            .min(reach - inset)
             .max(px(0.));
         if self.lyrics_wrap_width != Some(wrap_width) || self.lyrics_wrap_size != Some(wrap_size) {
             self.lyrics_wrap_width = Some(wrap_width);
@@ -795,29 +982,19 @@ impl Aside {
                 }
                 let instrumental_line = active_instrumental(lines, position);
                 let animations = ui::motion::animates(cx);
-                let hazing = effects();
+                let hazing = effects() && self.pinned;
                 let blur = verse * BLUR;
                 let sharpen = self.sharpen_progress(window);
+                // with motion turned down a press is simply on or off
+                let sink = match animations {
+                    true => self.sink_progress(window),
+                    false => 1.,
+                };
                 let view = scroll.bounds();
                 if hazing && scroll.bounds_for_item(0).is_none() {
                     window.request_animation_frame();
                 }
-                let count = lyric_row_count(lines);
-                if self.row_heights.len() != count {
-                    self.row_heights = vec![px(0.); count];
-                }
-                let holds = |line: Option<usize>| line.map(|line| line_row(lines, line));
-                let grown = [holds(active_line), holds(self.departing_line)];
-                for row in 0..count {
-                    if grown.contains(&Some(row)) {
-                        continue;
-                    }
-                    if let Some(item) = scroll.bounds_for_item(row) {
-                        self.row_heights[row] = item.size.height;
-                    }
-                }
-                let slack = view.size.height * SPARE;
-                let mut rendered = Vec::with_capacity(count);
+                let mut rendered = Vec::with_capacity(lyric_row_count(lines));
 
                 for (index, line) in lines.iter().enumerate() {
                     let seek = line.start;
@@ -831,28 +1008,29 @@ impl Aside {
                     };
                     let instrumental_has_passed = position >= line.start;
 
-                    let waking = self.hovered == Some(index);
-                    let settling = self.fading == Some(index);
-                    let haze = |depth: f32| match (waking, settling) {
+                    let verse_touch = self.touch(Warm::Verse(index), sharpen, sink);
+                    let notes_touch = self.touch(Warm::Break(index), sharpen, sink);
+                    let warmth = verse_touch.warmth;
+                    let depth = verse_touch.depth;
+                    // whatever the pointer rests on comes back into focus
+                    let clearing = |touch: Touch, depth: f32| match (touch.waking, touch.settling) {
                         (true, _) => depth * (1. - sharpen),
                         (false, true) => depth * sharpen,
                         (false, false) => depth,
                     };
+                    let haze = |depth: f32| clearing(verse_touch, depth);
                     if has_instrumental {
-                        let row = rendered.len();
-                        if let Some(held) = spared(&scroll, row, view, slack)
-                            .then(|| self.row_heights.get(row).copied())
-                            .flatten()
-                            .filter(|held| *held > px(0.))
-                        {
-                            rendered.push(div().h(held).flex_none().into_any_element());
-                            continue;
-                        }
+                        let notes_row = rendered.len();
                         if singing && instrumental_line == Some(index) {
                             window.request_animation_frame();
                         }
+                        let notes_along = viewport_along(&scroll, notes_row, view, drag.downward);
+                        let notes_drift = self.dragged(notes_row, notes_along, drag, window);
                         let softness = match hazing && instrumental_line != Some(index) {
-                            true => haze(viewport_haze(&scroll, rendered.len(), view, blur)),
+                            true => clearing(
+                                notes_touch,
+                                viewport_haze(&scroll, notes_row, view, blur, notes_drift),
+                            ),
                             false => 0.,
                         };
                         let notes = instrumental_row(
@@ -862,35 +1040,54 @@ impl Aside {
                             &theme,
                         )
                         .id(("instrumental", index))
+                        .w_full()
+                        .max_w(reach)
                         .px_2()
                         .rounded(theme.radius)
                         .cursor_pointer()
-                        .hover(|style| style.bg(theme.table_hover))
+                        .when(notes_touch.warmth > 0., |this| {
+                            this.bg(theme.table_hover.opacity(notes_touch.warmth))
+                        })
+                        .when(notes_touch.depth > 0., |this| {
+                            this.layer_scale(1. - (1. - PRESSED) * notes_touch.depth)
+                        })
+                        .on_hover(cx.listener(move |this, over: &bool, _, cx| {
+                            this.set_hovered(Warm::Break(index), *over, cx)
+                        }))
+                        .on_mouse_down(
+                            gpui::MouseButton::Left,
+                            cx.listener(move |this, _, _, cx| {
+                                this.press_verse(Warm::Break(index), true, cx)
+                            }),
+                        )
+                        .on_mouse_up(
+                            gpui::MouseButton::Left,
+                            cx.listener(move |this, _, _, cx| {
+                                this.press_verse(Warm::Break(index), false, cx)
+                            }),
+                        )
+                        .on_mouse_up_out(
+                            gpui::MouseButton::Left,
+                            cx.listener(move |this, _, _, cx| {
+                                this.press_verse(Warm::Break(index), false, cx)
+                            }),
+                        )
                         .on_click(cx.listener(move |this, _, _, cx| {
-                            this.seek_lyrics(instrumental_start, cx);
+                            this.seek_verse(notes_row, instrumental_start, cx);
                         }))
                         .when(softness > 0., |this| this.opacity(1. - VEIL * softness))
                         .map(|this| match blur * softness {
                             soft if soft > HAZE_LEAST => this.blur(soft),
                             _ => this,
                         });
-                        rendered.push(notes.into_any_element());
+                        rendered.push(slip(notes, notes_drift).into_any_element());
                     }
 
+                    let row = rendered.len();
+                    let along = viewport_along(&scroll, row, view, drag.downward);
+                    let drift = self.dragged(row, along, drag, window);
                     let active = Some(index) == active_line;
                     let departing = Some(index) == self.departing_line;
-                    let row = rendered.len();
-                    if !active
-                        && !departing
-                        && let Some(held) = spared(&scroll, row, view, slack)
-                            .then(|| self.row_heights.get(row).copied())
-                            .flatten()
-                            .filter(|held| *held > px(0.))
-                    {
-                        rendered.push(div().h(held).flex_none().into_any_element());
-                        continue;
-                    }
-
                     let karaoke = Some(index) == active_line && line.worded() && karaoke_effects;
                     let primary_karaoke = karaoke && line.words.is_some();
                     if let std::collections::hash_map::Entry::Vacant(slot) =
@@ -916,6 +1113,32 @@ impl Aside {
                     let dimming = (animations && departing).then_some(self.departure);
                     let growing =
                         animations && active && self.arrived.elapsed() < Motion::Base.span();
+                    let shrinking = dimming.is_some();
+                    let active_size = active_verse_size(verse);
+                    let small = verse / active_size;
+                    let big = active_size / verse;
+                    let unsung = theme.muted_foreground.opacity(AHEAD);
+                    let lit = theme.foreground;
+
+                    // both ways land on 1
+                    let lift = match (growing, shrinking) {
+                        (true, _) => small + (1. - small) * ramp(self.arrived, window),
+                        (_, true) => big - (big - 1.) * ramp(self.departed, window),
+                        _ => 1.,
+                    };
+                    let paint = match (growing, shrinking) {
+                        (true, _) => mix(unsung, tint, ramp(self.arrived, window)),
+                        (_, true) => mix(lit, tint, ramp(self.departed, window)),
+                        _ => tint,
+                    };
+                    let sung = Sung {
+                        lift,
+                        from: match line.voice.lead() {
+                            true => gpui::point(0., 0.5),
+                            false => gpui::point(1., 0.5),
+                        },
+                        ..sung
+                    };
 
                     let primary = match (primary_karaoke, line.words.as_ref(), wrapped) {
                         (true, Some(words), Some(plan)) => {
@@ -923,7 +1146,7 @@ impl Aside {
                                 .into_any_element()
                         }
                         (_, _, Some(plan)) => {
-                            fixed_lyrics_lane(&plan.text, line.voice).into_any_element()
+                            fixed_lyrics_lane(&plan.text, line.voice, sung).into_any_element()
                         }
                         _ => div()
                             .child(SharedString::from(line.text.clone()))
@@ -942,6 +1165,7 @@ impl Aside {
                                 &line.secondary,
                                 romanization_scripts,
                                 theme.text(Text::Body),
+                                active_verse_size(verse) * ui::LEADING,
                                 wrap_width,
                                 window,
                             );
@@ -997,10 +1221,13 @@ impl Aside {
                             selected_romanization(&line.romanized, romanization_scripts),
                             |this, text| this.child(romanized_lyrics_lane(text, &theme)),
                         )
-                        .children(lanes);
+                        .children(lanes)
+                        .when(depth > 0., |this| {
+                            this.layer_scale(1. - (1. - PRESSED) * depth)
+                        });
 
                     let softness = match hazing && Some(index) != active_line {
-                        true => haze(viewport_haze(&scroll, rendered.len(), view, blur)),
+                        true => haze(viewport_haze(&scroll, row, view, blur, drift)),
                         false => 0.,
                     };
                     let traded = index
@@ -1008,21 +1235,43 @@ impl Aside {
                         .is_some_and(|previous| lines[previous].voice != line.voice);
                     let verse_line = div()
                         .id(("verse", index))
+                        .w_full()
+                        .max_w(reach)
                         .px_2()
                         .py_1()
-                        .when(traded, |this| this.pt_3())
+                        .when(traded, |this| this.mt_2())
                         .rounded(theme.radius)
                         .cursor_pointer()
-                        .hover(|style| style.bg(theme.table_hover))
+                        .when(warmth > 0., |this| {
+                            this.bg(theme.table_hover.opacity(warmth))
+                        })
+                        .on_mouse_down(
+                            gpui::MouseButton::Left,
+                            cx.listener(move |this, _, _, cx| {
+                                this.press_verse(Warm::Verse(index), true, cx)
+                            }),
+                        )
+                        .on_mouse_up(
+                            gpui::MouseButton::Left,
+                            cx.listener(move |this, _, _, cx| {
+                                this.press_verse(Warm::Verse(index), false, cx)
+                            }),
+                        )
+                        .on_mouse_up_out(
+                            gpui::MouseButton::Left,
+                            cx.listener(move |this, _, _, cx| {
+                                this.press_verse(Warm::Verse(index), false, cx)
+                            }),
+                        )
                         .text_size(verse)
                         .line_height(active_verse_size(verse) * ui::LEADING)
                         .text_color(tint)
                         .font_weight(FontWeight::SEMIBOLD)
                         .on_hover(cx.listener(move |this, over: &bool, _, cx| {
-                            this.set_hovered(index, *over, cx)
+                            this.set_hovered(Warm::Verse(index), *over, cx)
                         }))
                         .on_click(cx.listener(move |this, _, _, cx| {
-                            this.seek_lyrics(seek, cx);
+                            this.seek_verse(row, seek, cx);
                         }))
                         .child(content);
 
@@ -1032,51 +1281,14 @@ impl Aside {
                             soft if soft > HAZE_LEAST => this.blur(soft),
                             _ => this,
                         });
-                    let shrinking = dimming.is_some();
-                    let active_size = active_verse_size(verse);
-                    let unsung = theme.muted_foreground.opacity(AHEAD);
-                    let lit = theme.foreground;
-                    // The verse is drawn at the size it ends up and scaled into place,
-                    // so the text system is asked for one size rather than one per
-                    // frame, and nothing around it has to move.
-                    let small = verse / active_size;
-                    let from = match line.voice.lead() {
-                        true => gpui::point(0., 0.5),
-                        false => gpui::point(1., 0.5),
+                    let verse_line = match (growing, shrinking, active) {
+                        (_, true, false) => verse_line.text_color(paint),
+                        (true, _, _) | (_, _, true) => {
+                            verse_line.text_size(active_size).text_color(paint)
+                        }
+                        _ => verse_line,
                     };
-                    let verse_line = match (growing, shrinking) {
-                        (true, _) => verse_line
-                            .text_size(active_size)
-                            .with_animation(
-                                ("verse-grow", self.arrival as usize),
-                                Animation::new(Motion::Base.span()).with_easing(ease_out_expo),
-                                move |this, t| {
-                                    let this = this
-                                        .layer_scale(small + (1. - small) * t)
-                                        .layer_scale_origin(from);
-                                    match karaoke {
-                                        true => this,
-                                        false => this.text_color(mix(unsung, lit, t)),
-                                    }
-                                },
-                            )
-                            .into_any_element(),
-                        (_, true) => verse_line
-                            .text_size(active_size)
-                            .with_animation(
-                                ("verse-shrink", self.departure as usize),
-                                Animation::new(Motion::Base.span()).with_easing(ease_out_expo),
-                                move |this, t| {
-                                    this.layer_scale(1. - (1. - small) * t)
-                                        .layer_scale_origin(from)
-                                        .text_color(mix(lit, tint, t))
-                                },
-                            )
-                            .into_any_element(),
-                        _ if active => verse_line.text_size(active_size).into_any_element(),
-                        _ => verse_line.into_any_element(),
-                    };
-                    rendered.push(verse_line);
+                    rendered.push(slip(verse_line, drift).into_any_element());
                 }
 
                 rendered
@@ -1084,6 +1296,8 @@ impl Aside {
             (None, LyricsState::Ready) => match &shown {
                 Some(music::Lyrics::Plain { text, romanized }) => vec![
                     div()
+                        .w_full()
+                        .max_w(reach)
                         .px_2()
                         .flex()
                         .flex_col()
@@ -1114,25 +1328,40 @@ impl Aside {
         if state == LyricsState::Ready
             && let Some((source, writers)) = &credit
         {
+            let credit = body.len();
+            let along = viewport_along(&scroll, credit, scroll.bounds(), drag.downward);
+            let drift = self.dragged(credit, along, drag, window);
             body.push(
-                div()
-                    .px_2()
-                    .pt_2()
-                    .flex()
-                    .flex_col()
-                    .text_size(theme.text(Text::Small))
-                    .text_color(theme.muted_foreground)
-                    .child(t!("lyrics-source", source = *source))
-                    .when(!writers.is_empty(), |this| {
-                        let writers = writers.join(", ");
-                        this.child(t!("lyrics-writers", writers = writers.as_str()))
-                    })
-                    .into_any_element(),
+                slip(
+                    div()
+                        .w_full()
+                        .max_w(reach)
+                        .px_2()
+                        .pt_2()
+                        .flex()
+                        .flex_col()
+                        .text_size(theme.text(Text::Small))
+                        .text_color(theme.muted_foreground)
+                        .child(t!("lyrics-source", source = *source))
+                        .when(!writers.is_empty(), |this| {
+                            let writers = writers.join(", ");
+                            this.child(t!("lyrics-writers", writers = writers.as_str()))
+                        }),
+                    drift,
+                )
+                .into_any_element(),
             );
         }
 
         if let Some(lines) = &lines {
-            let focus = active_lyrics_row(lines, position);
+            let live = active_lyrics_row(lines, position);
+            let focus = match self.pinning {
+                Some(row) if Some(row) != live => Some(row),
+                _ => {
+                    self.pinning = None;
+                    live
+                }
+            };
             self.pin_verse(focus, window, cx);
         }
 
@@ -1144,7 +1373,8 @@ impl Aside {
         let sheet = Scroller::new("lyrics", &self.verse_bar)
             .flex()
             .flex_col()
-            .gap_1()
+            .items_center()
+            .gap_4()
             .flex_1()
             .min_h_0()
             .px_1()
@@ -1199,6 +1429,15 @@ impl Aside {
         self.nudged = None;
     }
 
+    /// Seeks to a verse and holds the panel on the row it was asked for. The
+    /// clock takes a moment to report the new position, and until it does the
+    /// verse being sung is still the old one, which is where the panel would
+    /// otherwise fly off to.
+    fn seek_verse(&mut self, row: usize, position: std::time::Duration, cx: &mut Context<Self>) {
+        self.pinning = Some(row);
+        self.seek_lyrics(position, cx);
+    }
+
     fn seek_lyrics(&mut self, position: std::time::Duration, cx: &mut Context<Self>) {
         self.anchor_verse();
         self.playback
@@ -1248,12 +1487,17 @@ impl Aside {
         };
         self.aiming = false;
         let view = scroll.bounds();
-        let goal = anchored_lyrics_offset(
-            view.origin.y,
-            item.origin.y,
-            view.size.height,
-            scroll.max_offset().y,
+        // land on the grid
+        let goal = snapped(
+            anchored_lyrics_offset(
+                view.origin.y,
+                item.origin.y,
+                view.size.height,
+                scroll.max_offset().y,
+            ),
+            window,
         );
+        self.flown(goal, scroll.offset().y);
         match std::mem::take(&mut self.placing) {
             true => self.verse_bar.update(cx, |bar, _| bar.place(goal)),
             false => self.verse_bar.update(cx, |bar, _| bar.aim(goal, window)),
@@ -1490,13 +1734,19 @@ fn source_link(name: SharedString, to: Destination, cx: &App) -> impl IntoElemen
         .child(name)
 }
 
-fn fixed_lyrics_lane(rows: &[SharedString], voice: Voice) -> Div {
-    div().flex().flex_col().children(rows.iter().map(|row| {
-        div()
-            .w_full()
-            .when(!voice.lead(), |this| this.text_right())
-            .child(row.clone())
-    }))
+fn fixed_lyrics_lane(rows: &[SharedString], voice: Voice, sung: Sung) -> Div {
+    div()
+        .flex()
+        .flex_col()
+        .children(rows.iter().map(move |row| {
+            lifted(
+                div()
+                    .w_full()
+                    .when(!voice.lead(), |this| this.text_right())
+                    .child(row.clone()),
+                sung,
+            )
+        }))
 }
 
 // a lane with no measured plan of its own, split on the spot
@@ -1580,10 +1830,13 @@ fn karaoke_lane(
             .text_left()
             .children((0..plan.rows.len()).map(|row| {
                 let reveal = revealed(plan, row, &windows, position, edge_fade);
-                div()
-                    .flex()
-                    .when(!voice.lead(), |this| this.justify_end())
-                    .child(lit(plan.text[row].clone(), reveal))
+                lifted(
+                    div()
+                        .flex()
+                        .when(!voice.lead(), |this| this.justify_end())
+                        .child(lit(plan.text[row].clone(), reveal)),
+                    sung,
+                )
             })),
         true => div()
             .flex()
@@ -1859,6 +2112,25 @@ fn needs_space(left: &str, right: &str) -> bool {
             first,
             ')' | ']' | '}' | ',' | '.' | '!' | '?' | ';' | ':' | '%' | '\'' | '’' | '-' | '—'
         )
+}
+
+/// How far along a transition started at this moment is, asking for frames while
+/// it runs.
+fn ramp(at: std::time::Instant, window: &mut Window) -> f32 {
+    let span = Motion::Base.span().as_secs_f32().max(f32::EPSILON);
+    let progress = (at.elapsed().as_secs_f32() / span).clamp(0., 1.);
+    if progress < 1. {
+        window.request_animation_frame();
+    }
+    ease_out_expo(progress)
+}
+
+/// Scales one line of text without touching the space between it and the next.
+fn lifted(row: Div, sung: Sung) -> Div {
+    match sung.lift == 1. {
+        true => row,
+        false => row.layer_scale(sung.lift).layer_scale_origin(sung.from),
+    }
 }
 
 fn active_verse_size(verse: Pixels) -> Pixels {
@@ -2187,6 +2459,7 @@ fn lanes_room(
     lanes: &[music::LyricsLane],
     scripts: Option<RomanizationScripts>,
     size: Pixels,
+    leading: Pixels,
     width: Pixels,
     window: &mut Window,
 ) -> Pixels {
@@ -2200,7 +2473,10 @@ fn lanes_room(
         })
         .sum::<usize>();
 
-    size * LANE_LEADING * rows as f32
+    // a lane inherits the line height of the verse, not its own text size
+    let gaps = window.rem_size() * LANE_GAP_REM * lanes.len().saturating_sub(1) as f32;
+
+    leading * (rows as f32 + LANE_SLACK) + gaps
 }
 
 fn wrapped_rows(text: &str, size: Pixels, width: Pixels, window: &mut Window) -> usize {
@@ -2208,38 +2484,73 @@ fn wrapped_rows(text: &str, size: Pixels, width: Pixels, window: &mut Window) ->
     lyrics_wrap_rows(&parts, size, width, window).map_or(1, |wrapped| wrapped.rows.len().max(1))
 }
 
-// rows this far outside the panel are held open by their measured height alone
-fn spared(scroll: &ScrollHandle, row: usize, view: Bounds<Pixels>, slack: Pixels) -> bool {
-    let height = view.size.height;
-    let Some(item) = scroll.bounds_for_item(row) else {
-        return false;
-    };
-    if height <= px(0.) {
-        return false;
-    }
-    let top = item.origin.y - view.origin.y + scroll.offset().y;
-    top + item.size.height + slack < px(0.) || top - slack > height
+struct Place {
+    top: Pixels,
+    height: Pixels,
+    travel: f32,
+    along: f32,
 }
 
-fn viewport_haze(scroll: &ScrollHandle, row: usize, view: Bounds<Pixels>, margin: Pixels) -> f32 {
+// shift is drawn, not laid out
+fn viewport_place(
+    scroll: &ScrollHandle,
+    row: usize,
+    view: Bounds<Pixels>,
+    shift: Pixels,
+) -> Option<Place> {
     let height = view.size.height;
-    let Some(item) = scroll.bounds_for_item(row) else {
-        return 0.;
-    };
+    let item = scroll.bounds_for_item(row)?;
     if height <= px(0.) {
-        return 0.;
+        return None;
     }
-    let top = item.origin.y - view.origin.y + scroll.offset().y;
-    if top + item.size.height + margin < px(0.) || top - margin > height {
-        return 0.;
-    }
+    let top = item.origin.y - view.origin.y + scroll.offset().y + shift;
     let travel = top - height * PIN;
     let reach = height
         * match travel >= px(0.) {
             true => 1. - PIN,
             false => PIN,
         };
-    (travel.abs() / reach.max(px(1.))).clamp(0., 1.).powf(HAZE)
+    Some(Place {
+        top,
+        height: item.size.height,
+        travel: (travel / reach.max(px(1.))).clamp(-1., 1.),
+        along: (top / height).clamp(0., 1.),
+    })
+}
+
+fn viewport_haze(
+    scroll: &ScrollHandle,
+    row: usize,
+    view: Bounds<Pixels>,
+    margin: Pixels,
+    drift: Pixels,
+) -> f32 {
+    let Some(place) = viewport_place(scroll, row, view, drift) else {
+        return 0.;
+    };
+    if place.top + place.height + margin < px(0.) || place.top - margin > view.size.height {
+        return 0.;
+    }
+    place.travel.abs().powf(HAZE)
+}
+
+#[derive(Clone, Copy, Default)]
+struct Drag {
+    step: Pixels,
+    beat: f32,
+    downward: bool,
+    most: Pixels,
+}
+
+// incoming rows last
+fn viewport_along(scroll: &ScrollHandle, row: usize, view: Bounds<Pixels>, downward: bool) -> f32 {
+    let Some(place) = viewport_place(scroll, row, view, px(0.)) else {
+        return 0.;
+    };
+    match downward {
+        true => place.along,
+        false => 1. - place.along,
+    }
 }
 
 fn line_has_passed(line: &music::LyricsLine, position: std::time::Duration) -> bool {

--- a/crates/views/src/chrome/sidebar_left.rs
+++ b/crates/views/src/chrome/sidebar_left.rs
@@ -154,10 +154,6 @@ impl SidebarLeft {
         cx.notify();
     }
 
-    pub(crate) fn shown_width(&self) -> Pixels {
-        self.width
-    }
-
     pub fn occupied_width(&self) -> Pixels {
         match self.is_open() && !self.overlays() {
             true => self.width,

--- a/crates/views/src/chrome/sidebar_left.rs
+++ b/crates/views/src/chrome/sidebar_left.rs
@@ -1,6 +1,6 @@
 use ui::{
-    ActiveTheme as _, Button, Card, DraggedPin, Edge, Panel, Pin, PinKind, Pinnable as _, Popup,
-    SNUG, Scrollbar, Scroller, Shield, Side, Tabs, Text, drop_gap, drop_marker,
+    ActiveTheme as _, Button, Card, DraggedPin, Edge, Panel, Pin, Pinnable as _, Popup, SNUG,
+    Scrollbar, Scroller, Shield, Side, Tabs, Text, drop_gap, drop_marker,
 };
 
 use gpui::prelude::*;
@@ -227,7 +227,7 @@ impl SidebarLeft {
             _ => None,
         };
 
-        let origin = origin_of(&pin);
+        let origin = Origin::from(&pin);
         let playing = matches!(
             self.playback.read(cx).playing_from(&origin),
             Some(PlaybackState::Playing)
@@ -482,15 +482,6 @@ impl Render for SidebarLeft {
                 .child(panel)
                 .into_any_element(),
         }
-    }
-}
-
-fn origin_of(pin: &Pin) -> Origin {
-    match pin.kind {
-        PinKind::Album => Origin::Album(pin.id.clone()),
-        PinKind::Playlist => Origin::Playlist(pin.id.clone()),
-        PinKind::Artist => Origin::Artist(pin.id.clone()),
-        PinKind::Song => Origin::Radio(pin.id.clone()),
     }
 }
 

--- a/crates/views/src/screens/artist.rs
+++ b/crates/views/src/screens/artist.rs
@@ -11,7 +11,7 @@ use crate::chrome::Chrome;
 use crate::shared::cells;
 use i18n::t;
 use music::{Album, ReleaseType, SavedArtist, Track};
-use state::{AppSettings, ArtistDetail, Playback, Sonora};
+use state::{AppSettings, ArtistDetail, Origin, Playback, Sonora};
 use ui::ActiveTheme as _;
 use ui::Table as _;
 use ui::{
@@ -145,6 +145,14 @@ impl ArtistView {
                 playback.clone(),
                 menu_scrollbar,
             )
+            .from({
+                let detail = detail.clone();
+                move |cx: &App| {
+                    let detail = detail.read(cx);
+                    let name = detail.artist()?.name.clone();
+                    Some(Origin::artist(detail.id()?).named(name))
+                }
+            })
             .with_liked(Sonora::global(cx).library.clone());
             let source = source.table(cx.weak_entity());
             let mut delegate = GridDelegate::new(source, width, cx);
@@ -282,12 +290,15 @@ impl ArtistView {
             .flex()
             .items_center()
             .gap_2()
-            .child(HeroPlayButton::new(
-                "play-artist",
-                t!("artist-play"),
-                self.popular.as_ref().clone(),
-                self.playback.clone(),
-            ))
+            .child(
+                HeroPlayButton::new(
+                    "play-artist",
+                    t!("artist-play"),
+                    self.popular.as_ref().clone(),
+                    self.playback.clone(),
+                )
+                .from(self.playing_from(cx)),
+            )
             .children(self.follow_button(cx))
             .children(overflow);
 
@@ -561,8 +572,16 @@ impl ArtistView {
             .into_any_element()
     }
 
+    fn playing_from(&self, cx: &App) -> Option<Origin> {
+        let detail = self.detail.read(cx);
+        let name = detail.artist()?.name.clone();
+
+        Some(Origin::artist(detail.id()?).named(name))
+    }
+
     fn popular(&self, cx: &mut Context<Self>) -> AnyElement {
         let tracks = self.popular.clone();
+        let from = self.playing_from(cx);
         let pages = Shape::new(self.width, tracks.len()).pages;
         let queued = tracks.clone();
         let playback = self.playback.clone();
@@ -603,7 +622,7 @@ impl ArtistView {
         })
         .on_start(move |place, cx| {
             playback.update(cx, |playback, cx| {
-                playback.start(queued.as_ref().clone(), place, cx)
+                playback.start(queued.as_ref().clone(), place, from.clone(), cx)
             });
         })
         .into_any_element()

--- a/crates/views/src/screens/detail.rs
+++ b/crates/views/src/screens/detail.rs
@@ -6,7 +6,7 @@ use gpui::{
 
 use i18n::t;
 use music::{Album, Playlist, Track};
-use state::{AppSettings, Collection, Detail, LibraryEvent, Playback, Sonora};
+use state::{AppSettings, Collection, Detail, LibraryEvent, Origin, Playback, Sonora};
 use ui::{ActiveTheme as _, Button, Menu, Picker, Popovers, Popup, SortAxis};
 use ui::{
     ColumnSpec, FlagAxis, GridDelegate, GridEvent, GridState, MIN_CONTENT, Pin, PinKind, RangeAxis,
@@ -96,6 +96,21 @@ impl DetailView {
                 true => source.with_album(detail.clone()),
                 false => source,
             };
+            let source = source.from({
+                let detail = detail.clone();
+                move |cx: &App| {
+                    let detail = detail.read(cx);
+                    match (detail.album(), detail.playlist()) {
+                        (Some(album), _) => {
+                            Some(Origin::album(album.id.clone()).named(album.name.clone()))
+                        }
+                        (_, Some(list)) => {
+                            Some(Origin::playlist(list.id.clone()).named(list.name.clone()))
+                        }
+                        _ => None,
+                    }
+                }
+            });
             let source = source.table(cx.weak_entity());
             let mut delegate = GridDelegate::new(source, width, cx);
             delegate.set_layout(saved, cx);

--- a/crates/views/src/screens/library/albums.rs
+++ b/crates/views/src/screens/library/albums.rs
@@ -124,11 +124,11 @@ impl AlbumSource {
     }
 
     fn index_cell(&self, cell: &Cell<AlbumField>, album: &Album, cx: &App) -> AnyElement {
-        let origin = Origin::Album(album.id.clone());
+        let origin = Origin::album(album.id.clone()).named(album.name.clone());
         let state = self.playback.read(cx).playing_from(&origin);
-        let id = album.id.clone();
+        let played = origin.clone();
         let press = cells::toggle(&self.playback, state.clone(), move |playback, cx| {
-            playback.play_album(&id, cx)
+            playback.play_origin(played.clone(), cx)
         });
 
         cells::index(cell, state, true, None, press, cx)
@@ -212,7 +212,7 @@ impl GridSource for AlbumSource {
 
     fn playing(&self, row: usize, cx: &App) -> bool {
         self.albums(cx).get(row).is_some_and(|album| {
-            let origin = Origin::Album(album.id.clone());
+            let origin = Origin::album(album.id.clone());
             self.playback.read(cx).playing_from(&origin).is_some()
         })
     }

--- a/crates/views/src/screens/library/artists.rs
+++ b/crates/views/src/screens/library/artists.rs
@@ -58,11 +58,11 @@ impl ArtistSource {
     }
 
     fn index_cell(&self, cell: &Cell<ArtistField>, artist: &SavedArtist, cx: &App) -> AnyElement {
-        let origin = Origin::Artist(artist.id.clone());
+        let origin = Origin::artist(artist.id.clone()).named(artist.name.clone());
         let state = self.playback.read(cx).playing_from(&origin);
-        let id = artist.id.clone();
+        let played = origin.clone();
         let press = cells::toggle(&self.playback, state.clone(), move |playback, cx| {
-            playback.play_artist(&id, cx)
+            playback.play_origin(played.clone(), cx)
         });
 
         cells::index(cell, state, true, None, press, cx)
@@ -98,7 +98,7 @@ impl GridSource for ArtistSource {
 
     fn playing(&self, row: usize, cx: &App) -> bool {
         self.artists(cx).get(row).is_some_and(|artist| {
-            let origin = Origin::Artist(artist.id.clone());
+            let origin = Origin::artist(artist.id.clone());
             self.playback.read(cx).playing_from(&origin).is_some()
         })
     }

--- a/crates/views/src/screens/library/local.rs
+++ b/crates/views/src/screens/library/local.rs
@@ -5,7 +5,7 @@ use gpui::{
 };
 use i18n::t;
 use music::{Album, Track};
-use state::{AppSettings, Library, LibraryPart, LibraryState, Playback, Sonora};
+use state::{AppSettings, Library, LibraryPart, LibraryState, Origin, Playback, Sonora};
 use ui::{
     ActiveTheme as _, Button, FlagAxis, GridDelegate, GridEvent, GridState, Popovers, Popup,
     RangeAxis, Scrollbar, Scroller, SortAxis, Table as _, Unit, grid, vacant,
@@ -124,7 +124,8 @@ impl LocalView {
                 LocalTracks(library.clone()),
                 playback.clone(),
                 playlist_scrollbar,
-            );
+            )
+            .from(|_| Some(Origin::local()));
             let source = source.table(cx.weak_entity());
             let mut delegate = GridDelegate::new(source, width, cx);
             let (layout, sorting) = stored(Section::Tracks, cx);

--- a/crates/views/src/screens/library/mod.rs
+++ b/crates/views/src/screens/library/mod.rs
@@ -20,7 +20,9 @@ use gpui::{
 use i18n::t;
 use music::Track;
 use router::{Destination, LibraryTab, navigate};
-use state::{AppSettings, Library, LibraryPart, LibraryState, Playback, PlaybackState, Sonora};
+use state::{
+    AppSettings, Library, LibraryPart, LibraryState, Origin, Playback, PlaybackState, Sonora,
+};
 use ui::{
     ActiveTheme as _, Button, Card, Deck, FlagAxis, GridDelegate, GridEvent, GridSource, GridState,
     LEADING, Menu, MenuItem, Mode, Pinnable, Popovers, Popup, RangeAxis, Scrollbar, Scroller, Sort,
@@ -212,7 +214,8 @@ impl LibraryView {
                 LibraryTracks(library.clone()),
                 playback.clone(),
                 playlist_scrollbar,
-            );
+            )
+            .from(|_| Some(Origin::saved()));
             let source = source.table(cx.weak_entity());
             let mut delegate = GridDelegate::new(source, width, cx).with_sort(
                 TrackField::AddedAt,
@@ -484,8 +487,9 @@ impl LibraryView {
 
     fn play(&mut self, display: usize, cx: &mut Context<Self>) {
         let queued = tracks::ordered(&self.tracks, cx);
+        let from = tracks::whence(&self.tracks, cx);
         self.playback
-            .update(cx, |playback, cx| playback.start(queued, display, cx));
+            .update(cx, |playback, cx| playback.start(queued, display, from, cx));
     }
 
     fn open_album(&mut self, display: usize, cx: &mut Context<Self>) {
@@ -804,7 +808,7 @@ impl LibraryView {
         let view = self.me.clone();
 
         Some(
-            cards::artist_card(("library-artist", display), &artist)
+            cards::artist_card(("library-artist", display), &artist, &self.playback, cx)
                 .tile(card)
                 .flat()
                 .menu(move |event, _, cx| {

--- a/crates/views/src/screens/library/playlists.rs
+++ b/crates/views/src/screens/library/playlists.rs
@@ -80,11 +80,11 @@ impl PlaylistSource {
     }
 
     fn index_cell(&self, cell: &Cell<PlaylistField>, playlist: &Playlist, cx: &App) -> AnyElement {
-        let origin = Origin::Playlist(playlist.id.clone());
+        let origin = Origin::playlist(playlist.id.clone()).named(playlist.name.clone());
         let state = self.playback.read(cx).playing_from(&origin);
-        let id = playlist.id.clone();
+        let played = origin.clone();
         let press = cells::toggle(&self.playback, state.clone(), move |playback, cx| {
-            playback.play_playlist(&id, cx)
+            playback.play_origin(played.clone(), cx)
         });
 
         cells::index(cell, state, true, None, press, cx)
@@ -121,7 +121,7 @@ impl GridSource for PlaylistSource {
 
     fn playing(&self, row: usize, cx: &App) -> bool {
         self.playlists(cx).get(row).is_some_and(|playlist| {
-            let origin = Origin::Playlist(playlist.id.clone());
+            let origin = Origin::playlist(playlist.id.clone());
             self.playback.read(cx).playing_from(&origin).is_some()
         })
     }

--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -221,7 +221,10 @@ impl SearchView {
                     .press(pressed(Press::Song(Box::new(track.clone())), me))
             }
             Hit::Artist(artist) => {
-                let origin = artist.id.clone().map(state::Origin::Artist);
+                let origin = artist
+                    .id
+                    .clone()
+                    .map(|id| state::Origin::artist(id).named(artist.name.clone()));
                 let playing = origin.as_ref().is_some_and(|origin| {
                     self.playback.read(cx).playing_from(origin)
                         == Some(state::PlaybackState::Playing)
@@ -249,7 +252,7 @@ impl SearchView {
                 }
             }
             Hit::Album(album) => {
-                let origin = state::Origin::Album(album.id.clone());
+                let origin = state::Origin::album(album.id.clone()).named(album.name.clone());
                 let playing = self.playback.read(cx).playing_from(&origin)
                     == Some(state::PlaybackState::Playing);
                 let toggled = me.clone();
@@ -268,7 +271,7 @@ impl SearchView {
                     .press(pressed(Press::Album(album.id.clone()), me))
             }
             Hit::Playlist(list) => {
-                let origin = state::Origin::Playlist(list.id.clone());
+                let origin = state::Origin::playlist(list.id.clone()).named(list.name.clone());
                 let playing = self.playback.read(cx).playing_from(&origin)
                     == Some(state::PlaybackState::Playing);
                 let toggled = me.clone();

--- a/crates/views/src/shared/cards.rs
+++ b/crates/views/src/shared/cards.rs
@@ -16,7 +16,7 @@ pub(crate) fn album_card(
 ) -> Card {
     let theme = *cx.theme();
     let cover = album.cover_large.clone().or_else(|| album.cover.clone());
-    let origin = Origin::Album(album.id.clone());
+    let origin = Origin::album(album.id.clone()).named(album.name.clone());
     let playing = matches!(
         playback.read(cx).playing_from(&origin),
         Some(PlaybackState::Playing)
@@ -51,7 +51,7 @@ pub(crate) fn playlist_card(
     playback: &Entity<Playback>,
     cx: &App,
 ) -> Card {
-    let origin = Origin::Playlist(playlist.id.clone());
+    let origin = Origin::playlist(playlist.id.clone()).named(playlist.name.clone());
     let playing = matches!(
         playback.read(cx).playing_from(&origin),
         Some(PlaybackState::Playing)
@@ -72,9 +72,20 @@ pub(crate) fn playlist_card(
         .when_some(pin, Pinnable::pin)
 }
 
-pub(crate) fn artist_card(id: impl Into<ElementId>, artist: &SavedArtist) -> Card {
+pub(crate) fn artist_card(
+    id: impl Into<ElementId>,
+    artist: &SavedArtist,
+    playback: &Entity<Playback>,
+    cx: &App,
+) -> Card {
+    let origin = Origin::artist(artist.id.clone()).named(artist.name.clone());
+    let playing = matches!(
+        playback.read(cx).playing_from(&origin),
+        Some(PlaybackState::Playing)
+    );
     let pin = artist.pin();
     let opened = SharedString::from(artist.id.clone());
+    let toggled = playback.clone();
 
     Card::new(id, SharedString::from(artist.name.clone()))
         .cover(artist.cover.clone())
@@ -82,6 +93,9 @@ pub(crate) fn artist_card(id: impl Into<ElementId>, artist: &SavedArtist) -> Car
         .weight(FontWeight::SEMIBOLD)
         .underline()
         .meta(i18n::lookup("artist-eyebrow", None))
+        .play(playing, move |_, _, cx| {
+            toggled.update(cx, |playback, cx| playback.toggle_origin(&origin, cx));
+        })
         .press(move |_, _, cx| navigate(Destination::Artist(opened.clone()), cx))
         .when_some(pin, Pinnable::pin)
 }

--- a/crates/views/src/shared/hero.rs
+++ b/crates/views/src/shared/hero.rs
@@ -7,7 +7,7 @@ use gpui::{
 };
 use i18n::t;
 use music::Track;
-use state::{Playback, PlaybackState};
+use state::{Origin, Playback, PlaybackState};
 use ui::{
     ActiveTheme as _, Artwork, Button, ExplicitBadge, GridState, LEADING, Pin, Pinnable as _, Text,
     upper,
@@ -116,6 +116,13 @@ impl Listing {
             Self::Listed(table) => tracks::ordered(table, cx),
         }
     }
+
+    fn whence(&self, cx: &App) -> Option<Origin> {
+        match self {
+            Self::Owned(_) => None,
+            Self::Listed(table) => tracks::whence(table, cx),
+        }
+    }
 }
 
 #[derive(IntoElement)]
@@ -123,6 +130,7 @@ pub(crate) struct HeroPlayButton {
     id: ElementId,
     label: SharedString,
     listing: Listing,
+    from: Option<Origin>,
     playback: Entity<Playback>,
 }
 
@@ -137,8 +145,14 @@ impl HeroPlayButton {
             id: id.into(),
             label: label.into(),
             listing: Listing::Owned(tracks),
+            from: None,
             playback,
         }
+    }
+
+    pub(crate) fn from(mut self, origin: Option<Origin>) -> Self {
+        self.from = origin;
+        self
     }
 
     pub(crate) fn listed(
@@ -151,6 +165,7 @@ impl HeroPlayButton {
             id: id.into(),
             label: label.into(),
             listing: Listing::Listed(table.clone()),
+            from: None,
             playback,
         }
     }
@@ -175,6 +190,7 @@ impl RenderOnce for HeroPlayButton {
         let disabled = first_playable.is_none() || blocked;
         let first_playable = first_playable.unwrap_or_default();
         let listing = self.listing;
+        let from = self.from;
         let playback = self.playback;
 
         div().flex().child(
@@ -190,7 +206,8 @@ impl RenderOnce for HeroPlayButton {
                         Some(PlaybackState::Loading) => {}
                         _ => {
                             let queued = listing.queue(cx);
-                            playback.start(queued, first_playable, cx)
+                            let from = from.clone().or_else(|| listing.whence(cx));
+                            playback.start(queued, first_playable, from, cx)
                         }
                     });
                 }),

--- a/crates/views/src/shared/menu.rs
+++ b/crates/views/src/shared/menu.rs
@@ -2,7 +2,7 @@ use gpui::{App, ClipboardItem, Entity, Styled as _};
 use i18n::t;
 use music::{Album, MediaKind, Playlist, SavedArtist, Track};
 use router::{Destination, navigate};
-use state::{Detail, LibraryState, Playback, Sonora};
+use state::{Detail, LibraryState, Origin, Playback, Sonora};
 use ui::{Menu, MenuItem, Pin, PinKind, Scrollbar, SubmenuState};
 
 use crate::shared::playlist_editor::{Edit, PlaylistEditor};
@@ -346,7 +346,7 @@ pub(crate) fn album_menu(
 ) -> Menu {
     let album_id = album.id.clone();
     let opened = album_id.clone();
-    let played = album_id.clone();
+    let played = Origin::album(album_id.clone()).named(album.name.clone());
     let next = album_id.clone();
     let queued = album_id.clone();
     let copied = album_id.clone();
@@ -371,7 +371,7 @@ pub(crate) fn album_menu(
                 MenuItem::new("play-album", t!("menu-play-album"))
                     .icon("icons/play.svg")
                     .on_click(move |_, _, cx| {
-                        playing.update(cx, |playback, cx| playback.play_album(&played, cx));
+                        playing.update(cx, |playback, cx| playback.play_origin(played.clone(), cx));
                     }),
                 MenuItem::new("play-album-next", t!("menu-play-next"))
                     .icon("icons/list-plus.svg")
@@ -425,7 +425,7 @@ pub(crate) fn artist_menu(
 ) -> Menu {
     let artist_id = artist.id.clone();
     let opened = artist_id.clone();
-    let played = artist_id.clone();
+    let played = Origin::artist(artist_id.clone()).named(artist.name.clone());
     let next = artist_id.clone();
     let queued = artist_id.clone();
     let copied = artist_id.clone();
@@ -450,7 +450,7 @@ pub(crate) fn artist_menu(
                 MenuItem::new("play-artist", t!("menu-play-artist"))
                     .icon("icons/play.svg")
                     .on_click(move |_, _, cx| {
-                        playing.update(cx, |playback, cx| playback.play_artist(&played, cx));
+                        playing.update(cx, |playback, cx| playback.play_origin(played.clone(), cx));
                     }),
                 MenuItem::new("play-artist-next", t!("menu-play-next"))
                     .icon("icons/list-plus.svg")
@@ -506,7 +506,7 @@ pub(crate) fn playlist_menu(
     cx: &App,
 ) -> Menu {
     let opened = playlist.id.clone();
-    let played = playlist.id.clone();
+    let played = Origin::playlist(playlist.id.clone()).named(playlist.name.clone());
     let next = playlist.id.clone();
     let queued = playlist.id.clone();
     let copied = playlist.id.clone();
@@ -570,7 +570,7 @@ pub(crate) fn playlist_menu(
                 MenuItem::new("play-playlist", t!("menu-play-playlist"))
                     .icon("icons/play.svg")
                     .on_click(move |_, _, cx| {
-                        playing.update(cx, |playback, cx| playback.play_playlist(&played, cx));
+                        playing.update(cx, |playback, cx| playback.play_origin(played.clone(), cx));
                     }),
                 MenuItem::new("play-playlist-next", t!("menu-play-next"))
                     .icon("icons/list-plus.svg")
@@ -674,7 +674,7 @@ fn open_key(kind: PinKind) -> &'static str {
 }
 
 fn transport_items(pin: &Pin, playback: Entity<Playback>) -> Vec<MenuItem> {
-    let played = pin.id.clone();
+    let played = Origin::from(pin);
     let next = pin.id.clone();
     let queued = pin.id.clone();
     let nexting = playback.clone();
@@ -685,7 +685,7 @@ fn transport_items(pin: &Pin, playback: Entity<Playback>) -> Vec<MenuItem> {
             MenuItem::new("play-pin", t!("menu-play-album"))
                 .icon("icons/play.svg")
                 .on_click(move |_, _, cx| {
-                    playback.update(cx, |playback, cx| playback.play_album(&played, cx));
+                    playback.update(cx, |playback, cx| playback.play_origin(played.clone(), cx));
                 }),
             MenuItem::new("play-pin-next", t!("menu-play-next"))
                 .icon("icons/list-plus.svg")
@@ -702,7 +702,7 @@ fn transport_items(pin: &Pin, playback: Entity<Playback>) -> Vec<MenuItem> {
             MenuItem::new("play-pin", t!("menu-play-playlist"))
                 .icon("icons/play.svg")
                 .on_click(move |_, _, cx| {
-                    playback.update(cx, |playback, cx| playback.play_playlist(&played, cx));
+                    playback.update(cx, |playback, cx| playback.play_origin(played.clone(), cx));
                 }),
             MenuItem::new("play-pin-next", t!("menu-play-next"))
                 .icon("icons/list-plus.svg")
@@ -719,7 +719,7 @@ fn transport_items(pin: &Pin, playback: Entity<Playback>) -> Vec<MenuItem> {
             MenuItem::new("play-pin", t!("menu-play-artist"))
                 .icon("icons/play.svg")
                 .on_click(move |_, _, cx| {
-                    playback.update(cx, |playback, cx| playback.play_artist(&played, cx));
+                    playback.update(cx, |playback, cx| playback.play_origin(played.clone(), cx));
                 }),
             MenuItem::new("play-pin-next", t!("menu-play-next"))
                 .icon("icons/list-plus.svg")
@@ -736,7 +736,7 @@ fn transport_items(pin: &Pin, playback: Entity<Playback>) -> Vec<MenuItem> {
             MenuItem::new("play-pin", t!("menu-song-radio"))
                 .icon("icons/radio.svg")
                 .on_click(move |_, _, cx| {
-                    playback.update(cx, |playback, cx| playback.play_track(&played, cx));
+                    playback.update(cx, |playback, cx| playback.play_origin(played.clone(), cx));
                 }),
         ],
     }

--- a/crates/views/src/shared/page.rs
+++ b/crates/views/src/shared/page.rs
@@ -35,7 +35,8 @@ pub(crate) fn play(
     cx: &mut App,
 ) {
     let queued = tracks::ordered(table, cx);
-    playback.update(cx, |playback, cx| playback.start(queued, display, cx));
+    let from = tracks::whence(table, cx);
+    playback.update(cx, |playback, cx| playback.start(queued, display, from, cx));
 }
 
 pub(crate) fn resize(

--- a/crates/views/src/shared/tracks/mod.rs
+++ b/crates/views/src/shared/tracks/mod.rs
@@ -16,7 +16,7 @@ use gpui::{
 use jiff::Timestamp;
 use music::Track;
 use router::Destination;
-use state::{Detail, Library, Playback, PlaybackState, Sonora};
+use state::{Detail, Library, Origin, Playback, PlaybackState, Sonora};
 use ui::{Button, Cell, ColumnSpec, GridSource, GridState, Menu, Pin, ROW_GROUP, Scrollbar, clock};
 
 use crate::shared::cells;
@@ -65,6 +65,10 @@ pub(crate) fn holds(table: &Entity<GridState<TrackSource>>, id: &str, cx: &App) 
     })
 }
 
+pub(crate) fn whence(table: &Entity<GridState<TrackSource>>, cx: &App) -> Option<Origin> {
+    table.read(cx).delegate().source().whence(cx)
+}
+
 pub(crate) fn ordered(table: &Entity<GridState<TrackSource>>, cx: &App) -> Vec<Track> {
     let state = table.read(cx);
     let delegate = state.delegate();
@@ -74,8 +78,11 @@ pub(crate) fn ordered(table: &Entity<GridState<TrackSource>>, cx: &App) -> Vec<T
         .collect()
 }
 
+type Whence = Rc<dyn Fn(&App) -> Option<Origin>>;
+
 pub(crate) struct TrackSource {
     columns: &'static [ColumnSpec<TrackField>],
+    whence: Option<Whence>,
     provider: Rc<dyn Tracks>,
     playback: Entity<Playback>,
     is_liked: Option<Entity<Library>>,
@@ -101,6 +108,7 @@ impl TrackSource {
     ) -> Self {
         Self {
             columns,
+            whence: None,
             provider: Rc::new(provider),
             playback,
             is_liked: None,
@@ -148,6 +156,16 @@ impl TrackSource {
         *self.spread.borrow_mut() = Some(Spread { stamp, extent });
 
         extent
+    }
+
+    // resolved when play starts
+    pub(crate) fn from(mut self, whence: impl Fn(&App) -> Option<Origin> + 'static) -> Self {
+        self.whence = Some(Rc::new(whence));
+        self
+    }
+
+    pub(crate) fn whence(&self, cx: &App) -> Option<Origin> {
+        self.whence.as_ref().and_then(|whence| whence(cx))
     }
 
     pub(crate) fn table(mut self, table: WeakEntity<GridState<TrackSource>>) -> Self {
@@ -209,17 +227,16 @@ impl TrackSource {
                 }));
                 let provider = self.provider.clone();
                 let table = self.table.clone();
+                let whence = self.whence.clone();
                 let row = cell.row;
                 let display = cell.display;
-                let press =
-                    cells::toggle(
-                        &self.playback,
-                        state.clone(),
-                        move |playback, cx| match table.as_ref().and_then(|table| table.upgrade()) {
-                            Some(table) => playback.start(ordered(&table, cx), display, cx),
-                            None => playback.start(provider.tracks(cx).to_vec(), row, cx),
-                        },
-                    );
+                let press = cells::toggle(&self.playback, state.clone(), move |playback, cx| {
+                    let from = whence.as_ref().and_then(|whence| whence(cx));
+                    match table.as_ref().and_then(|table| table.upgrade()) {
+                        Some(table) => playback.start(ordered(&table, cx), display, from, cx),
+                        None => playback.start(provider.tracks(cx).to_vec(), row, from, cx),
+                    }
+                });
                 (preload, press)
             }
         };
@@ -239,13 +256,15 @@ impl TrackSource {
                 let playback = self.playback.clone();
                 let provider = self.provider.clone();
                 let table = self.table.clone();
+                let whence = self.whence.clone();
                 let row = cell.row;
                 let display = cell.display;
                 Some(Box::new(move |cx| {
+                    let from = whence.as_ref().and_then(|whence| whence(cx));
                     playback.update(cx, |playback, cx| {
                         match table.as_ref().and_then(|table| table.upgrade()) {
-                            Some(table) => playback.start(ordered(&table, cx), display, cx),
-                            None => playback.start(provider.tracks(cx).to_vec(), row, cx),
+                            Some(table) => playback.start(ordered(&table, cx), display, from, cx),
+                            None => playback.start(provider.tracks(cx).to_vec(), row, from, cx),
                         }
                     });
                 }))

--- a/crates/views/src/shells/fullscreen.rs
+++ b/crates/views/src/shells/fullscreen.rs
@@ -2,9 +2,9 @@ use std::time::{Duration, Instant};
 
 use gpui::prelude::*;
 use gpui::{
-    AnyView, App, Context, Entity, FocusHandle, KeyDownEvent, MouseButton, MouseDownEvent,
-    MouseMoveEvent, MouseUpEvent, Pixels, Point, Render, ScrollWheelEvent, SharedString, Task,
-    ease_in_out,
+    AnyView, App, Context, Entity, FocusHandle, FontWeight, KeyDownEvent, MouseButton,
+    MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point, Render, ScrollWheelEvent,
+    SharedString, Task, ease_in_out,
 };
 use gpui::{Window, div, px, relative};
 use i18n::t;
@@ -330,6 +330,7 @@ impl FullscreenView {
                             .min_w_0()
                             .truncate()
                             .text_size(theme.text(Text::Title))
+                            .font_weight(FontWeight::SEMIBOLD)
                             .when_some(album, |this, album| {
                                 this.cursor_pointer()
                                     .hover(|style| style.underline())
@@ -424,6 +425,7 @@ impl FullscreenView {
                                     .id("strip-title")
                                     .min_w_0()
                                     .truncate()
+                                    .font_weight(FontWeight::SEMIBOLD)
                                     .when_some(album, |this, album| {
                                         this.cursor_pointer()
                                             .hover(|style| style.underline())

--- a/crates/views/src/shells/workspace.rs
+++ b/crates/views/src/shells/workspace.rs
@@ -184,9 +184,13 @@ impl Render for Workspace {
         Chrome::publish(left, right, cx);
         let covered = self.sidebar_right.read(cx).covers_content(window);
         let overlay = self.sidebar.read(cx).overlays();
-        let sidebar_width = self.sidebar.read(cx).shown_width();
         let bar_height = PlayerBar::height(window, cx);
-        let sidebar = match overlay {
+        // A cached view is laid out from the style given here and its own root
+        // style is never consulted, so it can only be cached while it is in the
+        // flow at a width this knows: an overlaid sidebar places itself, and a
+        // closed one hides itself and takes no space at all.
+        let sidebar_width = self.sidebar.read(cx).occupied_width();
+        let sidebar = match overlay || sidebar_width == gpui::Pixels::ZERO {
             true => self.sidebar.clone().into_any_element(),
             false => self
                 .sidebar


### PR DESCRIPTION
## Summary

- say in the queue where the music is playing from, and open it on click
- drag the lyrics rows along when the sheet scrolls itself, each on a spring of its own
- keep submenus open while the pointer travels to them
- restore turning the left sidebar off
- cache cover art on disk
- add a lyrics prober example for tracing which provider a sheet came from