### PR TITLE
fix(state): refresh an open playlist after adding a track

### DIFF
--- a/crates/state/src/detail.rs
+++ b/crates/state/src/detail.rs
@@ -87,16 +87,20 @@ impl Detail {
         })
         .detach();
 
-        cx.subscribe(&library, |this, _, event, cx| {
-            let LibraryEvent::TrackDropped { playlist, track } = event else {
-                return;
-            };
-            if this.id.as_deref() != Some(playlist.as_str()) {
-                return;
+        cx.subscribe(&library, |this, _, event, cx| match event {
+            LibraryEvent::TrackAdded { playlist }
+                if this.id.as_deref() == Some(playlist.as_str()) =>
+            {
+                this.load(Collection::Playlist, playlist.clone(), cx);
             }
-            this.tracks
-                .retain(|shown| shown.id.as_deref() != Some(track.as_str()));
-            cx.notify();
+            LibraryEvent::TrackDropped { playlist, track }
+                if this.id.as_deref() == Some(playlist.as_str()) =>
+            {
+                this.tracks
+                    .retain(|shown| shown.id.as_deref() != Some(track.as_str()));
+                cx.notify();
+            }
+            _ => {}
         })
         .detach();
 

--- a/crates/state/src/library.rs
+++ b/crates/state/src/library.rs
@@ -221,6 +221,7 @@ impl Savable for SavedArtist {
 
 pub enum LibraryEvent {
     PlaylistGone(String),
+    TrackAdded { playlist: String },
     TrackDropped { playlist: String, track: String },
 }
 
@@ -551,6 +552,7 @@ impl Library {
                 if let Some(ids) = this.contents.get_mut(&added) {
                     ids.insert(held);
                 }
+                cx.emit(LibraryEvent::TrackAdded { playlist: added });
             },
             cx,
         );


### PR DESCRIPTION
## Summary

- refresh an open playlist after adding a track
- keep the displayed track list in sync with youtube music