### PR TITLE
release 0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.24.1] - 2026-08-29
+
 ### Added
 
 - Hovering an album card's title shows the full name, so two releases that share a truncated title
   can be told apart.
+
+### Fixed
+
+- A track added to the playlist you have open appears in it right away, instead of only after you
+  leave the page and come back.
 
 ## [0.24.0] - 2026-08-29
 
@@ -1091,7 +1098,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Initial release: a native Spotify client with playback, an interactive queue, the saved library,
 search, album, playlist, artist and song pages, context menus and adaptive theming.
 
-[unreleased]: https://github.com/nolight132/sonora/compare/v0.24.0...HEAD
+[unreleased]: https://github.com/nolight132/sonora/compare/v0.24.1...HEAD
+[0.24.1]: https://github.com/nolight132/sonora/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/nolight132/sonora/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/nolight132/sonora/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/nolight132/sonora/compare/v0.21.0...v0.22.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Hovering an album card's title shows the full name, so two releases that share a truncated title
+  can be told apart.
+
 ## [0.24.0] - 2026-08-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "i18n"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "fluent-bundle",
  "gpui",
@@ -3383,7 +3383,7 @@ dependencies = [
 
 [[package]]
 name = "input"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "gpui",
  "ui",
@@ -4217,7 +4217,7 @@ dependencies = [
 
 [[package]]
 name = "music"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6053,7 +6053,7 @@ dependencies = [
 
 [[package]]
 name = "router"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "gpui",
  "ui",
@@ -6799,7 +6799,7 @@ dependencies = [
 
 [[package]]
 name = "sonora"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -6929,7 +6929,7 @@ dependencies = [
 
 [[package]]
 name = "state"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7951,7 +7951,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "gpui",
  "i18n",
@@ -8276,7 +8276,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "views"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "gpui",
  "i18n",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.24.0"
+version = "0.24.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/nolight132/sonora"

--- a/crates/state/src/detail.rs
+++ b/crates/state/src/detail.rs
@@ -87,16 +87,20 @@ impl Detail {
         })
         .detach();
 
-        cx.subscribe(&library, |this, _, event, cx| {
-            let LibraryEvent::TrackDropped { playlist, track } = event else {
-                return;
-            };
-            if this.id.as_deref() != Some(playlist.as_str()) {
-                return;
+        cx.subscribe(&library, |this, _, event, cx| match event {
+            LibraryEvent::TrackAdded { playlist }
+                if this.id.as_deref() == Some(playlist.as_str()) =>
+            {
+                this.load(Collection::Playlist, playlist.clone(), cx);
             }
-            this.tracks
-                .retain(|shown| shown.id.as_deref() != Some(track.as_str()));
-            cx.notify();
+            LibraryEvent::TrackDropped { playlist, track }
+                if this.id.as_deref() == Some(playlist.as_str()) =>
+            {
+                this.tracks
+                    .retain(|shown| shown.id.as_deref() != Some(track.as_str()));
+                cx.notify();
+            }
+            _ => {}
         })
         .detach();
 

--- a/crates/state/src/library.rs
+++ b/crates/state/src/library.rs
@@ -221,6 +221,7 @@ impl Savable for SavedArtist {
 
 pub enum LibraryEvent {
     PlaylistGone(String),
+    TrackAdded { playlist: String },
     TrackDropped { playlist: String, track: String },
 }
 
@@ -551,6 +552,7 @@ impl Library {
                 if let Some(ids) = this.contents.get_mut(&added) {
                     ids.insert(held);
                 }
+                cx.emit(LibraryEvent::TrackAdded { playlist: added });
             },
             cx,
         );

--- a/crates/ui/src/card.rs
+++ b/crates/ui/src/card.rs
@@ -57,6 +57,7 @@ pub struct Card {
     loading: bool,
     tile: Option<Pixels>,
     play: Option<Press>,
+    hint: bool,
     underline: bool,
     playing: bool,
     action: Option<AnyElement>,
@@ -90,6 +91,7 @@ impl Card {
             loading: false,
             tile: None,
             play: None,
+            hint: false,
             underline: false,
             playing: false,
             action: None,
@@ -133,6 +135,11 @@ impl Card {
     ) -> Self {
         self.play = Some(Box::new(handler));
         self.playing = playing;
+        self
+    }
+
+    pub fn hint(mut self) -> Self {
+        self.hint = true;
         self
     }
 
@@ -286,6 +293,7 @@ impl RenderOnce for Card {
             loading,
             tile,
             play,
+            hint,
             underline,
             playing,
             action,
@@ -430,6 +438,9 @@ impl RenderOnce for Card {
             .when_some(weight, |this, weight| this.font_weight(weight))
             .when(underline, |this| {
                 this.group_hover(CARD_GROUP, |style| style.underline())
+            })
+            .when(hint && !title.is_empty(), |this| {
+                this.tooltip(Tooltip::label(title.clone(), Perch::Pointer))
             })
             .text_color(tint.unwrap_or(theme.foreground))
             .when_some(size, |this, size| this.text_size(theme.text(size)))

--- a/crates/ui/src/tooltip.rs
+++ b/crates/ui/src/tooltip.rs
@@ -17,7 +17,8 @@ pub enum Perch {
 }
 
 pub struct Tooltip {
-    key: SharedString,
+    text: SharedString,
+    raw: bool,
     perch: Perch,
     at: Point<Pixels>,
 }
@@ -25,7 +26,8 @@ pub struct Tooltip {
 impl Tooltip {
     pub fn new(key: impl Into<SharedString>, at: Point<Pixels>) -> Self {
         Self {
-            key: key.into(),
+            text: key.into(),
+            raw: false,
             perch: Perch::default(),
             at,
         }
@@ -33,6 +35,11 @@ impl Tooltip {
 
     pub fn perch(mut self, perch: Perch) -> Self {
         self.perch = perch;
+        self
+    }
+
+    pub fn raw(mut self) -> Self {
+        self.raw = true;
         self
     }
 
@@ -44,6 +51,18 @@ impl Tooltip {
         move |window, cx| {
             let at = window.mouse_position();
             cx.new(|_| Self::new(key.clone(), at).perch(perch)).into()
+        }
+    }
+
+    pub fn label(
+        text: impl Into<SharedString>,
+        perch: Perch,
+    ) -> impl Fn(&mut Window, &mut App) -> AnyView + 'static {
+        let text = text.into();
+        move |window, cx| {
+            let at = window.mouse_position();
+            cx.new(|_| Self::new(text.clone(), at).perch(perch).raw())
+                .into()
         }
     }
 }
@@ -74,7 +93,10 @@ impl Render for Tooltip {
                     .bg(theme.popover)
                     .text_size(theme.text(Text::Small))
                     .text_color(theme.popover_foreground)
-                    .child(i18n::lookup(&self.key, None)),
+                    .child(match self.raw {
+                        true => self.text.clone(),
+                        false => i18n::lookup(&self.text, None),
+                    }),
             )
     }
 }

--- a/crates/views/src/shared/cards.rs
+++ b/crates/views/src/shared/cards.rs
@@ -37,6 +37,7 @@ pub(crate) fn album_card(
         .cover(cover)
         .weight(FontWeight::SEMIBOLD)
         .underline()
+        .hint()
         .bare_meta(artists)
         .play(playing, move |_, _, cx| {
             toggled.update(cx, |playback, cx| playback.toggle_origin(&origin, cx));


### PR DESCRIPTION
## Summary

- add a title tooltip to album cards so releases with the same truncated name can be told apart
- refresh an open playlist after a track is added to it
- release 0.24.1