### PR TITLE
Redesign sign-in flow

### DIFF
--- a/crates/sonora/src/main.rs
+++ b/crates/sonora/src/main.rs
@@ -161,6 +161,8 @@ fn open_window(
         },
         |window, cx| {
             window.set_rem_size(cx.theme().font_size);
+            #[cfg(target_os = "windows")]
+            strip_system_controls(window);
             state::attach_remote(window_handle(window), cx);
             state::remember_window(window, cx);
             cx.new(|cx| Root::new(session, library, playback, queue, window, cx))
@@ -182,4 +184,37 @@ fn window_handle(window: &gpui::Window) -> Option<*mut std::ffi::c_void> {
 #[cfg(not(target_os = "windows"))]
 fn window_handle(_window: &gpui::Window) -> Option<*mut std::ffi::c_void> {
     None
+}
+
+#[cfg(target_os = "windows")]
+fn strip_system_controls(window: &gpui::Window) {
+    const GWL_STYLE: i32 = -16;
+    const WS_SYSMENU: i32 = 0x00080000;
+    const WS_MINIMIZEBOX: i32 = 0x00020000;
+    const WS_MAXIMIZEBOX: i32 = 0x00010000;
+    const SWP_REFRESH_FRAME: u32 = 0x0037;
+
+    unsafe extern "system" {
+        fn GetWindowLongW(window: *mut std::ffi::c_void, index: i32) -> i32;
+        fn SetWindowLongW(window: *mut std::ffi::c_void, index: i32, value: i32) -> i32;
+        fn SetWindowPos(
+            window: *mut std::ffi::c_void,
+            after: *mut std::ffi::c_void,
+            x: i32,
+            y: i32,
+            width: i32,
+            height: i32,
+            flags: u32,
+        ) -> i32;
+    }
+
+    let Some(handle) = window_handle(window) else {
+        return;
+    };
+    let controls = WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX;
+    unsafe {
+        let style = GetWindowLongW(handle, GWL_STYLE);
+        SetWindowLongW(handle, GWL_STYLE, style & !controls);
+        SetWindowPos(handle, std::ptr::null_mut(), 0, 0, 0, 0, SWP_REFRESH_FRAME);
+    }
 }

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -87,7 +87,7 @@ pub use shield::Shield;
 pub use skeleton::{Initials, Skeleton};
 pub use slip::slip;
 pub use switch::Switch;
-pub use tabs::Tabs;
+pub use tabs::{TabBar, Tabs};
 pub use theme::{
     ActiveTheme, Look, MAX_FONT, MAX_TRANSPARENCY, MIN_FONT, Theme, ThemeKind, ThemeOverrides,
 };

--- a/crates/ui/src/tabs.rs
+++ b/crates/ui/src/tabs.rs
@@ -1,8 +1,10 @@
 use gpui::prelude::*;
 use gpui::{AnyElement, App, Div, StyleRefinement, Window, div, px};
 
+use crate::button::Button;
 use crate::theme::ActiveTheme as _;
 
+const GAP: f32 = 0.25;
 const LINE: f32 = 1.;
 const TICK: f32 = 6.;
 
@@ -10,6 +12,61 @@ const TICK: f32 = 6.;
 pub struct Tabs {
     base: Div,
     items: Vec<AnyElement>,
+}
+
+#[derive(IntoElement)]
+pub struct TabBar {
+    base: Div,
+    items: Vec<Button>,
+}
+
+impl Default for TabBar {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TabBar {
+    pub fn new() -> Self {
+        Self {
+            base: div(),
+            items: Vec::new(),
+        }
+    }
+
+    pub fn items(mut self, items: impl IntoIterator<Item = Button>) -> Self {
+        self.items = items.into_iter().collect();
+        self
+    }
+}
+
+impl Styled for TabBar {
+    fn style(&mut self) -> &mut StyleRefinement {
+        self.base.style()
+    }
+}
+
+impl RenderOnce for TabBar {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let Self { mut base, items } = self;
+        let theme = cx.theme();
+        let radius = (theme.radius - window.rem_size() * GAP).max(px(0.));
+        let overrides = std::mem::take(base.style());
+
+        let mut bar = base
+            .flex()
+            .items_center()
+            .gap_1()
+            .p_1()
+            .rounded(theme.radius)
+            .bg(theme.secondary)
+            .border_1()
+            .border_color(theme.border)
+            .children(items.into_iter().map(|item| item.rounded(radius)));
+
+        bar.style().refine(&overrides);
+        bar
+    }
 }
 
 impl Default for Tabs {

--- a/crates/views/src/root.rs
+++ b/crates/views/src/root.rs
@@ -518,7 +518,13 @@ impl Render for Root {
             None => {}
         }
 
-        let options = self.options(cx);
+        let options = match show_sign_in {
+            true => TitleBarOptions {
+                border: false,
+                ..TitleBarOptions::default()
+            },
+            false => self.options(cx),
+        };
         self.title_bar
             .update(cx, |bar, cx| bar.set_options(options, cx));
 
@@ -554,11 +560,12 @@ impl Render for Root {
             .on_action(
                 cx.listener(|this, _: &ToggleLyrics, _, cx| this.show_side(SideTab::Lyrics, cx)),
             )
+            .child(self.title_bar.clone())
             .when_else(
                 show_sign_in,
-                |this| this.child(self.login.clone()),
+                |this| this.child(div().flex().flex_1().min_h_0().child(self.login.clone())),
                 |this| {
-                    this.child(self.title_bar.clone()).child(match self.view {
+                    this.child(match self.view {
                         RootView::Workspace => self.shells.workspace.clone().into_any_element(),
                         RootView::Fullscreen => self.shells.fullscreen.clone().into_any_element(),
                     })

--- a/crates/views/src/screens/login.rs
+++ b/crates/views/src/screens/login.rs
@@ -9,11 +9,10 @@ use i18n::t;
 use music::{AccountChoice, SignIn, SignInPrompt};
 use state::{Session, SessionState};
 use ui::ActiveTheme as _;
-use ui::{Button, Input, Modal, Separator, Text};
+use ui::{Button, Input, Modal, TabBar, Text};
 
 const COLUMN: Pixels = px(280.);
 const LOGO: Pixels = px(48.);
-const RULE: Pixels = px(220.);
 
 struct Column {
     slug: &'static str,
@@ -27,6 +26,7 @@ pub struct LoginView {
     session: Entity<Session>,
     secret: Entity<Input>,
     browsers: Option<(&'static str, Vec<SharedString>)>,
+    tab: usize,
 }
 
 impl LoginView {
@@ -36,6 +36,7 @@ impl LoginView {
             session,
             secret: cx.new(|cx| Input::new("login-cookie-hint", cx)),
             browsers: None,
+            tab: 0,
         }
     }
 
@@ -213,54 +214,15 @@ impl LoginView {
             )
     }
 
-    fn guest_mode(
-        &self,
-        guests: Vec<(&'static str, &'static str)>,
-        pending: bool,
-        cx: &mut Context<Self>,
-    ) -> impl IntoElement {
-        let theme = *cx.theme();
-        let alone = guests.len() == 1;
-        let mut buttons = Vec::new();
-        for (slug, name) in guests {
-            let label = match alone {
-                true => t!("login-guest-use"),
-                false => t!("login-use", provider = name),
-            };
-            buttons.push(
-                Button::new(SharedString::from(format!("guest-{slug}")))
-                    .label(label)
-                    .outline()
-                    .disabled(pending)
-                    .on_click(cx.listener(move |this, _, _, cx| {
-                        this.start(slug, SignIn::Anonymous, cx);
-                    })),
-            );
-        }
-
-        div()
-            .flex()
-            .flex_col()
-            .items_center()
-            .gap_2()
-            .pt_4()
-            .border_t_1()
-            .border_color(theme.border)
-            .w(COLUMN * 2. + px(64.))
-            .child(
-                div()
-                    .font_weight(FontWeight::MEDIUM)
-                    .child(t!("login-guest-title")),
-            )
-            .child(
-                div()
-                    .max_w(px(420.))
-                    .text_center()
-                    .text_size(theme.text(Text::Small))
-                    .text_color(theme.muted_foreground)
-                    .child(t!("login-guest-detail")),
-            )
-            .child(div().flex().gap_2().children(buttons))
+    fn guest_mode(&self, slug: &'static str, pending: bool, cx: &mut Context<Self>) -> Button {
+        Button::new("guest-mode")
+            .label(t!("login-guest-title"))
+            .outline()
+            .w_full()
+            .disabled(pending)
+            .on_click(cx.listener(move |this, _, _, cx| {
+                this.start(slug, SignIn::Anonymous, cx);
+            }))
     }
 
     fn code_prompt(&self, code: String, url: String, cx: &mut Context<Self>) -> impl IntoElement {
@@ -356,15 +318,15 @@ impl Render for LoginView {
         let state = self.session.read(cx).state().clone();
         let pending = self.session.read(cx).is_pending();
         let providers: Vec<state::ProviderInfo> = self.session.read(cx).providers().collect();
-        let guests: Vec<(&'static str, &'static str)> = providers
+        let guest = providers
             .iter()
             .filter(|info| {
                 info.options
                     .iter()
                     .any(|option| matches!(option, SignIn::Anonymous))
             })
-            .map(|info| (info.slug, info.name))
-            .collect();
+            .map(|info| info.slug)
+            .next();
         let waiting = match &state {
             SessionState::Authorizing(prompt) => !matches!(
                 prompt,
@@ -372,16 +334,29 @@ impl Render for LoginView {
             ),
             _ => false,
         };
-        let columns: Vec<Column> = providers
-            .into_iter()
-            .map(|info| Column {
-                slug: info.slug,
-                name: info.name,
-                options: info.options,
-                disabled: pending,
-                cancel: waiting && info.pending,
+        let tabs = providers
+            .iter()
+            .enumerate()
+            .map(|(index, info)| {
+                Button::new(SharedString::from(format!("login-tab-{}", info.slug)))
+                    .label(SharedString::from(info.name))
+                    .small()
+                    .ghost()
+                    .selected(index == self.tab)
+                    .flex_1()
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.tab = index;
+                        cx.notify();
+                    }))
             })
-            .collect();
+            .collect::<Vec<_>>();
+        let column = providers.into_iter().nth(self.tab).map(|info| Column {
+            slug: info.slug,
+            name: info.name,
+            options: info.options,
+            disabled: pending,
+            cancel: waiting && info.pending,
+        });
 
         let failure = match &state {
             SessionState::Failed(failure) => Some(failure.clone()),
@@ -451,18 +426,25 @@ impl Render for LoginView {
             .when_some(code, |this, (code, url)| {
                 this.child(self.code_prompt(code, url, cx).into_any_element())
             })
-            .child(
-                div()
-                    .flex()
-                    .items_start()
-                    .justify_center()
-                    .gap_8()
-                    .children(interleave(columns, cx, |column, cx| {
-                        self.column(column, cx).into_any_element()
-                    })),
-            )
-            .when(!guests.is_empty(), |this| {
-                this.child(self.guest_mode(guests, pending, cx))
+            .child(TabBar::new().w(COLUMN).items(tabs))
+            .when_some(column, |this, column| this.child(self.column(column, cx)))
+            .when_some(guest, |this, slug| {
+                this.child(
+                    div()
+                        .flex()
+                        .flex_col()
+                        .items_center()
+                        .gap_2()
+                        .w(COLUMN)
+                        .child(self.guest_mode(slug, pending, cx))
+                        .child(
+                            div()
+                                .text_center()
+                                .text_size(theme.text(Text::Small))
+                                .text_color(theme.muted_foreground)
+                                .child(t!("login-guest-detail")),
+                        ),
+                )
             })
             .when(secret, |this| {
                 this.child(self.secret_prompt(cx).into_any_element())
@@ -474,23 +456,4 @@ impl Render for LoginView {
                 this.child(self.account_modal(accounts, cx).into_any_element())
             })
     }
-}
-
-fn interleave<F>(
-    columns: Vec<Column>,
-    cx: &mut Context<LoginView>,
-    mut render: F,
-) -> Vec<AnyElement>
-where
-    F: FnMut(Column, &mut Context<LoginView>) -> AnyElement,
-{
-    let last = columns.len().saturating_sub(1);
-    let mut children = Vec::new();
-    for (index, column) in columns.into_iter().enumerate() {
-        children.push(render(column, cx));
-        if index < last {
-            children.push(Separator::vertical().h(RULE).into_any_element());
-        }
-    }
-    children
 }


### PR DESCRIPTION
## Summary

- add a segmented provider tab bar to sign-in
- add guest mode details and the shared borderless title bar
- keep custom Windows controls without native caption overlap