### PR TITLE
feat(music): use youtube home recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- YouTube Music listeners see their Listen Again history and personalized Quick Picks on Home.
+
+### Fixed
+
+- YouTube Music Quick Picks paginate when the window cannot fit all three columns and never reuse
+  recommendations from a previously connected Spotify account.
+
 ## [0.24.1] - 2026-08-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Saving or removing a song, album or artist that the service refuses now says so instead of
+  quietly flipping the control back.
+
 ## [0.24.1] - 2026-08-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -102,14 +102,14 @@ partial translation is welcome — pick a language below and fill in what it lac
 
 <!-- i18n:start -->
 
-| Language | Translated | Coverage |
-| --- | --- | --- |
-| English (`en-US`) | 439/439 | 100% |
-| Deutsch (`de`) | 439/439 | 100% |
-| Français (`fr`) | 439/439 | 100% |
-| Русский (`ru`) | 439/439 | 100% |
-| Українська (`uk`) | 439/439 | 100% |
-| Polski (`pl`) | 439/439 | 100% |
+| Language          | Translated | Coverage |
+| ----------------- | ---------- | -------- |
+| English (`en-US`) | 439/439    | 100%     |
+| Deutsch (`de`)    | 439/439    | 100%     |
+| Français (`fr`)   | 439/439    | 100%     |
+| Русский (`ru`)    | 439/439    | 100%     |
+| Українська (`uk`) | 439/439    | 100%     |
+| Polski (`pl`)     | 439/439    | 100%     |
 
 <!-- i18n:end -->
 

--- a/README.md
+++ b/README.md
@@ -102,14 +102,14 @@ partial translation is welcome — pick a language below and fill in what it lac
 
 <!-- i18n:start -->
 
-| Language          | Translated | Coverage |
-| ----------------- | ---------- | -------- |
-| English (`en-US`) | 433/433    | 100%     |
-| Deutsch (`de`)    | 433/433    | 100%     |
-| Français (`fr`)   | 433/433    | 100%     |
-| Русский (`ru`)    | 433/433    | 100%     |
-| Українська (`uk`) | 433/433    | 100%     |
-| Polski (`pl`)     | 433/433    | 100%     |
+| Language | Translated | Coverage |
+| --- | --- | --- |
+| English (`en-US`) | 439/439 | 100% |
+| Deutsch (`de`) | 439/439 | 100% |
+| Français (`fr`) | 439/439 | 100% |
+| Русский (`ru`) | 439/439 | 100% |
+| Українська (`uk`) | 439/439 | 100% |
+| Polski (`pl`) | 439/439 | 100% |
 
 <!-- i18n:end -->
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ partial translation is welcome — pick a language below and fill in what it lac
 
 | Language | Translated | Coverage |
 | --- | --- | --- |
-| English (`en-US`) | 439/439 | 100% |
-| Deutsch (`de`) | 439/439 | 100% |
-| Français (`fr`) | 439/439 | 100% |
-| Русский (`ru`) | 439/439 | 100% |
-| Українська (`uk`) | 439/439 | 100% |
-| Polski (`pl`) | 439/439 | 100% |
+| English (`en-US`) | 441/441 | 100% |
+| Deutsch (`de`) | 441/441 | 100% |
+| Français (`fr`) | 441/441 | 100% |
+| Русский (`ru`) | 441/441 | 100% |
+| Українська (`uk`) | 441/441 | 100% |
+| Polski (`pl`) | 441/441 | 100% |
 
 <!-- i18n:end -->
 

--- a/assets/i18n/de/main.ftl
+++ b/assets/i18n/de/main.ftl
@@ -488,6 +488,8 @@ toast-queue-failed = Das konnte nicht zur Warteschlange hinzugefügt werden
 toast-keys-refused = Spotify gibt diesem Konto keine Wiedergabeschlüssel
 toast-sign-in-to-play = { $name } streamt nur für angemeldete Hörer
 toast-track-unplayable = { $name } konnte nicht abgespielt werden
+toast-library-add-failed = { $name } konnte nicht zur Mediathek hinzugefügt werden
+toast-library-remove-failed = { $name } konnte nicht aus der Mediathek entfernt werden
 
 # lyrics
 lyrics-title = Songtext

--- a/assets/i18n/de/main.ftl
+++ b/assets/i18n/de/main.ftl
@@ -244,6 +244,7 @@ release-meta = { $year } • { $kind }
 
 # home page
 home-quick-picks = Schnellauswahl
+home-listen-again = Noch einmal anhören
 home-quick-picks-eyebrow = Mit einem Song starten
 home-quick-picks-empty = Markiere ein paar Songs als Favoriten, dann erscheinen sie hier
 

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -244,6 +244,7 @@ release-meta = { $year } • { $kind }
 
 # home page
 home-quick-picks = Quick picks
+home-listen-again = Listen again
 home-quick-picks-eyebrow = Start from a song
 home-quick-picks-empty = Like a few songs and they will show up here
 

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -488,6 +488,8 @@ toast-queue-failed = That could not be added to the queue
 toast-keys-refused = Spotify is not granting this account playback keys
 toast-sign-in-to-play = { $name } only streams to a signed-in listener
 toast-track-unplayable = { $name } could not be played
+toast-library-add-failed = { $name } could not be added to your library
+toast-library-remove-failed = { $name } could not be removed from your library
 
 # lyrics
 lyrics-title = Lyrics

--- a/assets/i18n/fr/main.ftl
+++ b/assets/i18n/fr/main.ftl
@@ -489,6 +489,8 @@ toast-queue-failed = Impossible d'ajouter cela à la file d'attente
 toast-keys-refused = Spotify n'accorde pas de clés de lecture à ce compte
 toast-sign-in-to-play = { $name } ne diffuse qu'aux auditeurs connectés
 toast-track-unplayable = { $name } n'a pas pu être lu
+toast-library-add-failed = { $name } n'a pas pu être ajouté à votre bibliothèque
+toast-library-remove-failed = { $name } n'a pas pu être retiré de votre bibliothèque
 
 # lyrics
 lyrics-title = Paroles

--- a/assets/i18n/fr/main.ftl
+++ b/assets/i18n/fr/main.ftl
@@ -245,6 +245,7 @@ release-meta = { $year } • { $kind }
 
 # home page
 home-quick-picks = Sélection rapide
+home-listen-again = Réécouter
 home-quick-picks-eyebrow = Commencer par un titre
 home-quick-picks-empty = Likez quelques titres et ils apparaîtront ici
 

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -499,6 +499,8 @@ toast-queue-failed = Nie udało się dodać do kolejki
 toast-keys-refused = Spotify nie udziela temu kontu kluczy odtwarzania
 toast-sign-in-to-play = { $name } udostępnia muzykę tylko po zalogowaniu
 toast-track-unplayable = Nie udało się odtworzyć { $name }
+toast-library-add-failed = Nie udało się dodać { $name } do biblioteki
+toast-library-remove-failed = Nie udało się usunąć { $name } z biblioteki
 
 # lyrics
 lyrics-title = Tekst

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -248,6 +248,7 @@ release-meta = { $year } • { $kind }
 
 # home page
 home-quick-picks = Szybki wybór
+home-listen-again = Posłuchaj ponownie
 home-quick-picks-eyebrow = Zacznij od utworu
 home-quick-picks-empty = Polub kilka utworów, a pojawią się tutaj
 

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -499,6 +499,8 @@ toast-queue-failed = Не удалось добавить в очередь
 toast-keys-refused = Spotify не выдаёт этому аккаунту ключи воспроизведения
 toast-sign-in-to-play = { $name } отдаёт музыку только тем, кто вошёл в аккаунт
 toast-track-unplayable = Не удалось воспроизвести { $name }
+toast-library-add-failed = Не удалось добавить { $name } в медиатеку
+toast-library-remove-failed = Не удалось удалить { $name } из медиатеки
 
 # lyrics
 lyrics-title = Текст

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -248,6 +248,7 @@ release-meta = { $year } • { $kind }
 
 # home page
 home-quick-picks = Быстрый выбор
+home-listen-again = Послушать снова
 home-quick-picks-eyebrow = Начните с трека
 home-quick-picks-empty = Добавьте несколько треков, и они появятся здесь
 

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -248,6 +248,7 @@ release-meta = { $year } • { $kind }
 
 # home page
 home-quick-picks = Швидкий вибір
+home-listen-again = Послухати знову
 home-quick-picks-eyebrow = Почніть із треку
 home-quick-picks-empty = Додайте кілька треків, і вони з'являться тут
 

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -499,6 +499,8 @@ toast-queue-failed = Не вдалося додати до черги
 toast-keys-refused = Spotify не надає цьому обліковому запису ключі відтворення
 toast-sign-in-to-play = { $name } віддає музику лише тим, хто увійшов в акаунт
 toast-track-unplayable = Не вдалося відтворити { $name }
+toast-library-add-failed = Не вдалося додати { $name } до медіатеки
+toast-library-remove-failed = Не вдалося вилучити { $name } з медіатеки
 
 # lyrics
 lyrics-title = Текст

--- a/crates/music/src/lib.rs
+++ b/crates/music/src/lib.rs
@@ -20,9 +20,9 @@ use async_trait::async_trait;
 
 pub use models::{
     Album, AlbumDetail, Artist, ArtistProfile, ArtistRef, Contributor, Credit, Genre, GenreDetail,
-    GenreItem, GenreSection, Lyrics, LyricsHit, LyricsLane, LyricsLine, LyricsQuery, LyricsWord,
-    Playlist, PlaylistDetail, ReleaseType, RomanizedText, SavedArtist, Track, TrackKey, UserDetail,
-    UserProfile, Voice, WritingSystem,
+    GenreItem, GenreSection, HomeFeed, Lyrics, LyricsHit, LyricsLane, LyricsLine, LyricsQuery,
+    LyricsWord, Playlist, PlaylistDetail, ReleaseType, RomanizedText, SavedArtist, Track, TrackKey,
+    UserDetail, UserProfile, Voice, WritingSystem,
 };
 
 pub const LOCAL_TRACK_PREFIX: &str = "local:";
@@ -109,8 +109,8 @@ pub trait MusicApi: Send + Sync {
         Ok(Vec::new())
     }
 
