### PR TITLE
fix: startup theme, switch mount state and macos lyrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the focused window: light, medium or strong, for 90, 60 or 30 frames a second. It is off by
   default, and a change applies from the next launch.
 
+### Fixed
+
+- Switches appear already on or off when a screen opens, instead of sliding into place after it.
+
 ## [0.22.0] - 2026-08-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the focused window: light, medium or strong, for 90, 60 or 30 frames a second. It is off by
   default, and a change applies from the next launch.
 
+### Changed
+
+- The karaoke sweep advances on a clock of its own instead of following the display refresh rate,
+  so a fast panel no longer spends frames on it, and battery saving paces it too while Sonora is in
+  the background.
+
 ### Fixed
 
 - Switches appear already on or off when a screen opens, instead of sliding into place after it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Switches appear already on or off when a screen opens, instead of sliding into place after it.
+- With the theme set to System, Sonora no longer opens as a light window and fades into the dark
+  palette. It remembers what the system last reported and starts there.
 
 ## [0.22.0] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Switches appear already on or off when a screen opens, instead of sliding into place after it.
 - With the theme set to System, Sonora no longer opens as a light window and fades into the dark
   palette. It remembers what the system last reported and starts there.
+- On macOS the lyrics sheet showed only the lines around the one being sung. The rows it blurs
+  above and below render again.
 
 ## [0.22.0] - 2026-08-28
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1642,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2516,7 +2516,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "gpui_apple"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "anyhow",
  "block",
@@ -2610,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -2702,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2713,7 +2713,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "gpui",
  "gpui_linux",
@@ -2724,7 +2724,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "schemars",
  "serde",
@@ -2734,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "anyhow",
  "log",
@@ -2744,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2770,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -3038,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4102,7 +4102,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -5052,7 +5052,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "collections",
  "serde",
@@ -5903,7 +5903,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "derive_refineable",
 ]
@@ -6335,7 +6335,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "async-task",
  "backtrace",
@@ -7002,7 +7002,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "heapless",
  "log",
@@ -8150,7 +8150,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "perf",
  "quote",
@@ -9708,7 +9708,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9725,7 +9725,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -9736,7 +9736,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/gpui?rev=87d0ed566327d377abbc66cb5560facffafe884d#87d0ed566327d377abbc66cb5560facffafe884d"
+source = "git+https://github.com/nolight132/gpui?rev=19f299ddac4ac46ba89b8a07fc71a52989546f3f#19f299ddac4ac46ba89b8a07fc71a52989546f3f"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ env_logger = "0.11"
 fastrand = "2.5"
 futures = "0.3"
 fluent-bundle = "0.16"
