### PR TITLE
chore(nix): point the flake at 0.23.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,15 +16,15 @@
       forEachSystem = fn: nixpkgs.lib.genAttrs systems (system: fn nixpkgs.legacyPackages.${system});
 
       release = {
-        version = "0.22.0";
+        version = "0.23.0";
         assets = {
           x86_64-linux = {
             target = "x86_64-unknown-linux-gnu";
-            hash = "sha256-Qj+pC7DtpEwwjWvUwO4IYwKsekPpqiqfdhFcpo05XuY=";
+            hash = "sha256-4slJg85gf0jnh3nUA1ghA8Z/h9eF1wJ4B3M5N0JQapU=";
           };
           aarch64-linux = {
             target = "aarch64-unknown-linux-gnu";
-            hash = "sha256-E53uqYNqDduwJvu132lciR1DG0Voz/ZgoAsQsHq90GY=";
+            hash = "sha256-jc8AFDxucNSiTM9Jt8wQ19I0Plbmrrv12UyGcfONjrM=";
           };
         };
       };


### PR DESCRIPTION
## Summary

- point the flake's release version and both linux asset hashes at 0.23.0