-    async fn home(&self) -> Result<Vec<GenreSection>> {
-        Ok(Vec::new())
+    async fn home(&self) -> Result<HomeFeed> {
+        Ok(HomeFeed::default())
     }
 
     async fn name_home_playlists(&self, sections: Vec<GenreSection>) -> Vec<GenreSection> {

--- a/crates/music/src/models.rs
+++ b/crates/music/src/models.rs
@@ -155,6 +155,13 @@ pub struct GenreSection {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct HomeFeed {
+    pub listen_again: Vec<Track>,
+    pub quick_picks: Vec<Track>,
+    pub sections: Vec<GenreSection>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct GenreDetail {
     pub name: String,
     pub sections: Vec<GenreSection>,

--- a/crates/music/src/models.rs
+++ b/crates/music/src/models.rs
@@ -157,7 +157,7 @@ pub struct GenreSection {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct HomeFeed {
     pub listen_again: Vec<Track>,
-    pub quick_picks: Vec<Track>,
+    pub quick_picks: Option<Vec<Track>>,
     pub sections: Vec<GenreSection>,
 }
 

--- a/crates/music/src/spotify/client.rs
+++ b/crates/music/src/spotify/client.rs
@@ -12,7 +12,7 @@ use crate::spotify::{
     search, wire,
 };
 use crate::{
-    Album, AlbumDetail, Artist, ArtistProfile, Genre, GenreDetail, GenreSection, Lyrics, Playlist,
+    Album, AlbumDetail, Artist, ArtistProfile, Genre, GenreDetail, HomeFeed, Lyrics, Playlist,
     PlaylistDetail, SavedArtist, Track, UserDetail, UserProfile,
 };
 
@@ -160,13 +160,16 @@ impl MusicApi for LibrespotClient {
         pathfinder::search_playlists(&self.session, query).await
     }
 
-    async fn home(&self) -> Result<Vec<GenreSection>> {
+    async fn home(&self) -> Result<HomeFeed> {
         let mut sections = pathfinder::genre(&self.session, MADE_FOR_YOU)
             .await?
             .sections;
         playlists::name_blanks(&self.session, &mut sections).await;
 
-        Ok(sections)
+        Ok(HomeFeed {
+            sections,
+            ..HomeFeed::default()
+        })
     }
 
     async fn genres(&self) -> Result<Vec<Genre>> {

--- a/crates/music/src/youtube/client.rs
+++ b/crates/music/src/youtube/client.rs
@@ -259,7 +259,10 @@ impl MusicApi for YouTubeClient {
             .album
             .playlist_id
             .context("album has no audio playlist")?;
-        self.api.rate_playlist(&playlist_id, saved).await
+        self.api
+            .rate_playlist(&playlist_id, saved)
+            .await
+            .with_context(|| format!("cannot rate the album {album_id} as {playlist_id}"))
     }
 
     async fn saved_artists(&self, _limit: u32) -> Result<Vec<SavedArtist>> {

--- a/crates/music/src/youtube/client.rs
+++ b/crates/music/src/youtube/client.rs
@@ -8,8 +8,8 @@ use ytmusic::YtMusic;
 
 use crate::youtube::{genres, wire};
 use crate::{
-    Album, AlbumDetail, Artist, ArtistProfile, Genre, GenreDetail, GenreSection, MediaKind,
-    MusicApi, Playlist, PlaylistDetail, SavedArtist, Track, UserProfile,
+    Album, AlbumDetail, Artist, ArtistProfile, Genre, GenreDetail, HomeFeed, MediaKind, MusicApi,
+    Playlist, PlaylistDetail, SavedArtist, Track, UserProfile,
 };
 
 const PORTRAIT_LIMIT: usize = 24;
@@ -337,7 +337,7 @@ impl MusicApi for YouTubeClient {
             .collect())
     }
 
-    async fn home(&self) -> Result<Vec<GenreSection>> {
+    async fn home(&self) -> Result<HomeFeed> {
         genres::home(&self.api).await
     }
 

--- a/crates/music/src/youtube/genres.rs
+++ b/crates/music/src/youtube/genres.rs
@@ -71,9 +71,7 @@ pub(crate) async fn genre(api: &YtMusic, params: &str) -> Result<GenreDetail> {
 }
 
 fn section(shelf: &Value) -> Option<GenreSection> {
-    let title = shelf
-        .run_text(&["header", "musicCarouselShelfBasicHeaderRenderer", "title"])
-        .unwrap_or_default();
+    let title = shelf_title(shelf).unwrap_or_default();
     let items: Vec<GenreItem> = shelf.items(&["contents"]).iter().filter_map(item).collect();
 
     (!items.is_empty()).then_some(GenreSection { title, items })
@@ -84,9 +82,7 @@ fn sections(answer: &Value) -> Vec<GenreSection> {
         .into_iter()
         .filter(|shelf| {
             !matches!(
-                shelf
-                    .run_text(&["header", "musicCarouselShelfBasicHeaderRenderer", "title"])
-                    .as_deref(),
+                shelf_title(shelf).as_deref(),
                 Some(LISTEN_AGAIN | QUICK_PICKS)
             )
         })
@@ -97,12 +93,7 @@ fn sections(answer: &Value) -> Vec<GenreSection> {
 fn tracks(answer: &Value, wanted: &str) -> Vec<Track> {
     let shelf = parse::find_renderers(answer, "musicCarouselShelfRenderer")
         .into_iter()
-        .find(|shelf| {
-            shelf
-                .run_text(&["header", "musicCarouselShelfBasicHeaderRenderer", "title"])
-                .as_deref()
-                == Some(wanted)
-        });
+        .find(|shelf| shelf_title(shelf).as_deref() == Some(wanted));
     let Some(shelf) = shelf else {
         return Vec::new();
     };
@@ -114,6 +105,10 @@ fn tracks(answer: &Value, wanted: &str) -> Vec<Track> {
         .enumerate()
         .map(|(index, track)| wire::track(track, index as u32))
         .collect()
+}
+
+fn shelf_title(shelf: &Value) -> Option<String> {
+    shelf.run_text(&["header", "musicCarouselShelfBasicHeaderRenderer", "title"])
 }
 
 fn track(item: &Value) -> Option<ytmusic::Track> {

--- a/crates/music/src/youtube/genres.rs
+++ b/crates/music/src/youtube/genres.rs
@@ -9,6 +9,7 @@ use crate::{Genre, GenreDetail, GenreItem, GenreSection, HomeFeed, Track};
 const HOME: &str = "FEmusic_home";
 const LISTEN_AGAIN: &str = "Listen again";
 const QUICK_PICKS: &str = "Quick picks";
+const QUICK_PICKS_LIMIT: usize = 15;
 const CATEGORIES: &str = "FEmusic_moods_and_genres";
 const CATEGORY: &str = "FEmusic_moods_and_genres_category";
 const THUMB: u32 = 120;
@@ -23,7 +24,10 @@ pub(crate) async fn home(api: &YtMusic) -> Result<HomeFeed> {
             .execute("browse", Client::Music, json!({ "continuation": token }))
             .await
         {
-            Ok(continued) => tracks(&continued, QUICK_PICKS),
+            Ok(continued) => tracks(&continued, QUICK_PICKS)
+                .into_iter()
+                .take(QUICK_PICKS_LIMIT)
+                .collect(),
             Err(error) => {
                 log::warn!("youtube: cannot load Quick picks: {error:#}");
                 Vec::new()

--- a/crates/music/src/youtube/genres.rs
+++ b/crates/music/src/youtube/genres.rs
@@ -33,7 +33,7 @@ pub(crate) async fn home(api: &YtMusic) -> Result<HomeFeed> {
     };
     Ok(HomeFeed {
         listen_again,
-        quick_picks,
+        quick_picks: Some(quick_picks),
         sections: sections(&answer),
     })
 }

--- a/crates/music/src/youtube/genres.rs
+++ b/crates/music/src/youtube/genres.rs
@@ -82,6 +82,14 @@ fn section(shelf: &Value) -> Option<GenreSection> {
 fn sections(answer: &Value) -> Vec<GenreSection> {
     parse::find_renderers(answer, "musicCarouselShelfRenderer")
         .into_iter()
+        .filter(|shelf| {
+            !matches!(
+                shelf
+                    .run_text(&["header", "musicCarouselShelfBasicHeaderRenderer", "title"])
+                    .as_deref(),
+                Some(LISTEN_AGAIN | QUICK_PICKS)
+            )
+        })
         .filter_map(section)
         .collect()
 }

--- a/crates/music/src/youtube/genres.rs
+++ b/crates/music/src/youtube/genres.rs
@@ -4,22 +4,38 @@ use ytmusic::nav::Nav as _;
 use ytmusic::{Client, YtMusic, parse};
 
 use crate::youtube::wire;
-use crate::{Genre, GenreDetail, GenreItem, GenreSection};
+use crate::{Genre, GenreDetail, GenreItem, GenreSection, HomeFeed, Track};
 
 const HOME: &str = "FEmusic_home";
+const LISTEN_AGAIN: &str = "Listen again";
+const QUICK_PICKS: &str = "Quick picks";
 const CATEGORIES: &str = "FEmusic_moods_and_genres";
 const CATEGORY: &str = "FEmusic_moods_and_genres_category";
 const THUMB: u32 = 120;
 
-pub(crate) async fn home(api: &YtMusic) -> Result<Vec<GenreSection>> {
+pub(crate) async fn home(api: &YtMusic) -> Result<HomeFeed> {
     let answer = api
         .execute("browse", Client::Music, json!({ "browseId": HOME }))
         .await?;
-
-    Ok(parse::find_renderers(&answer, "musicCarouselShelfRenderer")
-        .into_iter()
-        .filter_map(section)
-        .collect())
+    let listen_again = tracks(&answer, LISTEN_AGAIN);
+    let quick_picks = match continuation(&answer) {
+        Some(token) => match api
+            .execute("browse", Client::Music, json!({ "continuation": token }))
+            .await
+        {
+            Ok(continued) => tracks(&continued, QUICK_PICKS),
+            Err(error) => {
+                log::warn!("youtube: cannot load Quick picks: {error:#}");
+                Vec::new()
+            }
+        },
+        None => Vec::new(),
+    };
+    Ok(HomeFeed {
+        listen_again,
+        quick_picks,
+        sections: sections(&answer),
+    })
 }
 
 pub(crate) async fn genres(api: &YtMusic) -> Result<Vec<Genre>> {
@@ -61,6 +77,102 @@ fn section(shelf: &Value) -> Option<GenreSection> {
     let items: Vec<GenreItem> = shelf.items(&["contents"]).iter().filter_map(item).collect();
 
     (!items.is_empty()).then_some(GenreSection { title, items })
+}
+
+fn sections(answer: &Value) -> Vec<GenreSection> {
+    parse::find_renderers(answer, "musicCarouselShelfRenderer")
+        .into_iter()
+        .filter_map(section)
+        .collect()
+}
+
+fn tracks(answer: &Value, wanted: &str) -> Vec<Track> {
+    let shelf = parse::find_renderers(answer, "musicCarouselShelfRenderer")
+        .into_iter()
+        .find(|shelf| {
+            shelf
+                .run_text(&["header", "musicCarouselShelfBasicHeaderRenderer", "title"])
+                .as_deref()
+                == Some(wanted)
+        });
+    let Some(shelf) = shelf else {
+        return Vec::new();
+    };
+
+    shelf
+        .items(&["contents"])
+        .iter()
+        .filter_map(|item| parse::list_item_track(item).or_else(|| track(item)))
+        .enumerate()
+        .map(|(index, track)| wire::track(track, index as u32))
+        .collect()
+}
+
+fn track(item: &Value) -> Option<ytmusic::Track> {
+    let renderer = item.at(&["musicTwoRowItemRenderer"])?;
+    let page = renderer.str_at(&[
+        "navigationEndpoint",
+        "browseEndpoint",
+        "browseEndpointContextSupportedConfigs",
+        "browseEndpointContextMusicConfig",
+        "pageType",
+    ]);
+    if matches!(
+        page,
+        Some("MUSIC_PAGE_TYPE_ALBUM" | "MUSIC_PAGE_TYPE_PLAYLIST")
+    ) {
+        return None;
+    }
+
+    let endpoint = renderer.at(&[
+        "thumbnailOverlay",
+        "musicItemThumbnailOverlayRenderer",
+        "content",
+        "musicPlayButtonRenderer",
+        "playNavigationEndpoint",
+        "watchEndpoint",
+    ])?;
+    let video_id = endpoint.str_at(&["videoId"])?.to_owned();
+    let artists = parse::artist_runs(renderer.runs(&["subtitle"]));
+    let kind = match endpoint.str_at(&[
+        "watchEndpointMusicSupportedConfigs",
+        "watchEndpointMusicConfig",
+        "musicVideoType",
+    ]) {
+        Some("MUSIC_VIDEO_TYPE_ATV") => ytmusic::TrackKind::Song,
+        _ => ytmusic::TrackKind::Video,
+    };
+
+    Some(ytmusic::Track {
+        video_id: Some(video_id),
+        title: renderer.run_text(&["title"])?,
+        artists,
+        album: None,
+        duration: None,
+        thumbnails: parse::thumbnails(renderer),
+        explicit: parse::explicit(renderer),
+        available: true,
+        kind,
+        set_video_id: None,
+        liked: None,
+        views: None,
+    })
+}
+
+fn continuation(answer: &Value) -> Option<&str> {
+    answer.str_at(&[
+        "contents",
+        "singleColumnBrowseResultsRenderer",
+        "tabs",
+        "0",
+        "tabRenderer",
+        "content",
+        "sectionListRenderer",
+        "continuations",
+        "0",
+        "nextContinuationData",
+        "continuation",
+    ])
 }
 
 fn item(node: &Value) -> Option<GenreItem> {

--- a/crates/state/src/home.rs
+++ b/crates/state/src/home.rs
@@ -13,6 +13,7 @@ pub struct Home {
     library: Entity<Library>,
     session: Entity<Session>,
     io: Io,
+    listen_again: Rc<Vec<Track>>,
     quick_picks: Rc<Vec<Track>>,
     quick_picks_seed: u64,
     sections: Rc<Vec<GenreSection>>,
@@ -36,6 +37,7 @@ impl Home {
             SessionEvent::SignedOut => {
                 this.task = None;
                 this.naming = None;
+                this.listen_again = Rc::new(Vec::new());
                 this.sections = Rc::new(Vec::new());
                 this.feeding = false;
                 cx.notify();
@@ -62,6 +64,7 @@ impl Home {
             library,
             session,
             io,
+            listen_again: Rc::new(Vec::new()),
             quick_picks,
             quick_picks_seed,
             sections: Rc::new(Vec::new()),
@@ -97,9 +100,13 @@ impl Home {
             this.update(cx, |this, cx| {
                 this.feeding = false;
                 match loaded {
-                    Ok(sections) => {
-                        this.sections = Rc::new(pruned(&sections));
-                        this.name_playlists(sections, cx);
+                    Ok(feed) => {
+                        this.listen_again = Rc::new(feed.listen_again);
+                        if !feed.quick_picks.is_empty() {
+                            this.quick_picks = Rc::new(feed.quick_picks);
+                        }
+                        this.sections = Rc::new(pruned(&feed.sections));
+                        this.name_playlists(feed.sections, cx);
                     }
                     Err(error) => log::warn!("home: cannot load the feed: {error:#}"),
                 }
@@ -135,6 +142,10 @@ impl Home {
             })
             .ok();
         }));
+    }
+
+    pub fn listen_again(&self) -> Rc<Vec<Track>> {
+        self.listen_again.clone()
     }
 
     pub fn quick_picks(&self) -> Rc<Vec<Track>> {

--- a/crates/state/src/home.rs
+++ b/crates/state/src/home.rs
@@ -15,7 +15,6 @@ pub struct Home {
     io: Io,
     listen_again: Rc<Vec<Track>>,
     quick_picks: Rc<Vec<Track>>,
-    quick_picks_navigation: bool,
     quick_picks_seed: u64,
     sections: Rc<Vec<GenreSection>>,
     feeding: bool,
@@ -40,7 +39,6 @@ impl Home {
                 this.naming = None;
                 this.listen_again = Rc::new(Vec::new());
                 this.quick_picks = Rc::new(Vec::new());
-                this.quick_picks_navigation = true;
                 this.sections = Rc::new(Vec::new());
                 this.feeding = false;
                 cx.notify();
@@ -69,7 +67,6 @@ impl Home {
             io,
             listen_again: Rc::new(Vec::new()),
             quick_picks,
-            quick_picks_navigation: true,
             quick_picks_seed,
             sections: Rc::new(Vec::new()),
             feeding: false,
@@ -106,7 +103,6 @@ impl Home {
                 match loaded {
                     Ok(feed) => {
                         this.listen_again = Rc::new(feed.listen_again);
-                        this.quick_picks_navigation = feed.quick_picks.is_none();
                         if let Some(quick_picks) = feed.quick_picks {
                             this.quick_picks = Rc::new(quick_picks);
                         }
@@ -155,10 +151,6 @@ impl Home {
 
     pub fn quick_picks(&self) -> Rc<Vec<Track>> {
         self.quick_picks.clone()
-    }
-
-    pub fn quick_picks_navigation(&self) -> bool {
-        self.quick_picks_navigation
     }
 
     pub fn is_loading(&self, cx: &App) -> bool {

--- a/crates/state/src/home.rs
+++ b/crates/state/src/home.rs
@@ -39,6 +39,7 @@ impl Home {
                 this.task = None;
                 this.naming = None;
                 this.listen_again = Rc::new(Vec::new());
+                this.quick_picks = Rc::new(Vec::new());
                 this.quick_picks_paged = true;
                 this.sections = Rc::new(Vec::new());
                 this.feeding = false;

--- a/crates/state/src/home.rs
+++ b/crates/state/src/home.rs
@@ -15,6 +15,7 @@ pub struct Home {
     io: Io,
     listen_again: Rc<Vec<Track>>,
     quick_picks: Rc<Vec<Track>>,
+    quick_picks_paged: bool,
     quick_picks_seed: u64,
     sections: Rc<Vec<GenreSection>>,
     feeding: bool,
@@ -38,6 +39,7 @@ impl Home {
                 this.task = None;
                 this.naming = None;
                 this.listen_again = Rc::new(Vec::new());
+                this.quick_picks_paged = true;
                 this.sections = Rc::new(Vec::new());
                 this.feeding = false;
                 cx.notify();
@@ -66,6 +68,7 @@ impl Home {
             io,
             listen_again: Rc::new(Vec::new()),
             quick_picks,
+            quick_picks_paged: true,
             quick_picks_seed,
             sections: Rc::new(Vec::new()),
             feeding: false,
@@ -102,8 +105,9 @@ impl Home {
                 match loaded {
                     Ok(feed) => {
                         this.listen_again = Rc::new(feed.listen_again);
-                        if !feed.quick_picks.is_empty() {
-                            this.quick_picks = Rc::new(feed.quick_picks);
+                        this.quick_picks_paged = feed.quick_picks.is_none();
+                        if let Some(quick_picks) = feed.quick_picks {
+                            this.quick_picks = Rc::new(quick_picks);
                         }
                         this.sections = Rc::new(pruned(&feed.sections));
                         this.name_playlists(feed.sections, cx);
@@ -150,6 +154,10 @@ impl Home {
 
     pub fn quick_picks(&self) -> Rc<Vec<Track>> {
         self.quick_picks.clone()
+    }
+
+    pub fn quick_picks_paged(&self) -> bool {
+        self.quick_picks_paged
     }
 
     pub fn is_loading(&self, cx: &App) -> bool {

--- a/crates/state/src/home.rs
+++ b/crates/state/src/home.rs
@@ -15,7 +15,7 @@ pub struct Home {
     io: Io,
     listen_again: Rc<Vec<Track>>,
     quick_picks: Rc<Vec<Track>>,
-    quick_picks_paged: bool,
+    quick_picks_navigation: bool,
     quick_picks_seed: u64,
     sections: Rc<Vec<GenreSection>>,
     feeding: bool,
@@ -40,7 +40,7 @@ impl Home {
                 this.naming = None;
                 this.listen_again = Rc::new(Vec::new());
                 this.quick_picks = Rc::new(Vec::new());
-                this.quick_picks_paged = true;
+                this.quick_picks_navigation = true;
                 this.sections = Rc::new(Vec::new());
                 this.feeding = false;
                 cx.notify();
@@ -69,7 +69,7 @@ impl Home {
             io,
             listen_again: Rc::new(Vec::new()),
             quick_picks,
-            quick_picks_paged: true,
+            quick_picks_navigation: true,
             quick_picks_seed,
             sections: Rc::new(Vec::new()),
             feeding: false,
@@ -106,7 +106,7 @@ impl Home {
                 match loaded {
                     Ok(feed) => {
                         this.listen_again = Rc::new(feed.listen_again);
-                        this.quick_picks_paged = feed.quick_picks.is_none();
+                        this.quick_picks_navigation = feed.quick_picks.is_none();
                         if let Some(quick_picks) = feed.quick_picks {
                             this.quick_picks = Rc::new(quick_picks);
                         }
@@ -157,8 +157,8 @@ impl Home {
         self.quick_picks.clone()
     }
 
-    pub fn quick_picks_paged(&self) -> bool {
-        self.quick_picks_paged
+    pub fn quick_picks_navigation(&self) -> bool {
+        self.quick_picks_navigation
     }
 
     pub fn is_loading(&self, cx: &App) -> bool {

--- a/crates/state/src/library.rs
+++ b/crates/state/src/library.rs
@@ -103,11 +103,20 @@ impl Library {
             this.update(cx, |this, cx| {
                 S::requests(this).remove(&answered);
                 if let Err(error) = result {
+                    let name = match &previous {
+                        Some(previous) => previous.title().to_owned(),
+                        None => item.title().to_owned(),
+                    };
                     match previous {
                         Some(previous) => S::hold(this, previous, true),
                         None => S::hold(this, item, false),
                     }
                     log::warn!("library: cannot update the {}: {error:#}", S::TROUBLE);
+                    let key = match saved {
+                        true => "toast-library-add-failed",
+                        false => "toast-library-remove-failed",
+                    };
+                    Toasts::about(Outcome::Failed, key, name, cx);
                 }
                 cx.notify();
             })
@@ -122,6 +131,7 @@ trait Savable: Clone + Send + Sized + 'static {
     const TROUBLE: &'static str;
 
     fn id(&self) -> Option<&str>;
+    fn title(&self) -> &str;
     fn stamp_added(&mut self) {}
     fn saved_now(library: &Library, id: &str) -> Option<Self>;
     fn requests(library: &mut Library) -> &mut HashMap<String, Task<()>>;
@@ -138,6 +148,10 @@ impl Savable for Track {
 
     fn id(&self) -> Option<&str> {
         self.id.as_deref()
+    }
+
+    fn title(&self) -> &str {
+        &self.name
     }
 
     fn stamp_added(&mut self) {
@@ -174,6 +188,10 @@ impl Savable for Album {
         Some(&self.id)
     }
 
+    fn title(&self) -> &str {
+        &self.name
+    }
+
     fn saved_now(library: &Library, id: &str) -> Option<Self> {
         library.album(id).cloned()
     }
@@ -196,6 +214,10 @@ impl Savable for SavedArtist {
 
     fn id(&self) -> Option<&str> {
         Some(&self.id)
+    }
+
+    fn title(&self) -> &str {
+        &self.name
     }
 
     fn stamp_added(&mut self) {

--- a/crates/views/src/screens/home/listen_again.rs
+++ b/crates/views/src/screens/home/listen_again.rs
@@ -1,0 +1,219 @@
+use std::rc::Rc;
+
+use gpui::prelude::*;
+use gpui::{App, ClickEvent, Entity, MouseDownEvent, Pixels, SharedString, Window, div};
+use music::Track;
+use state::{Playback, PlaybackState};
+use ui::{ActiveTheme as _, Button, Card, Pinnable, Text, heading};
+
+use crate::shared::album_grid::{CardGrid, CardLayout};
+use crate::shared::cells;
+use crate::shared::pins::Pinned as _;
+
+type ClickHandler = Rc<dyn Fn(&ClickEvent, &mut Window, &mut App)>;
+type ContextHandler = Rc<dyn Fn(usize, &MouseDownEvent, &mut Window, &mut App)>;
+
+#[derive(Clone, Copy)]
+pub(super) struct Shape {
+    pub(super) columns: usize,
+    pub(super) pages: usize,
+}
+
+impl Shape {
+    pub(super) fn new(width: Pixels, count: usize) -> Self {
+        let columns = CardGrid::layout(width).columns;
+
+        Self {
+            columns,
+            pages: count.div_ceil(columns).max(1),
+        }
+    }
+}
+
+#[derive(IntoElement)]
+pub(super) struct ListenAgain {
+    tracks: Rc<Vec<Track>>,
+    playback: Entity<Playback>,
+    active: Option<String>,
+    width: Pixels,
+    page: usize,
+    on_previous: Option<ClickHandler>,
+    on_next: Option<ClickHandler>,
+    on_context_menu: Option<ContextHandler>,
+}
+
+impl ListenAgain {
+    pub(super) fn new(
+        tracks: Rc<Vec<Track>>,
+        playback: Entity<Playback>,
+        active: Option<String>,
+        width: Pixels,
+        page: usize,
+    ) -> Self {
+        Self {
+            tracks,
+            playback,
+            active,
+            width,
+            page,
+            on_previous: None,
+            on_next: None,
+            on_context_menu: None,
+        }
+    }
+
+    pub(super) fn on_previous(
+        mut self,
+        handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_previous = Some(Rc::new(handler));
+        self
+    }
+
+    pub(super) fn on_next(
+        mut self,
+        handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_next = Some(Rc::new(handler));
+        self
+    }
+
+    pub(super) fn on_context_menu(
+        mut self,
+        handler: impl Fn(usize, &MouseDownEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_context_menu = Some(Rc::new(handler));
+        self
+    }
+}
+
+impl RenderOnce for ListenAgain {
+    fn render(self, _: &mut Window, cx: &mut App) -> impl IntoElement {
+        let layout = CardGrid::layout(self.width);
+        let shape = Shape::new(self.width, self.tracks.len());
+        let page = self.page.min(shape.pages.saturating_sub(1));
+        let start = page * shape.columns;
+        let tracks = self.tracks;
+        let cards = tracks
+            .iter()
+            .enumerate()
+            .skip(start)
+            .take(shape.columns)
+            .map(|(place, track)| {
+                card(
+                    track,
+                    place,
+                    layout,
+                    tracks.clone(),
+                    self.playback.clone(),
+                    self.active.as_deref(),
+                    self.on_context_menu.clone(),
+                    cx,
+                )
+                .into_any_element()
+            });
+
+        div()
+            .w_full()
+            .flex()
+            .flex_col()
+            .gap_3()
+            .child(
+                div()
+                    .flex()
+                    .items_end()
+                    .justify_between()
+                    .gap_4()
+                    .child(heading(i18n::lookup("home-listen-again", None), cx))
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .gap_1()
+                            .child(
+                                Button::new("listen-again-previous")
+                                    .small()
+                                    .outline()
+                                    .icon("icons/chevron-left.svg")
+                                    .tooltip("common-previous")
+                                    .disabled(page == 0)
+                                    .when_some(self.on_previous, |button, handler| {
+                                        button.on_click(move |event, window, cx| {
+                                            handler(event, window, cx)
+                                        })
+                                    }),
+                            )
+                            .child(
+                                Button::new("listen-again-next")
+                                    .small()
+                                    .outline()
+                                    .icon("icons/chevron-right.svg")
+                                    .tooltip("common-next")
+                                    .disabled(page + 1 >= shape.pages)
+                                    .when_some(self.on_next, |button, handler| {
+                                        button.on_click(move |event, window, cx| {
+                                            handler(event, window, cx)
+                                        })
+                                    }),
+                            ),
+                    ),
+            )
+            .child(CardGrid::new(self.width).children(cards))
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn card(
+    track: &Track,
+    place: usize,
+    layout: CardLayout,
+    tracks: Rc<Vec<Track>>,
+    playback: Entity<Playback>,
+    active: Option<&str>,
+    on_context_menu: Option<ContextHandler>,
+    cx: &App,
+) -> Card {
+    let theme = *cx.theme();
+    let current = track.id.as_deref() == active;
+    let playing = current && playback.read(cx).state() == &PlaybackState::Playing;
+    let pin = track.pin();
+    let artists = cells::artist_links(
+        SharedString::new_static("listen-again-artist"),
+        track.artist_refs.clone(),
+        track.artists.clone(),
+        theme.muted_foreground,
+    )
+    .text_size(theme.text(Text::Small))
+    .truncate();
+    let pressed_tracks = tracks.clone();
+    let pressed_playback = playback.clone();
+    let transport_tracks = tracks.clone();
+    let transport_playback = playback.clone();
+
+    Card::new(
+        ("listen-again-card", place),
+        SharedString::from(track.name.clone()),
+    )
+    .cover(track.cover.clone())
+    .tile(layout.card)
+    .flat()
+    .weight(gpui::FontWeight::SEMIBOLD)
+    .hint()
+    .bare_meta(artists)
+    .when(track.explicit, Card::explicit)
+    .when_some(on_context_menu, |card, handler| {
+        card.menu(move |event, window, cx| handler(place, event, window, cx))
+    })
+    .play(playing, move |_, _, cx| match current {
+        true => transport_playback.update(cx, |playback, cx| playback.toggle_play(cx)),
+        false => transport_playback.update(cx, |playback, cx| {
+            playback.play_radio(&transport_tracks[place], cx);
+        }),
+    })
+    .press(move |_, _, cx| {
+        pressed_playback.update(cx, |playback, cx| {
+            playback.play_radio(&pressed_tracks[place], cx);
+        });
+    })
+    .when_some(pin, Pinnable::pin)
+}

--- a/crates/views/src/screens/home/listen_again.rs
+++ b/crates/views/src/screens/home/listen_again.rs
@@ -1,17 +1,15 @@
 use std::rc::Rc;
 
 use gpui::prelude::*;
-use gpui::{App, ClickEvent, Entity, MouseDownEvent, Pixels, SharedString, Window, div};
+use gpui::{App, ClickEvent, Entity, FontWeight, MouseDownEvent, Pixels, Window, div};
 use music::Track;
-use state::{Playback, PlaybackState};
-use ui::{ActiveTheme as _, Button, Card, Pinnable, Text, heading};
+use state::Playback;
+use ui::{Button, heading};
 
-use crate::shared::album_grid::{CardGrid, CardLayout};
-use crate::shared::cells;
-use crate::shared::pins::Pinned as _;
+use crate::shared::album_grid::CardGrid;
+use crate::shared::picks::{ContextHandler, track_card};
 
 type ClickHandler = Rc<dyn Fn(&ClickEvent, &mut Window, &mut App)>;
-type ContextHandler = Rc<dyn Fn(usize, &MouseDownEvent, &mut Window, &mut App)>;
 
 #[derive(Clone, Copy)]
 pub(super) struct Shape {
@@ -100,16 +98,22 @@ impl RenderOnce for ListenAgain {
             .skip(start)
             .take(shape.columns)
             .map(|(place, track)| {
-                card(
+                track_card(
                     track,
                     place,
-                    layout,
+                    "listen-again-card",
+                    false,
                     tracks.clone(),
                     self.playback.clone(),
                     self.active.as_deref(),
                     self.on_context_menu.clone(),
+                    None,
                     cx,
                 )
+                .tile(layout.card)
+                .flat()
+                .weight(FontWeight::SEMIBOLD)
+                .hint()
                 .into_any_element()
             });
 
@@ -160,60 +164,4 @@ impl RenderOnce for ListenAgain {
             )
             .child(CardGrid::new(self.width).children(cards))
     }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn card(
-    track: &Track,
-    place: usize,
-    layout: CardLayout,
-    tracks: Rc<Vec<Track>>,
-    playback: Entity<Playback>,
-    active: Option<&str>,
-    on_context_menu: Option<ContextHandler>,
-    cx: &App,
-) -> Card {
-    let theme = *cx.theme();
-    let current = track.id.as_deref() == active;
-    let playing = current && playback.read(cx).state() == &PlaybackState::Playing;
-    let pin = track.pin();
-    let artists = cells::artist_links(
-        SharedString::new_static("listen-again-artist"),
-        track.artist_refs.clone(),
-        track.artists.clone(),
-        theme.muted_foreground,
-    )
-    .text_size(theme.text(Text::Small))
-    .truncate();
-    let pressed_tracks = tracks.clone();
-    let pressed_playback = playback.clone();
-    let transport_tracks = tracks.clone();
-    let transport_playback = playback.clone();
-
-    Card::new(
-        ("listen-again-card", place),
-        SharedString::from(track.name.clone()),
-    )
-    .cover(track.cover.clone())
-    .tile(layout.card)
-    .flat()
-    .weight(gpui::FontWeight::SEMIBOLD)
-    .hint()
-    .bare_meta(artists)
-    .when(track.explicit, Card::explicit)
-    .when_some(on_context_menu, |card, handler| {
-        card.menu(move |event, window, cx| handler(place, event, window, cx))
-    })
-    .play(playing, move |_, _, cx| match current {
-        true => transport_playback.update(cx, |playback, cx| playback.toggle_play(cx)),
-        false => transport_playback.update(cx, |playback, cx| {
-            playback.play_radio(&transport_tracks[place], cx);
-        }),
-    })
-    .press(move |_, _, cx| {
-        pressed_playback.update(cx, |playback, cx| {
-            playback.play_radio(&pressed_tracks[place], cx);
-        });
-    })
-    .when_some(pin, Pinnable::pin)
 }

--- a/crates/views/src/screens/home/listen_again.rs
+++ b/crates/views/src/screens/home/listen_again.rs
@@ -7,7 +7,7 @@ use state::Playback;
 use ui::{Button, heading};
 
 use crate::shared::album_grid::CardGrid;
-use crate::shared::picks::{ContextHandler, track_card};
+use crate::shared::track_card::{ContextHandler, TrackCard};
 
 type ClickHandler = Rc<dyn Fn(&ClickEvent, &mut Window, &mut App)>;
 
@@ -97,19 +97,16 @@ impl RenderOnce for ListenAgain {
             .enumerate()
             .skip(start)
             .take(shape.columns)
-            .map(|(place, track)| {
-                track_card(
-                    track,
-                    place,
+            .map(|(place, _)| {
+                TrackCard::new(
                     "listen-again-card",
-                    false,
+                    place,
                     tracks.clone(),
                     self.playback.clone(),
                     self.active.as_deref(),
-                    self.on_context_menu.clone(),
-                    None,
-                    cx,
                 )
+                .context(self.on_context_menu.clone())
+                .render(cx)
                 .tile(layout.card)
                 .flat()
                 .weight(FontWeight::SEMIBOLD)

--- a/crates/views/src/screens/home/mod.rs
+++ b/crates/views/src/screens/home/mod.rs
@@ -27,13 +27,28 @@ pub(crate) struct HomeView {
     playback_status: PlaybackStatus,
     shelves: Entity<Shelves>,
     width: Pixels,
-    listen_again_columns: usize,
-    listen_again_page: usize,
-    quick_picks_columns: usize,
-    quick_picks_page: usize,
+    listen_again: Pager,
+    quick_picks: Pager,
     scrollbar: Entity<Scrollbar>,
     track_menu: ItemMenu,
     context_menu: Option<(Track, Point<Pixels>)>,
+}
+
+#[derive(Default)]
+struct Pager {
+    columns: usize,
+    page: usize,
+}
+
+impl Pager {
+    fn fit(&mut self, columns: usize, pages: usize) -> usize {
+        if self.columns != columns {
+            self.columns = columns;
+            self.page = 0;
+        }
+        self.page = self.page.min(pages.saturating_sub(1));
+        self.page
+    }
 }
 
 impl HomeView {
@@ -47,8 +62,8 @@ impl HomeView {
         let track_menu = ItemMenu::new(playlist_scrollbar);
 
         cx.observe(&home, |this, _, cx| {
-            this.listen_again_page = 0;
-            this.quick_picks_page = 0;
+            this.listen_again.page = 0;
+            this.quick_picks.page = 0;
             this.track_menu.reset(cx);
             this.context_menu = None;
             cx.notify();
@@ -79,10 +94,8 @@ impl HomeView {
             playback_status: current_playback,
             shelves,
             width: Pixels::ZERO,
-            listen_again_columns: 0,
-            listen_again_page: 0,
-            quick_picks_columns: 0,
-            quick_picks_page: 0,
+            listen_again: Pager::default(),
+            quick_picks: Pager::default(),
             scrollbar: cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(me)),
             track_menu,
             context_menu: None,
@@ -99,23 +112,15 @@ impl Render for HomeView {
         }
         let listen_again = self.home.read(cx).listen_again();
         let listen_shape = ListenAgainShape::new(available, listen_again.len());
-        if self.listen_again_columns != listen_shape.columns {
-            self.listen_again_columns = listen_shape.columns;
-            self.listen_again_page = 0;
-        }
         let listen_pages = listen_shape.pages;
-        self.listen_again_page = self.listen_again_page.min(listen_pages.saturating_sub(1));
-        let listen_page = self.listen_again_page;
+        let listen_page = self
+            .listen_again
+            .fit(listen_shape.columns, listen_shape.pages);
 
         let quick_picks = self.home.read(cx).quick_picks();
         let quick_shape = Shape::new(available, quick_picks.len());
-        if self.quick_picks_columns != quick_shape.columns {
-            self.quick_picks_columns = quick_shape.columns;
-            self.quick_picks_page = 0;
-        }
         let quick_pages = quick_shape.pages;
-        self.quick_picks_page = self.quick_picks_page.min(quick_pages.saturating_sub(1));
-        let quick_page = self.quick_picks_page;
+        let quick_page = self.quick_picks.fit(quick_shape.columns, quick_shape.pages);
         let context_menu = self.context_menu.clone().map(|(track, position)| {
             Popup::new(position, self.track_menu.for_track(&track, cx)).on_close(cx.listener(
                 |this, _, _, cx| {
@@ -136,13 +141,13 @@ impl Render for HomeView {
                 listen_page,
             )
             .on_previous(cx.listener(|this, _, _, cx| {
-                this.listen_again_page = this.listen_again_page.saturating_sub(1);
+                this.listen_again.page = this.listen_again.page.saturating_sub(1);
                 this.context_menu = None;
                 cx.notify();
             }))
             .on_next(cx.listener(move |this, _, _, cx| {
-                this.listen_again_page =
-                    (this.listen_again_page + 1).min(listen_pages.saturating_sub(1));
+                this.listen_again.page =
+                    (this.listen_again.page + 1).min(listen_pages.saturating_sub(1));
                 this.context_menu = None;
                 cx.notify();
             }))
@@ -166,12 +171,12 @@ impl Render for HomeView {
         .vacancy("home-quick-picks-empty")
         .loading(self.home.read(cx).is_loading(cx))
         .on_previous(cx.listener(|this, _, _, cx| {
-            this.quick_picks_page = this.quick_picks_page.saturating_sub(1);
+            this.quick_picks.page = this.quick_picks.page.saturating_sub(1);
             this.context_menu = None;
             cx.notify();
         }))
         .on_next(cx.listener(move |this, _, _, cx| {
-            this.quick_picks_page = (this.quick_picks_page + 1).min(quick_pages.saturating_sub(1));
+            this.quick_picks.page = (this.quick_picks.page + 1).min(quick_pages.saturating_sub(1));
             this.context_menu = None;
             cx.notify();
         }))

--- a/crates/views/src/screens/home/mod.rs
+++ b/crates/views/src/screens/home/mod.rs
@@ -103,6 +103,7 @@ impl Render for HomeView {
         let listen_page = self.listen_again_page;
 
         let quick_picks = self.home.read(cx).quick_picks();
+        let quick_picks_paged = self.home.read(cx).quick_picks_paged();
         let quick_shape = Shape::new(available, quick_picks.len());
         if self.quick_picks_columns != quick_shape.columns {
             self.quick_picks_columns = quick_shape.columns;
@@ -170,6 +171,7 @@ impl Render for HomeView {
         .eyebrow("home-quick-picks-eyebrow")
         .vacancy("home-quick-picks-empty")
         .loading(self.home.read(cx).is_loading(cx))
+        .paged(quick_picks_paged)
         .on_previous(cx.listener(|this, _, _, cx| {
             this.quick_picks_page = this.quick_picks_page.saturating_sub(1);
             this.context_menu = None;

--- a/crates/views/src/screens/home/mod.rs
+++ b/crates/views/src/screens/home/mod.rs
@@ -1,9 +1,14 @@
 mod listen_again;
 
+use std::rc::Rc;
+
 use crate::chrome::Chrome;
 use crate::shared::menu::ItemMenu;
 use gpui::prelude::*;
-use gpui::{Context, Entity, Pixels, Point, Render, ScrollHandle, Window, div, px};
+use gpui::{
+    Context, Entity, MouseDownEvent, Pixels, Point, Render, ScrollHandle, WeakEntity, Window, div,
+    px,
+};
 use music::Track;
 use state::{Home, Playback, Sonora};
 use ui::{ActiveTheme as _, Mode, Popup, Scrollbar, Scroller};
@@ -103,7 +108,7 @@ impl Render for HomeView {
         let listen_page = self.listen_again_page;
 
         let quick_picks = self.home.read(cx).quick_picks();
-        let quick_picks_paged = self.home.read(cx).quick_picks_paged();
+        let quick_picks_navigation = self.home.read(cx).quick_picks_navigation();
         let quick_shape = Shape::new(available, quick_picks.len());
         if self.quick_picks_columns != quick_shape.columns {
             self.quick_picks_columns = quick_shape.columns;
@@ -143,17 +148,7 @@ impl Render for HomeView {
                 cx.notify();
             }))
             .on_context_menu(move |place, event, _, cx| {
-                let Some(track) = tracks.get(place).cloned() else {
-                    return;
-                };
-                let Some(home) = home.upgrade() else {
-                    return;
-                };
-                home.update(cx, |this, cx| {
-                    this.track_menu.reset(cx);
-                    this.context_menu = Some((track, event.position));
-                    cx.notify();
-                });
+                open_menu(&home, &tracks, place, event, cx);
             })
         });
 
@@ -171,7 +166,7 @@ impl Render for HomeView {
         .eyebrow("home-quick-picks-eyebrow")
         .vacancy("home-quick-picks-empty")
         .loading(self.home.read(cx).is_loading(cx))
-        .paged(quick_picks_paged)
+        .navigation(quick_picks_navigation)
         .on_previous(cx.listener(|this, _, _, cx| {
             this.quick_picks_page = this.quick_picks_page.saturating_sub(1);
             this.context_menu = None;
@@ -183,17 +178,7 @@ impl Render for HomeView {
             cx.notify();
         }))
         .on_context_menu(move |place, event, _, cx| {
-            let Some(track) = tracks.get(place).cloned() else {
-                return;
-            };
-            let Some(home) = home.upgrade() else {
-                return;
-            };
-            home.update(cx, |this, cx| {
-                this.track_menu.reset(cx);
-                this.context_menu = Some((track, event.position));
-                cx.notify();
-            });
+            open_menu(&home, &tracks, place, event, cx);
         });
 
         let sections = self.home.read(cx).sections();
@@ -221,4 +206,24 @@ impl Render for HomeView {
             )
             .when_some(context_menu, |this, menu| this.child(menu))
     }
+}
+
+fn open_menu(
+    home: &WeakEntity<HomeView>,
+    tracks: &Rc<Vec<Track>>,
+    place: usize,
+    event: &MouseDownEvent,
+    cx: &mut gpui::App,
+) {
+    let Some(track) = tracks.get(place).cloned() else {
+        return;
+    };
+    let Some(home) = home.upgrade() else {
+        return;
+    };
+    home.update(cx, |this, cx| {
+        this.track_menu.reset(cx);
+        this.context_menu = Some((track, event.position));
+        cx.notify();
+    });
 }

--- a/crates/views/src/screens/home/mod.rs
+++ b/crates/views/src/screens/home/mod.rs
@@ -108,7 +108,6 @@ impl Render for HomeView {
         let listen_page = self.listen_again_page;
 
         let quick_picks = self.home.read(cx).quick_picks();
-        let quick_picks_navigation = self.home.read(cx).quick_picks_navigation();
         let quick_shape = Shape::new(available, quick_picks.len());
         if self.quick_picks_columns != quick_shape.columns {
             self.quick_picks_columns = quick_shape.columns;
@@ -166,7 +165,6 @@ impl Render for HomeView {
         .eyebrow("home-quick-picks-eyebrow")
         .vacancy("home-quick-picks-empty")
         .loading(self.home.read(cx).is_loading(cx))
-        .navigation(quick_picks_navigation)
         .on_previous(cx.listener(|this, _, _, cx| {
             this.quick_picks_page = this.quick_picks_page.saturating_sub(1);
             this.context_menu = None;

--- a/crates/views/src/screens/home/mod.rs
+++ b/crates/views/src/screens/home/mod.rs
@@ -1,7 +1,10 @@
+mod listen_again;
+
 use crate::chrome::Chrome;
 use crate::shared::menu::ItemMenu;
 use gpui::prelude::*;
 use gpui::{Context, Entity, Pixels, Point, Render, ScrollHandle, Window, div, px};
+use music::Track;
 use state::{Home, Playback, Sonora};
 use ui::{ActiveTheme as _, Mode, Popup, Scrollbar, Scroller};
 
@@ -9,6 +12,7 @@ use crate::shared::cells;
 use crate::shared::picks::{Picks, Shape};
 use crate::shared::shelves::Shelves;
 use crate::shared::tracks::{PlaybackStatus, playback_status};
+use listen_again::{ListenAgain, Shape as ListenAgainShape};
 
 const STEADY: Pixels = px(0.5);
 
@@ -18,11 +22,13 @@ pub(crate) struct HomeView {
     playback_status: PlaybackStatus,
     shelves: Entity<Shelves>,
     width: Pixels,
+    listen_again_columns: usize,
+    listen_again_page: usize,
     quick_picks_columns: usize,
     quick_picks_page: usize,
     scrollbar: Entity<Scrollbar>,
     track_menu: ItemMenu,
-    context_menu: Option<(usize, Point<Pixels>)>,
+    context_menu: Option<(Track, Point<Pixels>)>,
 }
 
 impl HomeView {
@@ -36,6 +42,7 @@ impl HomeView {
         let track_menu = ItemMenu::new(playlist_scrollbar);
 
         cx.observe(&home, |this, _, cx| {
+            this.listen_again_page = 0;
             this.quick_picks_page = 0;
             this.track_menu.reset(cx);
             this.context_menu = None;
@@ -67,6 +74,8 @@ impl HomeView {
             playback_status: current_playback,
             shelves,
             width: Pixels::ZERO,
+            listen_again_columns: 0,
+            listen_again_page: 0,
             quick_picks_columns: 0,
             quick_picks_page: 0,
             scrollbar: cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(me)),
@@ -83,27 +92,106 @@ impl Render for HomeView {
         if (available - self.width).abs() >= STEADY {
             self.width = available;
         }
-        let tracks = self.home.read(cx).quick_picks();
-        let shape = Shape::new(available, tracks.len());
-        if self.quick_picks_columns != shape.columns {
-            self.quick_picks_columns = shape.columns;
+        let listen_again = self.home.read(cx).listen_again();
+        let listen_shape = ListenAgainShape::new(available, listen_again.len());
+        if self.listen_again_columns != listen_shape.columns {
+            self.listen_again_columns = listen_shape.columns;
+            self.listen_again_page = 0;
+        }
+        let listen_pages = listen_shape.pages;
+        self.listen_again_page = self.listen_again_page.min(listen_pages.saturating_sub(1));
+        let listen_page = self.listen_again_page;
+
+        let quick_picks = self.home.read(cx).quick_picks();
+        let quick_shape = Shape::new(available, quick_picks.len());
+        if self.quick_picks_columns != quick_shape.columns {
+            self.quick_picks_columns = quick_shape.columns;
             self.quick_picks_page = 0;
         }
-
-        let pages = shape.pages;
-        self.quick_picks_page = self.quick_picks_page.min(pages.saturating_sub(1));
-        let page = self.quick_picks_page;
-        let home = cx.entity().downgrade();
-        let selected = self.context_menu.and_then(|(place, position)| {
-            tracks.get(place).cloned().map(|track| (track, position))
-        });
-        let context_menu = selected.map(|(track, position)| {
+        let quick_pages = quick_shape.pages;
+        self.quick_picks_page = self.quick_picks_page.min(quick_pages.saturating_sub(1));
+        let quick_page = self.quick_picks_page;
+        let context_menu = self.context_menu.clone().map(|(track, position)| {
             Popup::new(position, self.track_menu.for_track(&track, cx)).on_close(cx.listener(
                 |this, _, _, cx| {
                     this.context_menu = None;
                     cx.notify();
                 },
             ))
+        });
+
+        let listen = (!listen_again.is_empty()).then(|| {
+            let tracks = listen_again.clone();
+            let home = cx.entity().downgrade();
+            ListenAgain::new(
+                listen_again,
+                self.playback.clone(),
+                self.playback_status.0.clone(),
+                available,
+                listen_page,
+            )
+            .on_previous(cx.listener(|this, _, _, cx| {
+                this.listen_again_page = this.listen_again_page.saturating_sub(1);
+                this.context_menu = None;
+                cx.notify();
+            }))
+            .on_next(cx.listener(move |this, _, _, cx| {
+                this.listen_again_page =
+                    (this.listen_again_page + 1).min(listen_pages.saturating_sub(1));
+                this.context_menu = None;
+                cx.notify();
+            }))
+            .on_context_menu(move |place, event, _, cx| {
+                let Some(track) = tracks.get(place).cloned() else {
+                    return;
+                };
+                let Some(home) = home.upgrade() else {
+                    return;
+                };
+                home.update(cx, |this, cx| {
+                    this.track_menu.reset(cx);
+                    this.context_menu = Some((track, event.position));
+                    cx.notify();
+                });
+            })
+        });
+
+        let tracks = quick_picks.clone();
+        let home = cx.entity().downgrade();
+        let quick = Picks::new(
+            "quick-pick",
+            quick_picks,
+            self.playback.clone(),
+            self.playback_status.0.clone(),
+            available,
+            quick_page,
+        )
+        .title("home-quick-picks")
+        .eyebrow("home-quick-picks-eyebrow")
+        .vacancy("home-quick-picks-empty")
+        .loading(self.home.read(cx).is_loading(cx))
+        .on_previous(cx.listener(|this, _, _, cx| {
+            this.quick_picks_page = this.quick_picks_page.saturating_sub(1);
+            this.context_menu = None;
+            cx.notify();
+        }))
+        .on_next(cx.listener(move |this, _, _, cx| {
+            this.quick_picks_page = (this.quick_picks_page + 1).min(quick_pages.saturating_sub(1));
+            this.context_menu = None;
+            cx.notify();
+        }))
+        .on_context_menu(move |place, event, _, cx| {
+            let Some(track) = tracks.get(place).cloned() else {
+                return;
+            };
+            let Some(home) = home.upgrade() else {
+                return;
+            };
+            home.update(cx, |this, cx| {
+                this.track_menu.reset(cx);
+                this.context_menu = Some((track, event.position));
+                cx.notify();
+            });
         });
 
         let sections = self.home.read(cx).sections();
@@ -125,41 +213,8 @@ impl Render for HomeView {
                     .flex()
                     .flex_col()
                     .gap_8()
-                    .child(
-                        Picks::new(
-                            "quick-pick",
-                            tracks,
-                            self.playback.clone(),
-                            self.playback_status.0.clone(),
-                            available,
-                            page,
-                        )
-                        .title("home-quick-picks")
-                        .eyebrow("home-quick-picks-eyebrow")
-                        .vacancy("home-quick-picks-empty")
-                        .loading(self.home.read(cx).is_loading(cx))
-                        .on_previous(cx.listener(|this, _, _, cx| {
-                            this.quick_picks_page = this.quick_picks_page.saturating_sub(1);
-                            this.context_menu = None;
-                            cx.notify();
-                        }))
-                        .on_next(cx.listener(move |this, _, _, cx| {
-                            this.quick_picks_page =
-                                (this.quick_picks_page + 1).min(pages.saturating_sub(1));
-                            this.context_menu = None;
-                            cx.notify();
-                        }))
-                        .on_context_menu(move |place, event, _, cx| {
-                            let Some(home) = home.upgrade() else {
-                                return;
-                            };
-                            home.update(cx, |this, cx| {
-                                this.track_menu.reset(cx);
-                                this.context_menu = Some((place, event.position));
-                                cx.notify();
-                            });
-                        }),
-                    )
+                    .children(listen)
+                    .child(quick)
                     .children(shelves),
             )
             .when_some(context_menu, |this, menu| this.child(menu))

--- a/crates/views/src/shared/mod.rs
+++ b/crates/views/src/shared/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod pins;
 pub(crate) mod playlist_editor;
 pub(crate) mod shelves;
 pub(crate) mod text;
+pub(crate) mod track_card;
 pub(crate) mod tracks;
 pub(crate) mod transport;
 pub(crate) mod trouble;

--- a/crates/views/src/shared/picks.rs
+++ b/crates/views/src/shared/picks.rs
@@ -57,7 +57,6 @@ pub(crate) struct Picks {
     page: usize,
     detailed: bool,
     loading: bool,
-    navigation: bool,
     on_previous: Option<ClickHandler>,
     on_next: Option<ClickHandler>,
     on_context_menu: Option<ContextHandler>,
@@ -85,7 +84,6 @@ impl Picks {
             page,
             detailed: false,
             loading: false,
-            navigation: true,
             on_previous: None,
             on_next: None,
             on_context_menu: None,
@@ -115,11 +113,6 @@ impl Picks {
 
     pub(crate) fn loading(mut self, loading: bool) -> Self {
         self.loading = loading;
-        self
-    }
-
-    pub(crate) fn navigation(mut self, navigation: bool) -> Self {
-        self.navigation = navigation;
         self
     }
 
@@ -195,40 +188,38 @@ impl RenderOnce for Picks {
                             .children(self.eyebrow.map(|key| eyebrow(i18n::lookup(key, None), cx)))
                             .child(heading(i18n::lookup(self.title, None), cx)),
                     )
-                    .when(self.navigation, |this| {
-                        this.child(
-                            div()
-                                .flex()
-                                .items_center()
-                                .gap_1()
-                                .child(
-                                    Button::new(SharedString::from(format!("{id}-previous")))
-                                        .small()
-                                        .outline()
-                                        .icon("icons/chevron-left.svg")
-                                        .tooltip("common-previous")
-                                        .disabled(empty || page == 0)
-                                        .when_some(on_previous, |button, handler| {
-                                            button.on_click(move |event, window, cx| {
-                                                handler(event, window, cx)
-                                            })
-                                        }),
-                                )
-                                .child(
-                                    Button::new(SharedString::from(format!("{id}-next")))
-                                        .small()
-                                        .outline()
-                                        .icon("icons/chevron-right.svg")
-                                        .tooltip("common-next")
-                                        .disabled(empty || page + 1 >= shape.pages)
-                                        .when_some(on_next, |button, handler| {
-                                            button.on_click(move |event, window, cx| {
-                                                handler(event, window, cx)
-                                            })
-                                        }),
-                                ),
-                        )
-                    }),
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .gap_1()
+                            .child(
+                                Button::new(SharedString::from(format!("{id}-previous")))
+                                    .small()
+                                    .outline()
+                                    .icon("icons/chevron-left.svg")
+                                    .tooltip("common-previous")
+                                    .disabled(empty || page == 0)
+                                    .when_some(on_previous, |button, handler| {
+                                        button.on_click(move |event, window, cx| {
+                                            handler(event, window, cx)
+                                        })
+                                    }),
+                            )
+                            .child(
+                                Button::new(SharedString::from(format!("{id}-next")))
+                                    .small()
+                                    .outline()
+                                    .icon("icons/chevron-right.svg")
+                                    .tooltip("common-next")
+                                    .disabled(empty || page + 1 >= shape.pages)
+                                    .when_some(on_next, |button, handler| {
+                                        button.on_click(move |event, window, cx| {
+                                            handler(event, window, cx)
+                                        })
+                                    }),
+                            ),
+                    ),
             )
             .when(barren, |this| {
                 this.child(vacant(i18n::lookup(self.vacancy, None), cx))

--- a/crates/views/src/shared/picks.rs
+++ b/crates/views/src/shared/picks.rs
@@ -191,18 +191,16 @@ impl RenderOnce for Picks {
                     .py_2()
                     .border_b_1()
                     .border_color(theme.border)
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap_0p5()
+                            .children(self.eyebrow.map(|key| eyebrow(i18n::lookup(key, None), cx)))
+                            .child(heading(i18n::lookup(self.title, None), cx)),
+                    )
                     .when(self.paged, |this| {
                         this.child(
-                            div()
-                                .flex()
-                                .flex_col()
-                                .gap_0p5()
-                                .children(
-                                    self.eyebrow.map(|key| eyebrow(i18n::lookup(key, None), cx)),
-                                )
-                                .child(heading(i18n::lookup(self.title, None), cx)),
-                        )
-                        .child(
                             div()
                                 .flex()
                                 .items_center()

--- a/crates/views/src/shared/picks.rs
+++ b/crates/views/src/shared/picks.rs
@@ -57,6 +57,7 @@ pub(crate) struct Picks {
     page: usize,
     detailed: bool,
     loading: bool,
+    paged: bool,
     on_previous: Option<ClickHandler>,
     on_next: Option<ClickHandler>,
     on_context_menu: Option<ContextHandler>,
@@ -84,6 +85,7 @@ impl Picks {
             page,
             detailed: false,
             loading: false,
+            paged: true,
             on_previous: None,
             on_next: None,
             on_context_menu: None,
@@ -113,6 +115,11 @@ impl Picks {
 
     pub(crate) fn loading(mut self, loading: bool) -> Self {
         self.loading = loading;
+        self
+    }
+
+    pub(crate) fn paged(mut self, paged: bool) -> Self {
+        self.paged = paged;
         self
     }
 
@@ -152,6 +159,10 @@ impl RenderOnce for Picks {
         let shape = Shape::new(self.width, self.tracks.len());
         let page = self.page.min(shape.pages.saturating_sub(1));
         let start = page * shape.slots();
+        let rows = match self.paged {
+            true => ROWS,
+            false => self.tracks.len().div_ceil(shape.columns).max(1),
+        };
         let row = snapped(theme.metrics.list_row, window);
         let tracks = self.tracks;
         let empty = tracks.is_empty();
@@ -180,46 +191,50 @@ impl RenderOnce for Picks {
                     .py_2()
                     .border_b_1()
                     .border_color(theme.border)
-                    .child(
-                        div()
-                            .flex()
-                            .flex_col()
-                            .gap_0p5()
-                            .children(self.eyebrow.map(|key| eyebrow(i18n::lookup(key, None), cx)))
-                            .child(heading(i18n::lookup(self.title, None), cx)),
-                    )
-                    .child(
-                        div()
-                            .flex()
-                            .items_center()
-                            .gap_1()
-                            .child(
-                                Button::new(SharedString::from(format!("{id}-previous")))
-                                    .small()
-                                    .outline()
-                                    .icon("icons/chevron-left.svg")
-                                    .tooltip("common-previous")
-                                    .disabled(empty || page == 0)
-                                    .when_some(on_previous, |button, handler| {
-                                        button.on_click(move |event, window, cx| {
-                                            handler(event, window, cx)
-                                        })
-                                    }),
-                            )
-                            .child(
-                                Button::new(SharedString::from(format!("{id}-next")))
-                                    .small()
-                                    .outline()
-                                    .icon("icons/chevron-right.svg")
-                                    .tooltip("common-next")
-                                    .disabled(empty || page + 1 >= shape.pages)
-                                    .when_some(on_next, |button, handler| {
-                                        button.on_click(move |event, window, cx| {
-                                            handler(event, window, cx)
-                                        })
-                                    }),
-                            ),
-                    ),
+                    .when(self.paged, |this| {
+                        this.child(
+                            div()
+                                .flex()
+                                .flex_col()
+                                .gap_0p5()
+                                .children(
+                                    self.eyebrow.map(|key| eyebrow(i18n::lookup(key, None), cx)),
+                                )
+                                .child(heading(i18n::lookup(self.title, None), cx)),
+                        )
+                        .child(
+                            div()
+                                .flex()
+                                .items_center()
+                                .gap_1()
+                                .child(
+                                    Button::new(SharedString::from(format!("{id}-previous")))
+                                        .small()
+                                        .outline()
+                                        .icon("icons/chevron-left.svg")
+                                        .tooltip("common-previous")
+                                        .disabled(empty || page == 0)
+                                        .when_some(on_previous, |button, handler| {
+                                            button.on_click(move |event, window, cx| {
+                                                handler(event, window, cx)
+                                            })
+                                        }),
+                                )
+                                .child(
+                                    Button::new(SharedString::from(format!("{id}-next")))
+                                        .small()
+                                        .outline()
+                                        .icon("icons/chevron-right.svg")
+                                        .tooltip("common-next")
+                                        .disabled(empty || page + 1 >= shape.pages)
+                                        .when_some(on_next, |button, handler| {
+                                            button.on_click(move |event, window, cx| {
+                                                handler(event, window, cx)
+                                            })
+                                        }),
+                                ),
+                        )
+                    }),
             )
             .when(barren, |this| {
                 this.child(vacant(i18n::lookup(self.vacancy, None), cx))
@@ -230,13 +245,13 @@ impl RenderOnce for Picks {
                     |this| {
                         this.children((0..shape.columns).map(|column| {
                             column_shell(column, theme.border)
-                                .children((0..ROWS).map(|slot| skeleton(id, column * ROWS + slot)))
+                                .children((0..rows).map(|slot| skeleton(id, column * rows + slot)))
                         }))
                     },
                     |this| {
                         this.children((0..shape.columns).map(|column| {
-                            column_shell(column, theme.border).children((0..ROWS).map(|slot| {
-                                let place = start + column * ROWS + slot;
+                            column_shell(column, theme.border).children((0..rows).map(|slot| {
+                                let place = start + column * rows + slot;
                                 match tracks.get(place) {
                                     None => div().flex_none().h(row).into_any_element(),
                                     Some(track) => pick(

--- a/crates/views/src/shared/picks.rs
+++ b/crates/views/src/shared/picks.rs
@@ -3,21 +3,16 @@ use std::rc::Rc;
 use gpui::prelude::*;
 use gpui::{App, ClickEvent, Entity, MouseDownEvent, Pixels, SharedString, Window, div};
 use music::Track;
-use state::{Playback, PlaybackState};
-use ui::{
-    ActiveTheme as _, Button, Card, Pinnable, Text, clock, eyebrow, heading, snapped, vacant,
-};
+use state::Playback;
+use ui::{ActiveTheme as _, Button, Card, eyebrow, heading, snapped, vacant};
 
-use crate::shared::cells;
-use crate::shared::pins::Pinned as _;
+use crate::shared::track_card::{ContextHandler, StartHandler, TrackCard};
 
 const ROWS: usize = 5;
 const MAX_COLUMNS: usize = 3;
 const MIN_COLUMN_WIDTH: Pixels = gpui::px(280.);
 
 type ClickHandler = Rc<dyn Fn(&ClickEvent, &mut Window, &mut App)>;
-pub(crate) type ContextHandler = Rc<dyn Fn(usize, &MouseDownEvent, &mut Window, &mut App)>;
-pub(crate) type StartHandler = Rc<dyn Fn(usize, &mut App)>;
 
 pub(crate) fn column_count(width: Pixels) -> usize {
     ((width / MIN_COLUMN_WIDTH).floor().max(1.) as usize).min(MAX_COLUMNS)
@@ -239,18 +234,17 @@ impl RenderOnce for Picks {
                                 let place = start + column * ROWS + slot;
                                 match tracks.get(place) {
                                     None => div().flex_none().h(row).into_any_element(),
-                                    Some(track) => track_card(
-                                        track,
-                                        place,
+                                    Some(_) => TrackCard::new(
                                         id,
-                                        self.detailed,
+                                        place,
                                         tracks.clone(),
                                         self.playback.clone(),
                                         self.active.as_deref(),
-                                        on_context_menu.clone(),
-                                        on_start.clone(),
-                                        cx,
                                     )
+                                    .detailed(self.detailed)
+                                    .context(on_context_menu.clone())
+                                    .start(on_start.clone())
+                                    .render(cx)
                                     .into_any_element(),
                                 }
                             }))
@@ -275,92 +269,6 @@ fn column_shell(column: usize, border: gpui::Hsla) -> gpui::Div {
 
 fn skeleton(id: &'static str, place: usize) -> impl IntoElement {
     Card::skeleton((id, place))
-}
-
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn track_card(
-    track: &Track,
-    place: usize,
-    id: &'static str,
-    detailed: bool,
-    tracks: Rc<Vec<Track>>,
-    playback: Entity<Playback>,
-    active: Option<&str>,
-    on_context_menu: Option<ContextHandler>,
-    on_start: Option<StartHandler>,
-    cx: &App,
-) -> Card {
-    let theme = *cx.theme();
-    let current = track.id.as_deref() == active;
-    let tint = match current {
-        true => theme.primary,
-        false => theme.foreground,
-    };
-    let playing = current && playback.read(cx).state() == &PlaybackState::Playing;
-    let pin = track.pin();
-    let pressed = {
-        let tracks = tracks.clone();
-        let playback = playback.clone();
-        let on_start = on_start.clone();
-        move |cx: &mut App| begin(place, &tracks, &playback, &on_start, cx)
-    };
-    let transport = move |cx: &mut App| match current {
-        true => playback.update(cx, |playback, cx| playback.toggle_play(cx)),
-        false => begin(place, &tracks, &playback, &on_start, cx),
-    };
-
-    let artists = (!detailed || featured(track)).then(|| {
-        cells::artist_links(
-            SharedString::new_static("pick-artist"),
-            track.artist_refs.clone(),
-            track.artists.clone(),
-            theme.muted_foreground,
-        )
-        .text_size(theme.text(Text::Small))
-        .truncate()
-    });
-    let length = detailed.then(|| {
-        div()
-            .text_size(theme.text(Text::Small))
-            .text_color(theme.muted_foreground)
-            .child(clock(track.duration))
-    });
-
-    Card::new((id, place), SharedString::from(track.name.clone()))
-        .cover(track.cover.clone())
-        .tint(tint)
-        .when(track.explicit, |card| card.explicit())
-        .when_some(artists, Card::bare_meta)
-        .when_some(length, Card::trailing)
-        .when_some(on_context_menu, |card, handler| {
-            card.menu(move |event, window, cx| handler(place, event, window, cx))
-        })
-        .play(playing, move |_, _, cx| transport(cx))
-        .press(move |_, _, cx| pressed(cx))
-        .when_some(pin, Pinnable::pin)
-        .min_w_0()
-}
-
-fn featured(track: &Track) -> bool {
-    match track.artist_refs.is_empty() {
-        false => track.artist_refs.len() > 1,
-        true => track.artists.contains(','),
-    }
-}
-
-fn begin(
-    place: usize,
-    tracks: &Rc<Vec<Track>>,
-    playback: &Entity<Playback>,
-    on_start: &Option<StartHandler>,
-    cx: &mut App,
-) {
-    match on_start {
-        Some(handler) => handler(place, cx),
-        None => playback.update(cx, |playback, cx| {
-            playback.play_radio(&tracks[place], cx);
-        }),
-    }
 }
 
 #[cfg(test)]

--- a/crates/views/src/shared/picks.rs
+++ b/crates/views/src/shared/picks.rs
@@ -16,8 +16,8 @@ const MAX_COLUMNS: usize = 3;
 const MIN_COLUMN_WIDTH: Pixels = gpui::px(280.);
 
 type ClickHandler = Rc<dyn Fn(&ClickEvent, &mut Window, &mut App)>;
-type ContextHandler = Rc<dyn Fn(usize, &MouseDownEvent, &mut Window, &mut App)>;
-type StartHandler = Rc<dyn Fn(usize, &mut App)>;
+pub(crate) type ContextHandler = Rc<dyn Fn(usize, &MouseDownEvent, &mut Window, &mut App)>;
+pub(crate) type StartHandler = Rc<dyn Fn(usize, &mut App)>;
 
 pub(crate) fn column_count(width: Pixels) -> usize {
     ((width / MIN_COLUMN_WIDTH).floor().max(1.) as usize).min(MAX_COLUMNS)
@@ -57,7 +57,7 @@ pub(crate) struct Picks {
     page: usize,
     detailed: bool,
     loading: bool,
-    paged: bool,
+    navigation: bool,
     on_previous: Option<ClickHandler>,
     on_next: Option<ClickHandler>,
     on_context_menu: Option<ContextHandler>,
@@ -85,7 +85,7 @@ impl Picks {
             page,
             detailed: false,
             loading: false,
-            paged: true,
+            navigation: true,
             on_previous: None,
             on_next: None,
             on_context_menu: None,
@@ -118,8 +118,8 @@ impl Picks {
         self
     }
 
-    pub(crate) fn paged(mut self, paged: bool) -> Self {
-        self.paged = paged;
+    pub(crate) fn navigation(mut self, navigation: bool) -> Self {
+        self.navigation = navigation;
         self
     }
 
@@ -195,7 +195,7 @@ impl RenderOnce for Picks {
                             .children(self.eyebrow.map(|key| eyebrow(i18n::lookup(key, None), cx)))
                             .child(heading(i18n::lookup(self.title, None), cx)),
                     )
-                    .when(self.paged, |this| {
+                    .when(self.navigation, |this| {
                         this.child(
                             div()
                                 .flex()
@@ -248,7 +248,7 @@ impl RenderOnce for Picks {
                                 let place = start + column * ROWS + slot;
                                 match tracks.get(place) {
                                     None => div().flex_none().h(row).into_any_element(),
-                                    Some(track) => pick(
+                                    Some(track) => track_card(
                                         track,
                                         place,
                                         id,
@@ -287,7 +287,7 @@ fn skeleton(id: &'static str, place: usize) -> impl IntoElement {
 }
 
 #[allow(clippy::too_many_arguments)]
-fn pick(
+pub(crate) fn track_card(
     track: &Track,
     place: usize,
     id: &'static str,
@@ -298,7 +298,7 @@ fn pick(
     on_context_menu: Option<ContextHandler>,
     on_start: Option<StartHandler>,
     cx: &App,
-) -> impl IntoElement {
+) -> Card {
     let theme = *cx.theme();
     let current = track.id.as_deref() == active;
     let tint = match current {

--- a/crates/views/src/shared/picks.rs
+++ b/crates/views/src/shared/picks.rs
@@ -159,10 +159,6 @@ impl RenderOnce for Picks {
         let shape = Shape::new(self.width, self.tracks.len());
         let page = self.page.min(shape.pages.saturating_sub(1));
         let start = page * shape.slots();
-        let rows = match self.paged {
-            true => ROWS,
-            false => self.tracks.len().div_ceil(shape.columns).max(1),
-        };
         let row = snapped(theme.metrics.list_row, window);
         let tracks = self.tracks;
         let empty = tracks.is_empty();
@@ -243,13 +239,13 @@ impl RenderOnce for Picks {
                     |this| {
                         this.children((0..shape.columns).map(|column| {
                             column_shell(column, theme.border)
-                                .children((0..rows).map(|slot| skeleton(id, column * rows + slot)))
+                                .children((0..ROWS).map(|slot| skeleton(id, column * ROWS + slot)))
                         }))
                     },
                     |this| {
                         this.children((0..shape.columns).map(|column| {
-                            column_shell(column, theme.border).children((0..rows).map(|slot| {
-                                let place = start + column * rows + slot;
+                            column_shell(column, theme.border).children((0..ROWS).map(|slot| {
+                                let place = start + column * ROWS + slot;
                                 match tracks.get(place) {
                                     None => div().flex_none().h(row).into_any_element(),
                                     Some(track) => pick(

--- a/crates/views/src/shared/track_card.rs
+++ b/crates/views/src/shared/track_card.rs
@@ -1,0 +1,149 @@
+use std::rc::Rc;
+
+use gpui::prelude::*;
+use gpui::{App, Entity, MouseDownEvent, SharedString, Window, div};
+use music::Track;
+use state::{Playback, PlaybackState};
+use ui::{ActiveTheme as _, Card, Pinnable, Text, clock};
+
+use crate::shared::cells;
+use crate::shared::pins::Pinned as _;
+
+pub(crate) type ContextHandler = Rc<dyn Fn(usize, &MouseDownEvent, &mut Window, &mut App)>;
+pub(crate) type StartHandler = Rc<dyn Fn(usize, &mut App)>;
+
+pub(crate) struct TrackCard {
+    id: &'static str,
+    place: usize,
+    tracks: Rc<Vec<Track>>,
+    playback: Entity<Playback>,
+    active: Option<String>,
+    detailed: bool,
+    context: Option<ContextHandler>,
+    start: Option<StartHandler>,
+}
+
+impl TrackCard {
+    pub(crate) fn new(
+        id: &'static str,
+        place: usize,
+        tracks: Rc<Vec<Track>>,
+        playback: Entity<Playback>,
+        active: Option<&str>,
+    ) -> Self {
+        Self {
+            id,
+            place,
+            tracks,
+            playback,
+            active: active.map(str::to_owned),
+            detailed: false,
+            context: None,
+            start: None,
+        }
+    }
+
+    pub(crate) fn detailed(mut self, detailed: bool) -> Self {
+        self.detailed = detailed;
+        self
+    }
+
+    pub(crate) fn context(mut self, context: Option<ContextHandler>) -> Self {
+        self.context = context;
+        self
+    }
+
+    pub(crate) fn start(mut self, start: Option<StartHandler>) -> Self {
+        self.start = start;
+        self
+    }
+
+    pub(crate) fn render(self, cx: &App) -> Card {
+        let theme = *cx.theme();
+        let track = &self.tracks[self.place];
+        let current = track.id.as_deref() == self.active.as_deref();
+        let tint = match current {
+            true => theme.primary,
+            false => theme.foreground,
+        };
+        let playing = current && self.playback.read(cx).state() == &PlaybackState::Playing;
+        let pin = track.pin();
+        let pressed_tracks = self.tracks.clone();
+        let pressed_playback = self.playback.clone();
+        let pressed_start = self.start.clone();
+        let transport_tracks = self.tracks.clone();
+        let transport_playback = self.playback.clone();
+        let transport_start = self.start.clone();
+        let place = self.place;
+
+        let artists = (!self.detailed || featured(track)).then(|| {
+            cells::artist_links(
+                SharedString::new_static("pick-artist"),
+                track.artist_refs.clone(),
+                track.artists.clone(),
+                theme.muted_foreground,
+            )
+            .text_size(theme.text(Text::Small))
+            .truncate()
+        });
+        let length = self.detailed.then(|| {
+            div()
+                .text_size(theme.text(Text::Small))
+                .text_color(theme.muted_foreground)
+                .child(clock(track.duration))
+        });
+
+        Card::new((self.id, place), SharedString::from(track.name.clone()))
+            .cover(track.cover.clone())
+            .tint(tint)
+            .when(track.explicit, Card::explicit)
+            .when_some(artists, Card::bare_meta)
+            .when_some(length, Card::trailing)
+            .when_some(self.context, |card, handler| {
+                card.menu(move |event, window, cx| handler(place, event, window, cx))
+            })
+            .play(playing, move |_, _, cx| match current {
+                true => transport_playback.update(cx, |playback, cx| playback.toggle_play(cx)),
+                false => begin(
+                    place,
+                    &transport_tracks,
+                    &transport_playback,
+                    &transport_start,
+                    cx,
+                ),
+            })
+            .press(move |_, _, cx| {
+                begin(
+                    place,
+                    &pressed_tracks,
+                    &pressed_playback,
+                    &pressed_start,
+                    cx,
+                );
+            })
+            .when_some(pin, Pinnable::pin)
+            .min_w_0()
+    }
+}
+
+fn featured(track: &Track) -> bool {
+    match track.artist_refs.is_empty() {
+        false => track.artist_refs.len() > 1,
+        true => track.artists.contains(','),
+    }
+}
+
+fn begin(
+    place: usize,
+    tracks: &Rc<Vec<Track>>,
+    playback: &Entity<Playback>,
+    start: &Option<StartHandler>,
+    cx: &mut App,
+) {
+    match start {
+        Some(handler) => handler(place, cx),
+        None => playback.update(cx, |playback, cx| {
+            playback.play_radio(&tracks[place], cx);
+        }),
+    }
+}


### PR DESCRIPTION
## Summary

- load Listen Again and Quick Picks from the YouTube Music home feed
- keep Spotify home recommendations unchanged
- show Listen Again as a YouTube Music-style card carousel