-gpui = { git = "https://github.com/nolight132/gpui", rev = "87d0ed566327d377abbc66cb5560facffafe884d" }
-gpui_platform = { git = "https://github.com/nolight132/gpui", rev = "87d0ed566327d377abbc66cb5560facffafe884d", features = [
+gpui = { git = "https://github.com/nolight132/gpui", rev = "19f299ddac4ac46ba89b8a07fc71a52989546f3f" }
+gpui_platform = { git = "https://github.com/nolight132/gpui", rev = "19f299ddac4ac46ba89b8a07fc71a52989546f3f", features = [
   "font-kit",
   "wayland",
   "x11",

--- a/crates/sonora/src/main.rs
+++ b/crates/sonora/src/main.rs
@@ -17,6 +17,7 @@ use music::LyricsProvider;
 use router::Screen;
 use state::{Library, Playback, Queue, Session, Sonora};
 use ui::ActiveTheme as _;
+use ui::ThemeKind;
 use views::Root;
 
 const LEAST_SIZE: Size<Pixels> = size(px(480.), px(400.));
@@ -79,7 +80,7 @@ fn main() {
                 .destination()
         });
         router::init(start, cx);
-        let (look, overrides, language, stillness, pace) = {
+        let (look, overrides, language, stillness, pace, remembered) = {
             let settings = Sonora::global(cx).settings.read(cx);
             (
                 settings.look(),
@@ -87,10 +88,23 @@ fn main() {
                 settings.language().to_owned(),
                 settings.stillness(),
                 settings.pace(),
+                settings.system_theme(),
             )
         };
         i18n::set(i18n::resolve(&language));
         ui::motion::apply(stillness, pace, cx);
+        // linux answers late
+        let reported = match cfg!(any(target_os = "linux", target_os = "freebsd")) {
+            true => None,
+            false => Some(ThemeKind::reported(cx)),
+        };
+        ThemeKind::assume(reported.unwrap_or(remembered));
+        if let Some(reported) = reported.filter(|reported| *reported != remembered) {
+            Sonora::global(cx)
+                .settings
+                .clone()
+                .update(cx, |settings, cx| settings.set_system_theme(reported, cx));
+        }
         ui::Theme::init(look, &overrides, cx);
 
         actions::register(cx);

--- a/crates/state/src/settings.rs
+++ b/crates/state/src/settings.rs
@@ -187,6 +187,7 @@ struct Appearance {
     reduce_motion: String,
     motion_pace: String,
     battery_saver: String,
+    system_theme: String,
     theme_overrides: ThemeOverrides,
 }
 
@@ -250,6 +251,7 @@ impl Default for Appearance {
             reduce_motion: Stillness::default().id().to_owned(),
             motion_pace: Pace::default().id().to_owned(),
             battery_saver: Saver::default().id().to_owned(),
+            system_theme: ThemeKind::Dark.id().to_owned(),
             theme_overrides: ThemeOverrides::default(),
         }
     }
@@ -384,6 +386,10 @@ impl AppSettings {
 
     pub fn saver(&self) -> Saver {
         Saver::from_id(&self.values.appearance.battery_saver)
+    }
+
+    pub fn system_theme(&self) -> ThemeKind {
+        ThemeKind::from_id(&self.values.appearance.system_theme)
     }
 
     pub fn look(&self) -> Look {
@@ -676,6 +682,14 @@ impl AppSettings {
         }
         self.values.appearance.motion_pace = pace.id().to_owned();
         ui::motion::apply(self.stillness(), pace, cx);
+        self.schedule_save(cx);
+    }
+
+    pub fn set_system_theme(&mut self, kind: ThemeKind, cx: &mut Context<Self>) {
+        if self.system_theme() == kind {
+            return;
+        }
+        self.values.appearance.system_theme = kind.id().to_owned();
         self.schedule_save(cx);
     }
 

--- a/crates/ui/src/switch.rs
+++ b/crates/ui/src/switch.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use gpui::prelude::*;
 use gpui::{
     App, ClickEvent, Div, ElementId, Interactivity, Stateful, StyleRefinement, Window, div, px,
@@ -104,7 +106,7 @@ impl RenderOnce for Switch {
         };
 
         let movement = window.use_keyed_state((id, "movement"), cx, |_, _| Movement::new(checked));
-        let animates = movement.update(cx, |movement, _| movement.moved_since_mount(checked));
+        let animates = movement.update(cx, |movement, _| movement.turning(checked));
         let knob = div().size(thumb).flex_none().rounded(thumb / 2.);
 
         let mut switch = base
@@ -169,23 +171,24 @@ impl RenderOnce for Switch {
 
 struct Movement {
     drawn: bool,
-    moved: bool,
+    turned: Option<Instant>,
 }
 
 impl Movement {
     fn new(checked: bool) -> Self {
         Self {
             drawn: checked,
-            moved: false,
+            turned: None,
         }
     }
 
-    fn moved_since_mount(&mut self, checked: bool) -> bool {
+    fn turning(&mut self, checked: bool) -> bool {
         if self.drawn != checked {
             self.drawn = checked;
-            self.moved = true;
+            self.turned = Some(Instant::now());
         }
 
-        self.moved
+        self.turned
+            .is_some_and(|turned| turned.elapsed() < Motion::Control.span())
     }
 }

--- a/crates/ui/src/theme.rs
+++ b/crates/ui/src/theme.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::{Duration, Instant};
 
 use gpui::{App, Global, Hsla, Pixels, Rgba, SharedString, Task, WindowAppearance, px, rgb, rgba};
@@ -100,12 +101,41 @@ impl ThemeKind {
 
     pub fn resolved(self, cx: &App) -> Self {
         match self {
-            Self::System => match cx.window_appearance() {
-                WindowAppearance::Light | WindowAppearance::VibrantLight => Self::Light,
-                WindowAppearance::Dark | WindowAppearance::VibrantDark => Self::Dark,
-            },
+            Self::System => assumed().unwrap_or_else(|| Self::reported(cx)),
             kind => kind,
         }
+    }
+
+    pub fn reported(cx: &App) -> Self {
+        match cx.window_appearance() {
+            WindowAppearance::Light | WindowAppearance::VibrantLight => Self::Light,
+            WindowAppearance::Dark | WindowAppearance::VibrantDark => Self::Dark,
+        }
+    }
+
+    // what system means meanwhile
+    pub fn assume(kind: Self) {
+        ASSUMED.store(
+            match kind {
+                Self::Light => 1,
+                _ => 2,
+            },
+            Ordering::Relaxed,
+        );
+    }
+
+    pub fn assumed() -> Option<Self> {
+        assumed()
+    }
+}
+
+static ASSUMED: AtomicU8 = AtomicU8::new(0);
+
+fn assumed() -> Option<ThemeKind> {
+    match ASSUMED.load(Ordering::Relaxed) {
+        1 => Some(ThemeKind::Light),
+        2 => Some(ThemeKind::Dark),
+        _ => None,
     }
 }
 

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -471,11 +471,16 @@ impl Aside {
         cx.notify();
     }
 
-    fn sweep_karaoke(&mut self, cx: &mut Context<Self>) {
+    fn sweep_karaoke(&mut self, window: &Window, cx: &mut Context<Self>) {
         if self.sweeping.is_some() {
             return;
         }
-        let wait = KARAOKE_FRAME.saturating_sub(self.swept_frame.elapsed());
+        let saved = match window.is_window_active() {
+            true => None,
+            false => self.settings.read(cx).saver().interval(),
+        };
+        let interval = KARAOKE_FRAME.max(saved.unwrap_or_default());
+        let wait = interval.saturating_sub(self.swept_frame.elapsed());
         self.sweeping = Some(cx.spawn(async move |this, cx| {
             cx.background_executor().timer(wait).await;
             this.update(cx, |this, cx| {
@@ -1008,7 +1013,7 @@ impl Aside {
                     && karaoke_effects
                     && active_line.is_some_and(|index| lines[index].worded())
                 {
-                    self.sweep_karaoke(cx);
+                    self.sweep_karaoke(window, cx);
                 }
                 if self.previous_active_line != active_line {
                     if self.previous_active_line.is_some() {

--- a/crates/views/src/root.rs
+++ b/crates/views/src/root.rs
@@ -155,10 +155,16 @@ impl Root {
         window
             .observe_window_appearance(|_, cx| {
                 let settings = Sonora::global(cx).settings.clone();
-                let settings = settings.read(cx);
-                if ThemeKind::from_id(settings.theme()) != ThemeKind::System {
+                if ThemeKind::from_id(settings.read(cx).theme()) != ThemeKind::System {
                     return;
                 }
+                let reported = ThemeKind::reported(cx);
+                if ThemeKind::assumed() == Some(reported) {
+                    return;
+                }
+                ThemeKind::assume(reported);
+                settings.update(cx, |settings, cx| settings.set_system_theme(reported, cx));
+                let settings = settings.read(cx);
                 let look = Look {
                     tint: cx.theme().tint,
                     ..settings.look()


### PR DESCRIPTION
## Summary

- settle a switch on mount instead of animating it into place on every screen open
- pace the karaoke sweep with the battery saving cap while the window is unfocused
- remember what the system theme resolved to so a system theme no longer opens light and fades
- point gpui at the blur shrink and filter scissor fixes, which restore blurred lyrics rows on macos