### PR TITLE
feat(views): confirm destructive media actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Ctrl-click (Cmd-click on macOS) adds or removes individual rows from a table selection.
 - Enter play/pauses the selected song when a table has exactly one row selected, or opens the
   selected album, artist or playlist.
-- Delete removes the selected songs from a playlist or from listening history. In the library it
-  also removes selected songs, albums, artists, and playlists you follow.
+- Delete asks before removing selected songs, albums, artists or playlists from the library, a
+  playlist, or listening history.
 - Search results can be moved through with the arrow keys, including left and right between
   columns, and Enter play/pauses the selected song.
 - Text fields have a Cut, Copy, Paste and Select all context menu.
@@ -26,6 +26,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The list/grid toggle is labelled Grid instead of Cards.
 - Clicking a song, album, artist or playlist in a table selects the row. Double-click or Enter
   still plays a song or opens an album, artist or playlist.
+- Dialogs pack the title, copy and buttons more tightly, with a divider above the actions.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - YouTube Music listeners see their Listen Again history and personalized Quick Picks on Home.
-- Shift-click or Shift-Up/Down selects a range of songs in a table, and the context menu acts on
-  all of them.
-- Ctrl-click (Cmd-click on macOS) adds or removes individual songs from a table selection.
-- Enter play/pauses the selected song when a table has exactly one row selected.
+- Shift-click or Shift-Up/Down selects a range of rows in a table. On songs, the context menu
+  acts on all of them.
+- Ctrl-click (Cmd-click on macOS) adds or removes individual rows from a table selection.
+- Enter play/pauses the selected song when a table has exactly one row selected, or opens the
+  selected album, artist or playlist.
+- Delete removes the selected songs from a playlist or from listening history. In the library it
+  also removes selected songs, albums, artists, and playlists you follow.
 - Search results can be moved through with the arrow keys, including left and right between
   columns, and Enter play/pauses the selected song.
 - Text fields have a Cut, Copy, Paste and Select all context menu.
@@ -21,6 +24,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - The list/grid toggle is labelled Grid instead of Cards.
+- Clicking a song, album, artist or playlist in a table selects the row. Double-click or Enter
+  still plays a song or opens an album, artist or playlist.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Ctrl-click (Cmd-click on macOS) adds or removes individual rows from a table selection.
 - Enter play/pauses the selected song when a table has exactly one row selected, or opens the
   selected album, artist or playlist.
-- Delete asks before removing selected songs, albums, artists or playlists from the library, a
-  playlist, or listening history.
+- Delete or a Remove from library (or playlist, or history) action asks before it runs.
 - Search results can be moved through with the arrow keys, including left and right between
   columns, and Enter play/pauses the selected song.
 - Text fields have a Cut, Copy, Paste and Select all context menu.
+- Search results for albums and playlists can be saved to the library from the context menu.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ partial translation is welcome — pick a language below and fill in what it lac
 
 | Language | Translated | Coverage |
 | --- | --- | --- |
-| English (`en-US`) | 452/452 | 100% |
-| Deutsch (`de`) | 441/452 | 98% |
-| Français (`fr`) | 441/452 | 98% |
-| Русский (`ru`) | 441/452 | 98% |
-| Українська (`uk`) | 441/452 | 98% |
-| Polski (`pl`) | 441/452 | 98% |
+| English (`en-US`) | 462/462 | 100% |
+| Deutsch (`de`) | 441/462 | 95% |
+| Français (`fr`) | 441/462 | 95% |
+| Русский (`ru`) | 441/462 | 95% |
+| Українська (`uk`) | 441/462 | 95% |
+| Polski (`pl`) | 441/462 | 95% |
 
 <!-- i18n:end -->
 

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -139,6 +139,36 @@ playlist-again-title = Add it again?
 playlist-again-confirm = This track is already in “{ $name }”. Add another copy?
 playlist-again-add = Add again
 
+# confirm
+confirm-remove-library-title = Remove from library
+confirm-remove-playlist-title = Remove from playlist
+confirm-remove-history-title = Remove from history
+confirm-unfollow-title = Unfollow
+confirm-remove-songs = { $count ->
+    [one] Remove this song from your library?
+   *[other] Remove { $count } songs from your library?
+}
+confirm-remove-playlist-songs = { $count ->
+    [one] Remove this song from the playlist?
+   *[other] Remove { $count } songs from the playlist?
+}
+confirm-remove-history-songs = { $count ->
+    [one] Remove this song from listening history?
+   *[other] Remove { $count } songs from listening history?
+}
+confirm-remove-albums = { $count ->
+    [one] Remove this album from your library?
+   *[other] Remove { $count } albums from your library?
+}
+confirm-unfollow-artists = { $count ->
+    [one] Unfollow this artist?
+   *[other] Unfollow { $count } artists?
+}
+confirm-remove-playlists = { $count ->
+    [one] Remove this playlist from your library?
+   *[other] Remove { $count } playlists from your library?
+}
+
 # queue panel
 queue-title = Queue
 queue-history = History

--- a/crates/input/src/lib.rs
+++ b/crates/input/src/lib.rs
@@ -1,8 +1,8 @@
 use gpui::{KeyBinding, actions};
 use ui::{
     Activate, Backspace, BackspaceWord, Copy, Cut, Delete, DeleteWord, Deselect, Dismiss, End,
-    FORM_CONTEXT, Home, INPUT_CONTEXT, Left, MENU_CONTEXT, Paste, Right, SelectAll, SelectEnd,
-    SelectHome, SelectLeft, SelectNext, SelectPrevious, SelectRight, SelectWordLeft,
+    FORM_CONTEXT, Home, INPUT_CONTEXT, Left, MENU_CONTEXT, Paste, Remove, Right, SelectAll,
+    SelectEnd, SelectHome, SelectLeft, SelectNext, SelectPrevious, SelectRight, SelectWordLeft,
     SelectWordRight, ShowCharacterPalette, Space, Submit, TABLE_CONTEXT, WordLeft, WordRight,
 };
 
@@ -47,12 +47,14 @@ pub fn bindings() -> Vec<KeyBinding> {
         KeyBinding::new("shift-down", SelectNext, table),
         KeyBinding::new("shift-up", SelectPrevious, table),
         KeyBinding::new("enter", Activate, table),
+        KeyBinding::new("delete", Remove, table),
         KeyBinding::new("escape", Deselect, table),
         KeyBinding::new("down", SelectNext, Some(&browsing)),
         KeyBinding::new("up", SelectPrevious, Some(&browsing)),
         KeyBinding::new("shift-down", SelectNext, Some(&browsing)),
         KeyBinding::new("shift-up", SelectPrevious, Some(&browsing)),
         KeyBinding::new("enter", Activate, Some(&browsing)),
+        KeyBinding::new("delete", Remove, Some(&browsing)),
         KeyBinding::new("escape", Deselect, Some(&browsing)),
         KeyBinding::new("down", SelectNext, search),
         KeyBinding::new("up", SelectPrevious, search),

--- a/crates/ui/src/card.rs
+++ b/crates/ui/src/card.rs
@@ -482,7 +482,9 @@ impl RenderOnce for Card {
                 |this| this.items_center().gap_3().px(inset),
             )
             .rounded(theme.radius)
-            .when(listed, |this| this.flex_none().h(height).py(inset).w_full().min_w_0())
+            .when(listed, |this| {
+                this.flex_none().h(height).py(inset).w_full().min_w_0()
+            })
             .when(chosen, |this| this.bg(theme.table_active))
             .when_some(hovered.filter(|_| !chosen), |this, style| {
                 this.hover(move |_| style)

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -81,9 +81,9 @@ pub use shield::Shield;
 pub use skeleton::{Initials, Skeleton};
 pub use switch::Switch;
 pub use table::{
-    Activate, Cell, ColumnSpec, Deselect, Layout, Listing, ROW_GROUP, SelectNext, SelectPrevious,
-    Sort, Sorting, TABLE_CONTEXT, Table, TableDelegate, TableEvent, TableSource, TableState,
-    Toggle, Viewport, Width, clear_listing, rank, show_listing, shown_listing, table,
+    Activate, Cell, ColumnSpec, Deselect, Layout, Listing, ROW_GROUP, Remove, SelectNext,
+    SelectPrevious, Sort, Sorting, TABLE_CONTEXT, Table, TableDelegate, TableEvent, TableSource,
+    TableState, Toggle, Viewport, Width, clear_listing, rank, show_listing, shown_listing, table,
 };
 pub use tabs::{TabBar, Tabs};
 pub use theme::{

--- a/crates/ui/src/modal.rs
+++ b/crates/ui/src/modal.rs
@@ -2,10 +2,10 @@ use std::rc::Rc;
 
 use gpui::prelude::*;
 use gpui::{
-    AnyElement, App, Div, ElementId, MouseButton, SharedString, StyleRefinement, Window, div,
+    AnyElement, App, Div, ElementId, FontWeight, MouseButton, SharedString, StyleRefinement,
+    Window, div,
 };
 
-use crate::label::heading;
 use crate::metrics::Text;
 use crate::shield::Shield;
 use crate::theme::ActiveTheme as _;
@@ -70,6 +70,8 @@ impl Styled for Modal {
 impl RenderOnce for Modal {
     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
         let theme = *cx.theme();
+        let pad = theme.metrics.pad;
+        let inset = theme.metrics.inset;
         let Self {
             mut base,
             id,
@@ -81,11 +83,12 @@ impl RenderOnce for Modal {
         } = self;
         let outside = dismiss.clone();
         let overrides = std::mem::take(base.style());
+        let band = pad * 2.;
 
         div()
             .absolute()
             .inset_0()
-            .p(theme.metrics.inset)
+            .p(inset)
             .flex()
             .items_center()
             .justify_center()
@@ -111,24 +114,61 @@ impl RenderOnce for Modal {
                     .max_h_full()
                     .flex()
                     .flex_col()
-                    .gap_4()
-                    .p(theme.metrics.inset)
                     .rounded(theme.radius)
                     .border_1()
                     .border_color(theme.border)
                     .bg(theme.popover)
-                    .child(heading(title, cx))
-                    .when_some(detail, |this, detail| {
+                    .shadow_md()
+                    .overflow_hidden()
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap(pad)
+                            .px(inset)
+                            .pt(inset)
+                            .pb(band)
+                            .child(
+                                div()
+                                    .text_size(theme.text(Text::Large))
+                                    .font_weight(FontWeight::SEMIBOLD)
+                                    .child(title),
+                            )
+                            .when_some(detail, |this, detail| {
+                                this.child(
+                                    div()
+                                        .text_size(theme.text(Text::Small))
+                                        .text_color(theme.muted_foreground)
+                                        .child(detail),
+                                )
+                            }),
+                    )
+                    .when(!body.is_empty(), |this| {
                         this.child(
                             div()
-                                .text_size(theme.text(Text::Small))
-                                .text_color(theme.muted_foreground)
-                                .child(detail),
+                                .flex()
+                                .flex_col()
+                                .gap(pad)
+                                .min_h_0()
+                                .px(inset)
+                                .py(band)
+                                .border_t_1()
+                                .border_color(theme.border)
+                                .children(body),
                         )
                     })
-                    .children(body)
                     .when(!actions.is_empty(), |this| {
-                        this.child(div().flex().justify_end().gap_2().children(actions))
+                        this.child(
+                            div()
+                                .flex()
+                                .justify_end()
+                                .gap_2()
+                                .px(inset)
+                                .py(band)
+                                .border_t_1()
+                                .border_color(theme.border)
+                                .children(actions),
+                        )
                     });
                 panel.style().refine(&overrides);
                 panel

--- a/crates/ui/src/modal.rs
+++ b/crates/ui/src/modal.rs
@@ -71,7 +71,7 @@ impl RenderOnce for Modal {
     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
         let theme = *cx.theme();
         let pad = theme.metrics.pad;
-        let inset = theme.metrics.inset;
+        let room = pad * 2.;
         let Self {
             mut base,
             id,
@@ -83,12 +83,11 @@ impl RenderOnce for Modal {
         } = self;
         let outside = dismiss.clone();
         let overrides = std::mem::take(base.style());
-        let band = pad * 2.;
 
         div()
             .absolute()
             .inset_0()
-            .p(inset)
+            .p(theme.metrics.inset)
             .flex()
             .items_center()
             .justify_center()
@@ -124,10 +123,10 @@ impl RenderOnce for Modal {
                         div()
                             .flex()
                             .flex_col()
-                            .gap(pad)
-                            .px(inset)
-                            .pt(inset)
-                            .pb(band)
+                            .gap_1()
+                            .px(room)
+                            .pt(room)
+                            .pb(pad)
                             .child(
                                 div()
                                     .text_size(theme.text(Text::Large))
@@ -150,8 +149,8 @@ impl RenderOnce for Modal {
                                 .flex_col()
                                 .gap(pad)
                                 .min_h_0()
-                                .px(inset)
-                                .py(band)
+                                .px(room)
+                                .py(pad)
                                 .border_t_1()
                                 .border_color(theme.border)
                                 .children(body),
@@ -163,8 +162,8 @@ impl RenderOnce for Modal {
                                 .flex()
                                 .justify_end()
                                 .gap_2()
-                                .px(inset)
-                                .py(band)
+                                .px(room)
+                                .py(pad)
                                 .border_t_1()
                                 .border_color(theme.border)
                                 .children(actions),

--- a/crates/ui/src/table/mod.rs
+++ b/crates/ui/src/table/mod.rs
@@ -22,7 +22,10 @@ use crate::theme::ActiveTheme as _;
 pub use layout::{ColumnSpec, Layout, Sort, Sorting, Width, rank};
 use layout::{PADDING, Resolved, SORT_ROOM, TRAIL, reordered, resolve, shifted, stretch};
 
-actions!(table, [SelectNext, SelectPrevious, Deselect, Activate]);
+actions!(
+    table,
+    [SelectNext, SelectPrevious, Deselect, Activate, Remove]
+);
 
 pub const TABLE_CONTEXT: &str = "Table";
 
@@ -488,6 +491,7 @@ impl<S: TableSource> TableDelegate<S> {
 pub enum TableEvent {
     DoubleClicked(usize),
     Activated(usize),
+    Removed,
     LayoutChanged,
     SortChanged,
 }
@@ -608,6 +612,10 @@ impl<S: TableSource> TableState<S> {
         self.fire_activate(cx);
     }
 
+    fn remove(&mut self, _: &Remove, _: &mut Window, cx: &mut Context<Self>) {
+        self.fire_remove(cx);
+    }
+
     fn fire_activate(&mut self, cx: &mut Context<Self>) {
         if self.delegate.picked().len() != 1 {
             return;
@@ -619,6 +627,13 @@ impl<S: TableSource> TableState<S> {
             return;
         };
         cx.emit(TableEvent::Activated(display));
+    }
+
+    fn fire_remove(&mut self, cx: &mut Context<Self>) {
+        if self.delegate.picked().is_empty() {
+            return;
+        }
+        cx.emit(TableEvent::Removed);
     }
 
     fn step(&mut self, delta: isize, window: &mut Window, cx: &mut Context<Self>) {
@@ -1112,6 +1127,7 @@ impl<S: TableSource> Render for TableState<S> {
             .on_action(cx.listener(Self::select_previous))
             .on_action(cx.listener(Self::deselect))
             .on_action(cx.listener(Self::activate))
+            .on_action(cx.listener(Self::remove))
             .on_mouse_down_out(cx.listener(|this, _: &MouseDownEvent, _, cx| {
                 if this.delegate.selected.is_none() && this.delegate.marked.is_empty() {
                     return;
@@ -1216,6 +1232,7 @@ pub trait Listing {
     fn select_previous(&self, window: &mut Window, cx: &mut App);
     fn deselect(&self, cx: &mut App);
     fn activate(&self, cx: &mut App);
+    fn remove(&self, cx: &mut App);
 }
 
 impl<S: TableSource> Listing for Entity<TableState<S>> {
@@ -1325,5 +1342,9 @@ impl<S: TableSource> Listing for Entity<TableState<S>> {
 
     fn activate(&self, cx: &mut App) {
         self.update(cx, |table, cx| table.fire_activate(cx));
+    }
+
+    fn remove(&self, cx: &mut App) {
+        self.update(cx, |table, cx| table.fire_remove(cx));
     }
 }

--- a/crates/ui/src/table/mod.rs
+++ b/crates/ui/src/table/mod.rs
@@ -551,7 +551,7 @@ pub struct TableState<S: TableSource> {
     corners: Corners<Pixels>,
     focus: FocusHandle,
     scroll: Option<ScrollHandle>,
-    context_menu: Option<(usize, Point<Pixels>)>,
+    context_menu: Option<(Vec<usize>, Point<Pixels>)>,
     moving: Option<(usize, usize)>,
     sizing: Option<Sizing>,
 }
@@ -1016,7 +1016,7 @@ impl<S: TableSource> TableState<S> {
                                 window.focus(&this.focus.clone(), cx);
                                 window.prevent_default();
                                 cx.stop_propagation();
-                                this.context_menu = Some((row, event.position));
+                                this.context_menu = Some((rows, event.position));
                                 cx.notify();
                             }
                         }),
@@ -1106,8 +1106,7 @@ impl<S: TableSource> Render for TableState<S> {
         let height = self.height(head, row);
         let pinned = snapped(self.viewport.top.clamp(Pixels::ZERO, height - head), window);
         let top = unpinned(self.corners, pinned);
-        let context_menu = self.context_menu.and_then(|(_, position)| {
-            let rows = self.delegate.picked();
+        let context_menu = self.context_menu.clone().and_then(|(rows, position)| {
             let visible = self.delegate.visible();
             self.delegate
                 .source
@@ -1129,6 +1128,9 @@ impl<S: TableSource> Render for TableState<S> {
             .on_action(cx.listener(Self::activate))
             .on_action(cx.listener(Self::remove))
             .on_mouse_down_out(cx.listener(|this, _: &MouseDownEvent, _, cx| {
+                if this.context_menu.is_some() {
+                    return;
+                }
                 if this.delegate.selected.is_none() && this.delegate.marked.is_empty() {
                     return;
                 }

--- a/crates/views/src/screens/artist.rs
+++ b/crates/views/src/screens/artist.rs
@@ -27,7 +27,7 @@ use crate::shared::hero::{HeroMetaStrip, HeroPlayButton, PageHero};
 use crate::shared::menus::{ItemMenu, album_menu, artist_menu};
 use crate::shared::page;
 use crate::shared::picks::{Picks, Shape};
-use crate::shared::tracks::{PlaybackStatus, TrackSource, Tracks, playback_status};
+use crate::shared::tracks::{PlaybackStatus, TrackSource, Tracks, drop_picked, playback_status};
 
 const SECTION: &str = "artist";
 const RELEASE_ROWS: usize = 2;
@@ -210,6 +210,7 @@ impl ArtistView {
             TableEvent::Activated(display) => {
                 page::play_or_toggle(&this.table, &this.playback, *display, cx)
             }
+            TableEvent::Removed => drop_picked(&this.table, cx),
             _ => this.persist(cx),
         })
         .detach();

--- a/crates/views/src/screens/artist.rs
+++ b/crates/views/src/screens/artist.rs
@@ -23,6 +23,7 @@ use crate::chrome::tools;
 use crate::chrome::{Toolbar, Tooled};
 use crate::shared::about::{AboutArtist, about_modal};
 use crate::shared::album_grid::{AlbumGrid, CardGrid};
+use crate::shared::confirm::Confirm;
 use crate::shared::hero::{HeroMetaStrip, HeroPlayButton, PageHero};
 use crate::shared::menus::{ItemMenu, album_menu, artist_menu};
 use crate::shared::page;
@@ -363,8 +364,11 @@ impl ArtistView {
                 true => heart.tint(theme.primary),
                 false => heart,
             }
-            .on_click(move |_, _, cx| {
-                library.update(cx, |library, cx| library.toggle_artist(target.clone(), cx));
+            .on_click(move |_, _, cx| match followed {
+                true => Confirm::artists(vec![target.clone()], cx),
+                false => {
+                    library.update(cx, |library, cx| library.toggle_artist(target.clone(), cx));
+                }
             }),
         )
     }

--- a/crates/views/src/screens/detail.rs
+++ b/crates/views/src/screens/detail.rs
@@ -20,6 +20,7 @@ use crate::shared::menus::{album_menu, playlist_menu};
 
 use crate::chrome::tools::{self, Sift, Sliders};
 use crate::chrome::{Chrome, Searchable, Toolbar, Tooled};
+use crate::shared::confirm::Confirm;
 use crate::shared::hero::{HeroMetaStrip, HeroPlayButton, PageHero, release_date_label};
 use crate::shared::tracks::{
     PlaybackStatus, TrackField, TrackSieve, TrackSource, Tracks, drop_picked, playback_status,
@@ -405,16 +406,19 @@ impl DetailView {
                 true => heart.tint(theme.primary),
                 false => heart,
             }
-            .on_click(move |_, _, cx| {
-                library.update(cx, |library, cx| match &target {
-                    Saveable::Album(album) => library.toggle_album(album.clone(), cx),
-                    Saveable::Playlist(playlist) if saved => {
-                        library.remove_playlist_from_library(playlist.id.clone(), cx)
-                    }
-                    Saveable::Playlist(playlist) => {
+            .on_click(move |_, _, cx| match &target {
+                Saveable::Album(album) if saved => Confirm::albums(vec![album.clone()], cx),
+                Saveable::Album(album) => {
+                    library.update(cx, |library, cx| library.toggle_album(album.clone(), cx));
+                }
+                Saveable::Playlist(playlist) if saved => {
+                    Confirm::playlists(vec![playlist.id.clone()], cx)
+                }
+                Saveable::Playlist(playlist) => {
+                    library.update(cx, |library, cx| {
                         library.add_playlist_to_library(playlist.clone(), cx)
-                    }
-                });
+                    });
+                }
             }),
         )
     }

--- a/crates/views/src/screens/detail.rs
+++ b/crates/views/src/screens/detail.rs
@@ -22,7 +22,8 @@ use crate::chrome::tools::{self, Sift, Sliders};
 use crate::chrome::{Chrome, Searchable, Toolbar, Tooled};
 use crate::shared::hero::{HeroMetaStrip, HeroPlayButton, PageHero, release_date_label};
 use crate::shared::tracks::{
-    PlaybackStatus, TrackField, TrackSieve, TrackSource, Tracks, playback_status, playlist_columns,
+    PlaybackStatus, TrackField, TrackSieve, TrackSource, Tracks, drop_picked, playback_status,
+    playlist_columns,
 };
 use crate::shared::{cells, page};
 
@@ -184,6 +185,7 @@ impl DetailView {
             TableEvent::Activated(display) => {
                 page::play_or_toggle(&this.table, &this.playback, *display, cx)
             }
+            TableEvent::Removed => drop_picked(&this.table, cx),
             _ => this.persist(cx),
         })
         .detach();

--- a/crates/views/src/screens/history.rs
+++ b/crates/views/src/screens/history.rs
@@ -14,7 +14,7 @@ use crate::chrome::{Searchable, Toolbar, Tooled};
 use crate::shared::cells;
 use crate::shared::hero::{HeroMetaStrip, PageHero};
 use crate::shared::page;
-use crate::shared::tracks::{HISTORY_COLUMNS, TrackSource, Tracks};
+use crate::shared::tracks::{HISTORY_COLUMNS, TrackSource, Tracks, drop_picked};
 
 struct HistoryTracks(Entity<History>);
 
@@ -79,6 +79,7 @@ impl HistoryView {
             TableEvent::Activated(display) => {
                 page::play_or_toggle(&this.table, &this.playback, *display, cx);
             }
+            TableEvent::Removed => drop_picked(&this.table, cx),
             _ => {}
         })
         .detach();

--- a/crates/views/src/screens/library/albums.rs
+++ b/crates/views/src/screens/library/albums.rs
@@ -5,7 +5,6 @@ use ui::ActiveTheme as _;
 use gpui::{AnyElement, App, Entity, SharedString, TextAlign};
 use i18n::t;
 use music::Album;
-use router::Destination;
 use state::{Library, LibraryState, Origin, Playback};
 use ui::rank::{HANDY, NICE, SPARE, USEFUL};
 use ui::{Cell, ColumnSpec, Menu, Pin, TableSource, Width};
@@ -228,6 +227,10 @@ impl TableSource for AlbumSource {
         self.albums(cx).get(row)?.pin()
     }
 
+    fn picking(&self) -> bool {
+        true
+    }
+
     fn context_menu(&self, rows: &[usize], _visible: &[AlbumField], cx: &App) -> Option<Menu> {
         Some(album_menu(
             self.at(*rows.first()?, cx)?,
@@ -251,13 +254,7 @@ impl TableSource for AlbumSource {
 
         match cell.field {
             AlbumField::Cover => cells::artwork(&cell, album.cover.clone()),
-            AlbumField::Name => cells::link(
-                &cell,
-                "album-name",
-                album.name.clone(),
-                theme.foreground,
-                Destination::Album(album.id.clone().into()),
-            ),
+            AlbumField::Name => cells::dim(&cell, album.name.clone(), theme.foreground),
             AlbumField::Artists => cells::artists(
                 &cell,
                 album.artist_refs.clone(),

--- a/crates/views/src/screens/library/artists.rs
+++ b/crates/views/src/screens/library/artists.rs
@@ -3,7 +3,6 @@ use ui::ActiveTheme as _;
 
 use gpui::{AnyElement, App, Entity, SharedString};
 use music::SavedArtist;
-use router::Destination;
 use state::{Library, LibraryState, Origin, Playback};
 use ui::rank::{ESSENTIAL, HANDY};
 use ui::{Cell, ColumnSpec, Menu, Pin, TableSource, Width};
@@ -111,6 +110,10 @@ impl TableSource for ArtistSource {
         self.artists(cx).get(row)?.pin()
     }
 
+    fn picking(&self) -> bool {
+        true
+    }
+
     fn context_menu(&self, rows: &[usize], _visible: &[ArtistField], cx: &App) -> Option<Menu> {
         Some(artist_menu(
             self.at(*rows.first()?, cx)?,
@@ -134,13 +137,7 @@ impl TableSource for ArtistSource {
 
         match cell.field {
             ArtistField::Cover => cells::avatar(&cell, artist.cover.clone()),
-            ArtistField::Name => cells::link(
-                &cell,
-                "artist-name",
-                artist.name.clone(),
-                theme.foreground,
-                Destination::Artist(artist.id.clone().into()),
-            ),
+            ArtistField::Name => cells::dim(&cell, artist.name.clone(), theme.foreground),
             ArtistField::AddedAt => cells::dim(&cell, cells::stamp(artist.added_at), muted),
             ArtistField::Index => cells::blank(&cell),
         }

--- a/crates/views/src/screens/library/local.rs
+++ b/crates/views/src/screens/library/local.rs
@@ -175,12 +175,14 @@ impl LocalView {
             TableEvent::Activated(display) => {
                 page::play_or_toggle(&this.tracks, &this.playback, *display, cx)
             }
+            TableEvent::Removed => {}
             _ => this.persist(Section::Tracks, cx),
         })
         .detach();
 
         cx.subscribe(&albums, |this, _, event, cx| match event {
             TableEvent::DoubleClicked(_) | TableEvent::Activated(_) => {}
+            TableEvent::Removed => {}
             _ => this.persist(Section::Albums, cx),
         })
         .detach();

--- a/crates/views/src/screens/library/mod.rs
+++ b/crates/views/src/screens/library/mod.rs
@@ -294,6 +294,7 @@ impl LibraryView {
             TableEvent::Activated(display) => {
                 page::play_or_toggle(&this.tracks, &this.playback, *display, cx)
             }
+            TableEvent::Removed => tracks::drop_picked(&this.tracks, cx),
             _ => this.persist(Section::Tracks, cx),
         })
         .detach();
@@ -302,6 +303,7 @@ impl LibraryView {
             TableEvent::DoubleClicked(display) | TableEvent::Activated(display) => {
                 this.open_album(*display, cx)
             }
+            TableEvent::Removed => this.drop_albums(cx),
             _ => {
                 this.cards_dirty = true;
                 this.persist(Section::Albums, cx);
@@ -313,6 +315,7 @@ impl LibraryView {
             TableEvent::DoubleClicked(display) | TableEvent::Activated(display) => {
                 this.open_playlist(*display, cx)
             }
+            TableEvent::Removed => this.drop_playlists(cx),
             _ => {
                 this.cards_dirty = true;
                 this.persist(Section::Playlists, cx);
@@ -324,6 +327,7 @@ impl LibraryView {
             TableEvent::DoubleClicked(display) | TableEvent::Activated(display) => {
                 this.open_artist(*display, cx)
             }
+            TableEvent::Removed => this.drop_artists(cx),
             _ => {
                 this.cards_dirty = true;
                 this.persist(Section::Artists, cx);
@@ -538,6 +542,73 @@ impl LibraryView {
             return;
         };
         navigate(Destination::Artist(artist.id.into()), cx);
+    }
+
+    fn drop_albums(&mut self, cx: &mut Context<Self>) {
+        let rows = self.albums.read(cx).delegate().picked();
+        let albums: Vec<_> = {
+            let state = self.albums.read(cx);
+            let source = state.delegate().source();
+            rows.iter().filter_map(|&row| source.at(row, cx)).collect()
+        };
+        if albums.is_empty() {
+            return;
+        }
+        self.library.update(cx, |library, cx| {
+            for album in albums {
+                library.toggle_album(album, cx);
+            }
+        });
+        self.albums.update(cx, |table, cx| {
+            table.delegate_mut().clear_selection();
+            cx.notify();
+        });
+    }
+
+    fn drop_artists(&mut self, cx: &mut Context<Self>) {
+        let rows = self.artists.read(cx).delegate().picked();
+        let artists: Vec<_> = {
+            let state = self.artists.read(cx);
+            let source = state.delegate().source();
+            rows.iter().filter_map(|&row| source.at(row, cx)).collect()
+        };
+        if artists.is_empty() {
+            return;
+        }
+        self.library.update(cx, |library, cx| {
+            for artist in artists {
+                library.toggle_artist(artist, cx);
+            }
+        });
+        self.artists.update(cx, |table, cx| {
+            table.delegate_mut().clear_selection();
+            cx.notify();
+        });
+    }
+
+    fn drop_playlists(&mut self, cx: &mut Context<Self>) {
+        let rows = self.playlists.read(cx).delegate().picked();
+        let ids: Vec<String> = {
+            let state = self.playlists.read(cx);
+            let source = state.delegate().source();
+            rows.iter()
+                .filter_map(|&row| source.at(row, cx))
+                .filter(|playlist| !playlist.owned)
+                .map(|playlist| playlist.id)
+                .collect()
+        };
+        if ids.is_empty() {
+            return;
+        }
+        self.library.update(cx, |library, cx| {
+            for id in ids {
+                library.remove_playlist_from_library(id, cx);
+            }
+        });
+        self.playlists.update(cx, |table, cx| {
+            table.delegate_mut().clear_selection();
+            cx.notify();
+        });
     }
 
     fn resize(&mut self, window: &Window, cx: &mut Context<Self>) {

--- a/crates/views/src/screens/library/mod.rs
+++ b/crates/views/src/screens/library/mod.rs
@@ -9,6 +9,7 @@ use std::rc::Rc;
 
 use crate::chrome::tools::{self, Sift, Sliders};
 use crate::chrome::{Chrome, Searchable, Toolbar, Tooled};
+use crate::shared::confirm::{Confirm, Kind};
 use crate::shared::menus::{Item, new_playlist_menu};
 use crate::shared::playlist_editor::{Edit, PlaylistEditor};
 
@@ -554,15 +555,23 @@ impl LibraryView {
         if albums.is_empty() {
             return;
         }
-        self.library.update(cx, |library, cx| {
-            for album in albums {
-                library.toggle_album(album, cx);
-            }
-        });
-        self.albums.update(cx, |table, cx| {
-            table.delegate_mut().clear_selection();
-            cx.notify();
-        });
+        let library = self.library.clone();
+        let table = self.albums.clone();
+        Confirm::ask(
+            Kind::Albums(albums.len()),
+            move |cx| {
+                library.update(cx, |library, cx| {
+                    for album in albums {
+                        library.toggle_album(album, cx);
+                    }
+                });
+                table.update(cx, |table, cx| {
+                    table.delegate_mut().clear_selection();
+                    cx.notify();
+                });
+            },
+            cx,
+        );
     }
 
     fn drop_artists(&mut self, cx: &mut Context<Self>) {
@@ -575,15 +584,23 @@ impl LibraryView {
         if artists.is_empty() {
             return;
         }
-        self.library.update(cx, |library, cx| {
-            for artist in artists {
-                library.toggle_artist(artist, cx);
-            }
-        });
-        self.artists.update(cx, |table, cx| {
-            table.delegate_mut().clear_selection();
-            cx.notify();
-        });
+        let library = self.library.clone();
+        let table = self.artists.clone();
+        Confirm::ask(
+            Kind::Artists(artists.len()),
+            move |cx| {
+                library.update(cx, |library, cx| {
+                    for artist in artists {
+                        library.toggle_artist(artist, cx);
+                    }
+                });
+                table.update(cx, |table, cx| {
+                    table.delegate_mut().clear_selection();
+                    cx.notify();
+                });
+            },
+            cx,
+        );
     }
 
     fn drop_playlists(&mut self, cx: &mut Context<Self>) {
@@ -600,15 +617,23 @@ impl LibraryView {
         if ids.is_empty() {
             return;
         }
-        self.library.update(cx, |library, cx| {
-            for id in ids {
-                library.remove_playlist_from_library(id, cx);
-            }
-        });
-        self.playlists.update(cx, |table, cx| {
-            table.delegate_mut().clear_selection();
-            cx.notify();
-        });
+        let library = self.library.clone();
+        let table = self.playlists.clone();
+        Confirm::ask(
+            Kind::Playlists(ids.len()),
+            move |cx| {
+                library.update(cx, |library, cx| {
+                    for id in ids {
+                        library.remove_playlist_from_library(id, cx);
+                    }
+                });
+                table.update(cx, |table, cx| {
+                    table.delegate_mut().clear_selection();
+                    cx.notify();
+                });
+            },
+            cx,
+        );
     }
 
     fn resize(&mut self, window: &Window, cx: &mut Context<Self>) {

--- a/crates/views/src/screens/library/playlists.rs
+++ b/crates/views/src/screens/library/playlists.rs
@@ -134,6 +134,10 @@ impl TableSource for PlaylistSource {
         self.playlists(cx).get(row)?.pin()
     }
 
+    fn picking(&self) -> bool {
+        true
+    }
+
     fn context_menu(&self, rows: &[usize], _visible: &[PlaylistField], cx: &App) -> Option<Menu> {
         Some(playlist_menu(
             self.at(*rows.first()?, cx)?,
@@ -157,13 +161,7 @@ impl TableSource for PlaylistSource {
 
         match cell.field {
             PlaylistField::Cover => cells::artwork(&cell, playlist.cover.clone()),
-            PlaylistField::Name => cells::link(
-                &cell,
-                "playlist-name",
-                playlist.name.clone(),
-                theme.foreground,
-                Destination::Playlist(playlist.id.clone().into()),
-            ),
+            PlaylistField::Name => cells::dim(&cell, playlist.name.clone(), theme.foreground),
             PlaylistField::Owner => match playlist.owner_id.is_empty() {
                 true => cells::dim(&cell, playlist.owner.clone(), muted),
                 false => cells::link(

--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -5,16 +5,16 @@ use gpui::{
 };
 use i18n::t;
 use input::SEARCH_CONTEXT;
-use music::Track;
+use music::{Album, Playlist, ReleaseType, SavedArtist, Track};
 use router::{Destination, navigate};
 use ui::Input;
 
 use crate::chrome::Chrome;
-use crate::shared::menus::{ItemMenu, item_menu};
-use state::{Genres, Hit, Kind, Playback, Search, Sonora};
+use crate::shared::menus::{ItemMenu, album_menu, artist_menu, playlist_menu};
+use state::{AlbumHit, ArtistHit, Genres, Hit, Kind, Playback, PlaylistHit, Search, Sonora};
 use ui::ActiveTheme as _;
 use ui::{
-    Activate, Card, Deck, Deselect, Pin, Pinnable, Popup, Room, Scrollbar, Scroller, SelectLeft,
+    Activate, Card, Deck, Deselect, Pinnable, Popup, Room, Scrollbar, Scroller, SelectLeft,
     SelectNext, SelectPrevious, SelectRight, Separator, Text, Theme, VAST, Viewport, clock,
     eyebrow, scrolled, snapped, vacant,
 };
@@ -40,14 +40,19 @@ enum Press {
 #[derive(Clone)]
 enum HitMenu {
     Song(Box<Track>),
-    Item(Pin),
+    Album(AlbumHit),
+    Playlist(PlaylistHit),
+    Artist(ArtistHit),
 }
 
 impl HitMenu {
     fn of(hit: &Hit) -> Option<Self> {
         match hit {
             Hit::Song(track) => Some(Self::Song(Box::new(track.clone()))),
-            Hit::Artist(_) | Hit::Album(_) | Hit::Playlist(_) => hit.pin().map(Self::Item),
+            Hit::Album(album) => Some(Self::Album(album.clone())),
+            Hit::Playlist(list) => Some(Self::Playlist(list.clone())),
+            Hit::Artist(artist) if artist.id.is_some() => Some(Self::Artist(artist.clone())),
+            Hit::Artist(_) => None,
         }
     }
 }
@@ -798,6 +803,65 @@ fn menu(
     }
 }
 
+fn album_of(hit: &AlbumHit, cx: &App) -> Album {
+    Sonora::global(cx)
+        .library
+        .read(cx)
+        .album(&hit.id)
+        .cloned()
+        .unwrap_or_else(|| Album {
+            id: hit.id.clone(),
+            name: hit.name.clone(),
+            artists: hit.artists.clone(),
+            artist_refs: hit.artist_refs.clone(),
+            cover: hit.cover.clone(),
+            cover_large: hit.cover.clone(),
+            release_type: ReleaseType::Album,
+            year: 0,
+            track_count: 0,
+            release_date: String::new(),
+            label: String::new(),
+            copyrights: Vec::new(),
+            added_at: None,
+        })
+}
+
+fn playlist_of(hit: &PlaylistHit, cx: &App) -> Playlist {
+    Sonora::global(cx)
+        .library
+        .read(cx)
+        .playlist(&hit.id)
+        .cloned()
+        .unwrap_or_else(|| Playlist {
+            id: hit.id.clone(),
+            name: hit.name.clone(),
+            owner: hit.owner.clone(),
+            owner_id: String::new(),
+            owned: false,
+            collaborative: false,
+            blend: false,
+            public: false,
+            cover: hit.cover.clone(),
+            track_count: 0,
+            modified_at: None,
+        })
+}
+
+fn artist_of(hit: &ArtistHit, cx: &App) -> SavedArtist {
+    let id = hit.id.clone().unwrap_or_default();
+    Sonora::global(cx)
+        .library
+        .read(cx)
+        .artist(&id)
+        .cloned()
+        .unwrap_or_else(|| SavedArtist {
+            id,
+            name: hit.name.clone(),
+            cover: hit.cover.clone(),
+            added_at: None,
+        })
+}
+
 fn cover(hit: &Hit) -> Option<String> {
     match hit {
         Hit::Song(track) => track.cover.clone(),
@@ -863,7 +927,15 @@ impl Render for SearchView {
         let context_menu = self.context_menu.clone().map(|(target, position)| {
             let menu = match target {
                 HitMenu::Song(track) => self.track_menu.for_track(&track, cx),
-                HitMenu::Item(pin) => item_menu(&pin, &self.track_menu, self.playback.clone(), cx),
+                HitMenu::Album(hit) => {
+                    album_menu(album_of(&hit, cx), self.playback.clone(), false, cx)
+                }
+                HitMenu::Playlist(hit) => {
+                    playlist_menu(playlist_of(&hit, cx), self.playback.clone(), false, cx)
+                }
+                HitMenu::Artist(hit) => {
+                    artist_menu(artist_of(&hit, cx), self.playback.clone(), false, cx)
+                }
             };
 
             Popup::new(position, menu).on_close(cx.listener(|this, _, _, cx| {

--- a/crates/views/src/shared/confirm.rs
+++ b/crates/views/src/shared/confirm.rs
@@ -1,0 +1,160 @@
+use gpui::prelude::*;
+use gpui::{App, Context, Entity, FocusHandle, Global, Render, Window, div};
+use i18n::t;
+use ui::{ActiveTheme as _, Button, Dismiss, FORM_CONTEXT, Modal, Submit};
+
+#[derive(Clone, Copy)]
+pub(crate) enum Kind {
+    LibrarySongs(usize),
+    PlaylistSongs(usize),
+    History(usize),
+    Albums(usize),
+    Artists(usize),
+    Playlists(usize),
+}
+
+impl Kind {
+    fn title(&self) -> gpui::SharedString {
+        match self {
+            Self::PlaylistSongs(_) => t!("confirm-remove-playlist-title"),
+            Self::History(_) => t!("confirm-remove-history-title"),
+            Self::Artists(_) => t!("confirm-unfollow-title"),
+            _ => t!("confirm-remove-library-title"),
+        }
+    }
+
+    fn detail(&self) -> gpui::SharedString {
+        match *self {
+            Self::LibrarySongs(count) => t!("confirm-remove-songs", count = count),
+            Self::PlaylistSongs(count) => t!("confirm-remove-playlist-songs", count = count),
+            Self::History(count) => t!("confirm-remove-history-songs", count = count),
+            Self::Albums(count) => t!("confirm-remove-albums", count = count),
+            Self::Artists(count) => t!("confirm-unfollow-artists", count = count),
+            Self::Playlists(count) => t!("confirm-remove-playlists", count = count),
+        }
+    }
+
+    fn action(&self) -> gpui::SharedString {
+        match self {
+            Self::Artists(_) => t!("artist-unfollow"),
+            _ => t!("common-delete"),
+        }
+    }
+}
+
+type Apply = Box<dyn FnOnce(&mut App)>;
+
+struct Pending {
+    kind: Kind,
+    apply: Apply,
+}
+
+pub(crate) struct Confirm {
+    pending: Option<Pending>,
+    focus: FocusHandle,
+    restore: Option<FocusHandle>,
+    grab: bool,
+}
+
+struct Installed(Entity<Confirm>);
+
+impl Global for Installed {}
+
+impl Confirm {
+    pub fn entity(cx: &mut App) -> Entity<Self> {
+        if cx.try_global::<Installed>().is_none() {
+            let confirm = cx.new(|cx| Self {
+                pending: None,
+                focus: cx.focus_handle(),
+                restore: None,
+                grab: false,
+            });
+            cx.set_global(Installed(confirm));
+        }
+        cx.global::<Installed>().0.clone()
+    }
+
+    pub fn ask(kind: Kind, apply: impl FnOnce(&mut App) + 'static, cx: &mut App) {
+        let confirm = Self::entity(cx);
+        confirm.update(cx, |this, cx| {
+            this.pending = Some(Pending {
+                kind,
+                apply: Box::new(apply),
+            });
+            this.grab = true;
+            cx.notify();
+        });
+    }
+
+    fn close(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.pending = None;
+        self.grab = false;
+        if let Some(focus) = self.restore.take() {
+            window.focus(&focus, cx);
+        }
+        cx.notify();
+    }
+
+    fn apply(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(pending) = self.pending.take() else {
+            return;
+        };
+        self.grab = false;
+        if let Some(focus) = self.restore.take() {
+            window.focus(&focus, cx);
+        }
+        (pending.apply)(cx);
+        cx.notify();
+    }
+}
+
+impl Render for Confirm {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let Some(pending) = self.pending.as_ref() else {
+            return div().into_any_element();
+        };
+        if self.grab {
+            self.restore = window.focused(cx);
+            window.focus(&self.focus, cx);
+            self.grab = false;
+        }
+
+        let title = pending.kind.title();
+        let detail = pending.kind.detail();
+        let action = pending.kind.action();
+        let theme = *cx.theme();
+
+        div()
+            .absolute()
+            .inset_0()
+            .key_context(FORM_CONTEXT)
+            .track_focus(&self.focus)
+            .on_action(cx.listener(|this, _: &Dismiss, window, cx| {
+                cx.stop_propagation();
+                this.close(window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &Submit, window, cx| {
+                cx.stop_propagation();
+                this.apply(window, cx);
+            }))
+            .child(
+                Modal::new("confirm-remove", title)
+                    .w(theme.metrics.cover * 2.8)
+                    .detail(detail)
+                    .action(
+                        Button::new("cancel-confirm")
+                            .ghost()
+                            .label(t!("common-cancel"))
+                            .on_click(cx.listener(|this, _, window, cx| this.close(window, cx))),
+                    )
+                    .action(
+                        Button::new("apply-confirm")
+                            .danger()
+                            .label(action)
+                            .on_click(cx.listener(|this, _, window, cx| this.apply(window, cx))),
+                    )
+                    .on_dismiss(cx.listener(|this, _, window, cx| this.close(window, cx))),
+            )
+            .into_any_element()
+    }
+}

--- a/crates/views/src/shared/confirm.rs
+++ b/crates/views/src/shared/confirm.rs
@@ -1,7 +1,9 @@
 use gpui::prelude::*;
 use gpui::{App, Context, Entity, FocusHandle, Global, Render, Window, div};
 use i18n::t;
-use ui::{ActiveTheme as _, Button, Dismiss, FORM_CONTEXT, Modal, Submit};
+use music::{Album, SavedArtist, Track};
+use state::{Detail, History, Sonora};
+use ui::{Button, Dismiss, FORM_CONTEXT, Modal, Submit};
 
 #[derive(Clone, Copy)]
 pub(crate) enum Kind {
@@ -86,6 +88,104 @@ impl Confirm {
         });
     }
 
+    pub fn library_songs(tracks: Vec<Track>, cx: &mut App) {
+        if tracks.is_empty() {
+            return;
+        }
+        Self::ask(
+            Kind::LibrarySongs(tracks.len()),
+            move |cx| {
+                let library = Sonora::global(cx).library.clone();
+                library.update(cx, |library, cx| library.save_tracks(tracks, false, cx));
+            },
+            cx,
+        );
+    }
+
+    pub fn playlist_songs(ids: Vec<String>, detail: Entity<Detail>, count: usize, cx: &mut App) {
+        if ids.is_empty() {
+            return;
+        }
+        Self::ask(
+            Kind::PlaylistSongs(count),
+            move |cx| {
+                detail.update(cx, |detail, cx| detail.remove_tracks_from_playlist(ids, cx));
+            },
+            cx,
+        );
+    }
+
+    pub fn history_songs(tracks: Vec<Track>, history: Entity<History>, cx: &mut App) {
+        if tracks.is_empty() {
+            return;
+        }
+        Self::ask(
+            Kind::History(tracks.len()),
+            move |cx| {
+                history.update(cx, |history, cx| {
+                    for track in &tracks {
+                        history.remove(track, cx);
+                    }
+                });
+            },
+            cx,
+        );
+    }
+
+    pub fn albums(albums: Vec<Album>, cx: &mut App) {
+        if albums.is_empty() {
+            return;
+        }
+        Self::ask(
+            Kind::Albums(albums.len()),
+            move |cx| {
+                let library = Sonora::global(cx).library.clone();
+                library.update(cx, |library, cx| {
+                    for album in albums {
+                        library.toggle_album(album, cx);
+                    }
+                });
+            },
+            cx,
+        );
+    }
+
+    pub fn artists(artists: Vec<SavedArtist>, cx: &mut App) {
+        if artists.is_empty() {
+            return;
+        }
+        Self::ask(
+            Kind::Artists(artists.len()),
+            move |cx| {
+                let library = Sonora::global(cx).library.clone();
+                library.update(cx, |library, cx| {
+                    for artist in artists {
+                        library.toggle_artist(artist, cx);
+                    }
+                });
+            },
+            cx,
+        );
+    }
+
+    pub fn playlists(ids: Vec<String>, cx: &mut App) {
+        if ids.is_empty() {
+            return;
+        }
+        Self::ask(
+            Kind::Playlists(ids.len()),
+            move |cx| {
+                let library = Sonora::global(cx).library.clone();
+                library.update(cx, |library, cx| {
+                    for id in ids {
+                        library.remove_playlist_from_library(id, cx);
+                    }
+                });
+            },
+            cx,
+        );
+    }
+
     fn close(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.pending = None;
         self.grab = false;
@@ -122,7 +222,6 @@ impl Render for Confirm {
         let title = pending.kind.title();
         let detail = pending.kind.detail();
         let action = pending.kind.action();
-        let theme = *cx.theme();
 
         div()
             .absolute()
@@ -139,7 +238,6 @@ impl Render for Confirm {
             }))
             .child(
                 Modal::new("confirm-remove", title)
-                    .w(theme.metrics.cover * 2.8)
                     .detail(detail)
                     .action(
                         Button::new("cancel-confirm")

--- a/crates/views/src/shared/menus/context.rs
+++ b/crates/views/src/shared/menus/context.rs
@@ -5,6 +5,7 @@ use router::{Destination, navigate};
 use state::{Detail, History, Library, LibraryState, Origin, Playback, Sonora};
 use ui::{Menu, MenuItem, Pin, PinKind, Scrollbar, SubmenuState};
 
+use crate::shared::confirm::Confirm;
 use crate::shared::playlist_editor::{Edit, PlaylistEditor};
 
 #[derive(Clone)]
@@ -110,9 +111,7 @@ impl ItemMenu {
             )
             .icon("icons/x.svg")
             .on_click(move |_, _, cx| {
-                detail.update(cx, |detail, cx| {
-                    detail.remove_tracks_from_playlist(ids.clone(), cx)
-                });
+                Confirm::playlist_songs(ids.clone(), detail.clone(), count, cx)
             }),
         };
         self.build(tracks, Some(remove), None, None, columns, cx)
@@ -135,13 +134,7 @@ impl ItemMenu {
             ),
         )
         .icon("icons/trash-2.svg")
-        .on_click(move |_, _, cx| {
-            history.update(cx, |history, cx| {
-                for track in &held {
-                    history.remove(track, cx);
-                }
-            });
-        });
+        .on_click(move |_, _, cx| Confirm::history_songs(held.clone(), history.clone(), cx));
         self.build(tracks, None, Some(forget), None, columns, cx)
     }
 
@@ -476,18 +469,17 @@ fn library_toggle(tracks: &[Track], library: &Entity<Library>, cx: &App) -> Menu
         false => {
             let library = library.clone();
             item.on_click(move |_, _, cx| {
+                if saved {
+                    Confirm::library_songs(actionable.clone(), cx);
+                    return;
+                }
                 library.update(cx, |library, cx| {
-                    let tracks = match saved {
-                        true => actionable.clone(),
-                        false => actionable
-                            .iter()
-                            .filter(|track| {
-                                !track.id.as_deref().is_some_and(|id| library.saved(id))
-                            })
-                            .cloned()
-                            .collect(),
-                    };
-                    library.save_tracks(tracks, !saved, cx);
+                    let tracks = actionable
+                        .iter()
+                        .filter(|track| !track.id.as_deref().is_some_and(|id| library.saved(id)))
+                        .cloned()
+                        .collect();
+                    library.save_tracks(tracks, true, cx);
                 });
             })
         }
@@ -581,8 +573,12 @@ fn album_library_item(album: Album, cx: &App) -> MenuItem {
 
     match library.read(cx).pending_album(&album.id) {
         true => item.disabled(),
-        false => item.on_click(move |_, _, cx| {
-            library.update(cx, |library, cx| library.toggle_album(album.clone(), cx));
+        false => item.on_click(move |_, _, cx| match saved {
+            true => Confirm::albums(vec![album.clone()], cx),
+            false => {
+                let library = Sonora::global(cx).library.clone();
+                library.update(cx, |library, cx| library.toggle_album(album.clone(), cx));
+            }
         }),
     }
 }
@@ -663,8 +659,12 @@ fn artist_library_item(artist: SavedArtist, cx: &App) -> Option<MenuItem> {
 
     Some(match library.read(cx).pending_artist(&artist.id) {
         true => item.disabled(),
-        false => item.on_click(move |_, _, cx| {
-            library.update(cx, |library, cx| library.toggle_artist(artist.clone(), cx));
+        false => item.on_click(move |_, _, cx| match followed {
+            true => Confirm::artists(vec![artist.clone()], cx),
+            false => {
+                let library = Sonora::global(cx).library.clone();
+                library.update(cx, |library, cx| library.toggle_artist(artist.clone(), cx));
+            }
         }),
     })
 }
@@ -972,12 +972,7 @@ fn playlist_library_item(playlist: Playlist, cx: &App) -> MenuItem {
             let id = playlist.id;
             MenuItem::new("leave-playlist", t!("menu-remove-playlist-from-library"))
                 .icon("icons/heart-off.svg")
-                .on_click(move |_, _, cx| {
-                    let library = Sonora::global(cx).library.clone();
-                    library.update(cx, |library, cx| {
-                        library.remove_playlist_from_library(id.clone(), cx)
-                    });
-                })
+                .on_click(move |_, _, cx| Confirm::playlists(vec![id.clone()], cx))
         }
         false => MenuItem::new("join-playlist", t!("menu-add-playlist-to-library"))
             .icon("icons/heart.svg")

--- a/crates/views/src/shared/mod.rs
+++ b/crates/views/src/shared/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod album_grid;
 pub(crate) mod browsers;
 pub(crate) mod cards;
 pub(crate) mod cells;
+pub(crate) mod confirm;
 pub(crate) mod hero;
 pub(crate) mod menus;
 pub(crate) mod page;

--- a/crates/views/src/shared/tracks/mod.rs
+++ b/crates/views/src/shared/tracks/mod.rs
@@ -80,6 +80,41 @@ pub(crate) fn ordered(table: &Entity<TableState<TrackSource>>, cx: &App) -> Vec<
         .collect()
 }
 
+pub(crate) fn drop_picked(table: &Entity<TableState<TrackSource>>, cx: &mut App) {
+    let rows = table.read(cx).delegate().picked();
+    if rows.is_empty() {
+        return;
+    }
+    let (tracks, playlist, history) = {
+        let state = table.read(cx);
+        let source = state.delegate().source();
+        let tracks: Vec<Track> = rows.iter().filter_map(|&row| source.at(row, cx)).collect();
+        (tracks, source.playlist.clone(), source.history.clone())
+    };
+    if tracks.is_empty() {
+        return;
+    }
+    if let Some(detail) = playlist {
+        let ids: Vec<String> = tracks.iter().filter_map(|track| track.id.clone()).collect();
+        if !ids.is_empty() {
+            detail.update(cx, |detail, cx| detail.remove_tracks_from_playlist(ids, cx));
+        }
+    } else if let Some(history) = history {
+        history.update(cx, |history, cx| {
+            for track in &tracks {
+                history.remove(track, cx);
+            }
+        });
+    } else {
+        let library = Sonora::global(cx).library.clone();
+        library.update(cx, |library, cx| library.save_tracks(tracks, false, cx));
+    }
+    table.update(cx, |table, cx| {
+        table.delegate_mut().clear_selection();
+        cx.notify();
+    });
+}
+
 type Whence = Rc<dyn Fn(&App) -> Option<Origin>>;
 
 pub(crate) struct TrackSource {
@@ -266,36 +301,13 @@ impl TrackSource {
         color: Option<Hsla>,
         cx: &App,
     ) -> AnyElement {
-        let press: Option<cells::Tap> = match track.playable {
-            true => {
-                let playback = self.playback.clone();
-                let provider = self.provider.clone();
-                let table = self.table.clone();
-                let whence = self.whence.clone();
-                let row = cell.row;
-                let display = cell.display;
-                Some(Box::new(move |cx| {
-                    let from = whence.as_ref().and_then(|whence| whence(cx));
-                    playback.update(cx, |playback, cx| {
-                        match table.as_ref().and_then(|table| table.upgrade()) {
-                            Some(table) => playback.start(ordered(&table, cx), display, from, cx),
-                            None => playback.start(provider.tracks(cx).to_vec(), row, from, cx),
-                        }
-                    });
-                }))
-            }
-            false => None,
-        };
-
-        let is_liked = self.liked_button(cell, track, cx);
-
         cells::title(
             cell,
             track.name.clone(),
             color,
             track.explicit,
-            press,
-            is_liked,
+            None,
+            self.liked_button(cell, track, cx),
         )
     }
 

--- a/crates/views/src/shared/tracks/mod.rs
+++ b/crates/views/src/shared/tracks/mod.rs
@@ -21,6 +21,7 @@ use ui::{
 };
 
 use crate::shared::cells;
+use crate::shared::confirm::{Confirm, Kind};
 use crate::shared::pins::Pinned as _;
 
 pub(crate) use columns::{
@@ -94,24 +95,51 @@ pub(crate) fn drop_picked(table: &Entity<TableState<TrackSource>>, cx: &mut App)
     if tracks.is_empty() {
         return;
     }
+    let kind = if playlist.is_some() {
+        Kind::PlaylistSongs(tracks.len())
+    } else if history.is_some() {
+        Kind::History(tracks.len())
+    } else {
+        Kind::LibrarySongs(tracks.len())
+    };
+    let table = table.clone();
+    Confirm::ask(
+        kind,
+        move |cx| {
+            forget(&tracks, playlist.as_ref(), history.as_ref(), cx);
+            table.update(cx, |table, cx| {
+                table.delegate_mut().clear_selection();
+                cx.notify();
+            });
+        },
+        cx,
+    );
+}
+
+fn forget(
+    tracks: &[Track],
+    playlist: Option<&Entity<Detail>>,
+    history: Option<&Entity<History>>,
+    cx: &mut App,
+) {
     if let Some(detail) = playlist {
         let ids: Vec<String> = tracks.iter().filter_map(|track| track.id.clone()).collect();
         if !ids.is_empty() {
             detail.update(cx, |detail, cx| detail.remove_tracks_from_playlist(ids, cx));
         }
-    } else if let Some(history) = history {
+        return;
+    }
+    if let Some(history) = history {
         history.update(cx, |history, cx| {
-            for track in &tracks {
+            for track in tracks {
                 history.remove(track, cx);
             }
         });
-    } else {
-        let library = Sonora::global(cx).library.clone();
-        library.update(cx, |library, cx| library.save_tracks(tracks, false, cx));
+        return;
     }
-    table.update(cx, |table, cx| {
-        table.delegate_mut().clear_selection();
-        cx.notify();
+    let library = Sonora::global(cx).library.clone();
+    library.update(cx, |library, cx| {
+        library.save_tracks(tracks.to_vec(), false, cx)
     });
 }
 

--- a/crates/views/src/shells/workspace.rs
+++ b/crates/views/src/shells/workspace.rs
@@ -12,6 +12,7 @@ use ui::{
 use crate::chrome::{
     Chrome, PlayerBar, SidebarLeft, SidebarRight, TitleBarOptions, ToastStack, UpdateNotice,
 };
+use crate::shared::confirm::Confirm;
 use crate::shared::playlist_editor::PlaylistEditor;
 use crate::shells::Shell;
 
@@ -47,6 +48,7 @@ pub(crate) struct Workspace {
     player_bar: Entity<PlayerBar>,
     sidebar_right: Entity<SidebarRight>,
     playlist_editor: Entity<PlaylistEditor>,
+    confirm: Entity<Confirm>,
     toasts: Entity<ToastStack>,
     notice: Entity<UpdateNotice>,
     content: AnyView,
@@ -70,6 +72,7 @@ impl Workspace {
             player_bar,
             sidebar_right,
             playlist_editor: PlaylistEditor::entity(cx),
+            confirm: Confirm::entity(cx),
             toasts: cx.new(ToastStack::new),
             notice: cx.new(UpdateNotice::new),
             content,
@@ -295,6 +298,7 @@ impl Render for Workspace {
                     .child(self.toasts.clone()),
             )
             .child(self.playlist_editor.clone())
+            .child(self.confirm.clone())
             .child(self.notice.clone())
     }
 }

--- a/crates/views/src/shells/workspace.rs
+++ b/crates/views/src/shells/workspace.rs
@@ -5,7 +5,9 @@ use gpui::{AnyView, App, Context, Entity, FocusHandle, Render, StyleRefinement, 
 use gpui::{Window, div};
 use input::WORKSPACE_CONTEXT;
 use state::{Playback, Queue, SideTab};
-use ui::{Activate, Deselect, Motion, SelectNext, SelectPrevious, ease_out_expo, shown_listing};
+use ui::{
+    Activate, Deselect, Motion, Remove, SelectNext, SelectPrevious, ease_out_expo, shown_listing,
+};
 
 use crate::chrome::{
     Chrome, PlayerBar, SidebarLeft, SidebarRight, TitleBarOptions, ToastStack, UpdateNotice,
@@ -231,6 +233,12 @@ impl Render for Workspace {
             .on_action(|_: &Activate, _, cx| {
                 if let Some(table) = shown_listing(cx) {
                     table.activate(cx);
+                    cx.stop_propagation();
+                }
+            })
+            .on_action(|_: &Remove, _, cx| {
+                if let Some(table) = shown_listing(cx) {
+                    table.remove(cx);
                     cx.stop_propagation();
                 }
             })


### PR DESCRIPTION
## Summary\n\n- select and activate rows consistently across all media tables\n- confirm destructive library, playlist, and history operations\n- expose complete context actions for search media\n- retain the selected row set while a table context menu is open\n- refresh translation coverage\n\n## Validation\n\n- \n- \n- 
running 4 tests
test tests::english_carries_every_key ... ok
test tests::plurals_pick_the_right_category ... ok
test tests::every_message_resolves ... ok
test tests::no_locale_invents_a_key ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 88 tests
test local::scan::tests::empty_root_yields_nothing ... ok
test lrclib::tests::skips_an_entry_without_any_lyrics ... ok
test lrclib::tests::an_empty_lyricsfile_line_preserves_an_instrumental_pause ... ok
test lrclib::tests::a_broken_lyricsfile_falls_back_to_the_lrc ... ok
test lrclib::tests::a_lyricsfile_with_words_beats_the_lrc ... ok
test lrclib::tests::prefers_synced_over_plain ... ok
test lyrics::lrc::tests::a_bare_end_tag_closes_the_last_word ... ok
test lyrics::lrc::tests::an_empty_timed_line_becomes_a_gap_between_lyrics ... ok
test lyrics::lrc::tests::a_repeated_worded_line_moves_its_words_along ... ok
test lyrics::lrc::tests::a_standalone_parenthetical_line_attaches_to_the_previous_verse ... ok
test lyrics::lrc::tests::angle_brackets_that_are_not_stamps_stay_in_the_text ... ok
test lyrics::lrc::tests::parses_lrc_and_closes_every_line ... ok
test lyrics::lrc::tests::reads_a_stamp ... ok
test lyrics::lrc::tests::one_line_can_carry_several_stamps ... ok
test lyrics::lrc::tests::parenthetical_words_become_an_independently_timed_background_lane ... ok
test local::scan::tests::ignores_non_audio_files ... ok
test lyrics::lrc::tests::reads_word_tags ... ok
test lyrics::romanize::tests::distinguishes_selectable_writing_systems ... ok
test lyrics::romanize::tests::latin_lyrics_do_not_get_a_duplicate_line ... ok
test lyrics::romanize::tests::generates_primary_and_background_romanization ... ok
test lyrics::lrc::tests::removing_an_inline_background_lane_closes_the_punctuation_gap ... ok
test lyrics::romanize::tests::romanizes_cyrillic_locally ... ok
test lyrics::lrc::tests::section_labels_and_decorative_marks_are_not_lyrics ... ok
test local::scan::tests::walks_nested_folders_for_stray_audio_files ... ok
test lyrics::tests::a_sung_line_holds_until_the_next_one_starts ... ok
test lyrics::tests::a_different_recording_is_not_treated_as_the_same_track ... ok
test lyrics::tests::a_same_length_song_by_the_same_artist_is_still_rejected ... ok
test lyrics::tests::a_matching_album_pulls_ahead ... ok
test lyrics::tests::a_short_title_does_not_match_a_long_one ... ok
test lyrics::romanize::tests::romanizes_japanese_with_song_wide_script_detection ... ok
test lyrics::tests::a_wrong_track_falls_behind ... ok
test lyrics::tests::a_truncated_sync_falls_behind ... ok
test lyrics::tests::karaoke_cannot_rescue_the_wrong_artist ... ok
test lyrics::tests::equal_hits_keep_a_stable_order ... ok
test lyrics::tests::one_stylized_shout_does_not_reject_an_otherwise_clean_sheet ... ok
test lyrics::tests::the_active_line_follows_the_clock ... ok
test lyrics::tests::the_active_word_follows_the_clock ... ok
test lyrics::tests::synced_breaks_a_tie ... ok
test lyrics::tests::one_shared_artist_is_enough_for_a_collaboration ... ok
test lyrics::tests::noisy_karaoke_cannot_beat_clean_lyrics ... ok
test lyrics::tests::the_closest_duration_wins ... ok
test lyrics::tests::trust_settles_an_otherwise_even_match ... ok
test lyrics::tests::twin_uploads_collapse_into_one ... ok
test lyrics::tests::worded_beats_merely_synced ... ok
test netease::tests::the_closest_durations_make_the_shortlist ... ok
test netease::tests::reads_a_yrc_line ... ok
test netease::tests::credit_headers_name_the_writers ... ok
test spotify::artists::tests::biography_html_becomes_readable_text ... ok
test netease::tests::untimed_parentheses_become_a_background_lane ... ok
test spotify::auth::tests::defaults_a_missing_port ... ok
test spotify::artists::tests::every_edition_survives_but_market_duplicates_do_not ... ok
test spotify::auth::tests::reads_host_and_port ... ok
test spotify::auth::tests::rejects_a_uri_without_a_scheme ... ok
test spotify::collection2::tests::drops_removed_item ... ok
test spotify::collection2::tests::parses_saved_item_with_date ... ok
test spotify::pathfinder::album::tests::advances_page_offset ... ok
test spotify::pathfinder::album::tests::maps_track_uri_to_playcount ... ok
test spotify::pathfinder::artist::tests::sends_current_overview_variables ... ok
test spotify::pathfinder::hashes::tests::keeps_the_operations_of_a_registry ... ok
test spotify::pathfinder::artist::tests::accepts_null_biography ... ok
test spotify::pathfinder::hashes::tests::rejects_an_empty_registry ... ok
test spotify::pathfinder::plays::tests::decodes_playcount ... ok
test spotify::pathfinder::hashes::tests::rejects_a_malformed_hash ... ok
test spotify::pathfinder::tests::decodes_data ... ok
test spotify::pathfinder::album::tests::decodes_album_page ... ok
test spotify::pathfinder::tests::reports_graphql_error ... ok
test spotify::playlists::tests::a_created_playlist_is_appended_to_the_rootlist ... ok
test spotify::pathfinder::artist::tests::decodes_overview ... ok
test spotify::playlists::tests::addition_appends_without_an_index ... ok
test spotify::playlists::tests::attribute_ops_set_one_value_each ... ok
test spotify::playlists::tests::a_name_survives_the_wire_in_any_script ... ok
test spotify::playlists::tests::every_op_encodes ... ok
test spotify::playlists::tests::removal_carries_the_index_and_the_revision ... ok
test spotify::playlists::tests::visibility_targets_the_rootlist_item ... ok
test youtube::auth::tests::picks_the_cookie_line_out_of_a_blob ... ok
test youtube::auth::tests::accepts_the_secure_variant_alone ... ok
test spotify::search::tests::percent_encodes_utf8 ... ok
test spotify::playlists::tests::leaving_a_playlist_rems_the_rootlist_item ... ok
test youtube::auth::tests::drops_the_header_name ... ok
test youtube::auth::tests::rejects_a_bare_cookie_name ... ok
test spotify::radio::tests::extracts_playlist_from_radio_response ... ok
test spotify::search::tests::keeps_latin_and_folds_spaces ... ok
test youtube::auth::tests::rejects_a_signed_out_header ... ok
test spotify::playlists::tests::position_is_absolute_within_a_page ... ok
test youtube::auth::tests::rejects_an_empty_paste ... ok
test youtube::playback::tests::normalisation_never_boosts ... ok
test youtube::playback::tests::normalisation_attenuates_loud_tracks ... ok
test youtube::auth::tests::keeps_a_signed_in_header ... ok

test result: ok. 88 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 6 tests
test uri::tests::drops_the_share_query ... ok
test uri::tests::reads_the_legacy_user_playlist_uri ... ok
test uri::tests::reads_web_links ... ok
test uri::tests::reads_every_uri_kind ... ok
test uri::tests::skips_the_locale_segment ... ok
test uri::tests::refuses_what_it_cannot_route ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 5 tests
test memory::tests::counters_ignore_lines_that_only_look_like_mappings ... ok
test memory::tests::every_mapping_lands_in_a_bucket ... ok
test http::tests::removes_expired_images ... ok
test http::tests::reads_a_cached_image_and_refreshes_its_age ... ok
test http::tests::evicts_the_least_recently_used_image_at_the_size_limit ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 68 tests
test mosaic::tests::a_path_never_escapes_the_cache_directory ... ok
test lyrics::tests::a_displayed_karaoke_result_stays_selected_after_final_ranking ... ok
test home::tests::mixed_selection_excludes_unavailable_tracks ... ok
test home::tests::mixed_selection_adds_artist_variety ... ok
test playback::tests::halves_the_slider_to_the_taper_midpoint ... ok
test playback::tests::live_clock_does_not_jump_when_corrected ... ok
test home::tests::mixed_selection_is_stable_and_has_no_duplicates ... ok
test playback::tests::live_clock_slews_backward_corrections_without_reversing ... ok
test playback::tests::never_amplifies_past_unity ... ok
test playback::tests::rises_with_the_slider ... ok
test catalog::tests::hits_and_retries_errors ... ok
test playback::tests::silences_a_closed_slider ... ok
test queue::tests::a_saved_track_keeps_what_the_player_bar_shows ... ok
test queue::tests::a_track_without_an_id_is_never_saved ... ok
test queue::tests::an_imported_track_outlives_the_session ... ok
test queue::tests::converts_gaps_to_insertion_indices ... ok
test queue::tests::gap_moves_match_visual_positions ... ok
test queue::tests::ignores_invalid_moves ... ok
test queue::tests::moves_items_in_both_directions ... ok
test queue::tests::restoring_keeps_both_copies_of_a_repeated_track ... ok
test queue::tests::a_record_caps_the_history_and_the_queue ... ok
test queue::tests::restoring_puts_unknown_tracks_last ... ok
test queue::tests::selecting_invalid_past_track_keeps_the_queue ... ok
test queue::tests::scrambling_keeps_every_track ... ok
test queue::tests::restoring_returns_the_source_order ... ok
test queue::tests::selecting_invalid_upcoming_track_keeps_the_queue ... ok
test queue::tests::selecting_past_rebuilds_the_queue_from_that_track ... ok
test queue::tests::selecting_upcoming_moves_skipped_tracks_to_the_past ... ok
test queue::tests::sifting_keeps_only_what_is_wanted ... ok
test queue::tests::sifting_reports_an_untouched_queue ... ok
test queue::tests::signing_out_leaves_only_imported_tracks ... ok
test queue::tests::spots_a_reordered_queue ... ok
test queue::tests::trimming_drops_the_oldest_history ... ok
test catalog::tests::playlist_invalidation_is_scoped_to_one_id ... ok
test catalog::tests::artist_navigation_reuses_the_first_artist ... ok
test search::tests::a_weak_library_hit_still_beats_the_catalog_top ... ok
test search::tests::artist_pictures_come_from_portraits ... ok
test search::tests::a_library_hit_holds_its_place_when_the_catalog_answers ... ok
test catalog::tests::song_reuses_an_album_loaded_by_album_detail ... ok
test catalog::tests::empty_details_are_cache_hits ... ok
test search::tests::artists_with_the_same_name_keep_separate_ids ... ok
test search::tests::every_term_must_match ... ok
test search::tests::library_songs_are_counted_for_artists ... ok
test search::tests::catalog_keeps_the_order_it_answered_with ... ok
test catalog::tests::song_keeps_its_required_track_when_enrichment_fails ... ok
test search::tests::popularity_breaks_ties ... ok
test search::tests::title_and_artist_terms_match_in_any_order ... ok
test search::tests::unmatched_catalog_entries_survive ... ok
test search::tests::whole_string_query_matches ... ok
test settings::tests::a_first_record_starts_from_the_beginning ... ok
test search::tests::saved_track_is_listed_once ... ok
test settings::tests::a_fresh_pin_lands_at_the_gap ... ok
test settings::tests::a_gap_past_the_end_still_appends ... ok
test settings::tests::a_new_track_starts_from_the_beginning ... ok
test settings::tests::a_move_backwards_keeps_the_gap ... ok
test settings::tests::another_provider_never_inherits_a_position ... ok
test settings::tests::kinds_with_the_same_id_stay_apart ... ok
test search::tests::library_exact_title_outranks_the_catalog_top ... ok
test settings::tests::no_gap_appends ... ok
test settings::tests::lyrics_start_karaoke_and_romanize_only_cjk ... ok
test settings::tests::pinning_twice_moves_instead_of_duplicating ... ok
test settings::tests::one_saved_romanization_choice_keeps_the_other_defaults ... ok
test settings::tests::the_gaps_around_an_item_are_no_ops ... ok
test settings::tests::the_saved_position_follows_the_same_track ... ok
test catalog::tests::replacing_a_source_cannot_return_the_old_sessions_values ... ok
test mosaic::tests::the_seam_leaves_no_gap_between_tiles ... ok
test mosaic::tests::each_tile_fills_its_own_quarter ... ok
test mosaic::tests::every_pixel_of_a_mosaic_is_opaque ... ok

test result: ok. 68 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 61 tests
test deck::tests::at_finds_the_row_under_an_offset ... ok
test deck::tests::span_starts_at_the_top_of_a_short_deck ... ok
test deck::tests::span_covers_the_visible_rows ... ok
test deck::tests::span_is_empty_without_rows ... ok
test deck::tests::tops_stack_rows_with_gaps ... ok
test filters::tests::clamping_leaves_a_selection_inside_the_bounds_alone ... ok
test filters::tests::clamping_pulls_a_stale_selection_into_view ... ok
test filters::tests::clock_and_plain_format_differently ... ok
test filters::tests::snapping_is_a_no_op_without_values ... ok
test filters::tests::every_present_value_owns_an_equal_slice ... ok
test filters::tests::stops_are_evenly_spaced_whatever_the_gaps ... ok
test deck::tests::extent_covers_every_row_and_the_gaps_between ... ok
test input::tests::clamps_past_the_end ... ok
test input::tests::clamps_ranges_in_order ... ok
test filters::tests::a_full_span_reads_as_untouched ... ok
test input::tests::clamps_to_char_boundaries ... ok
test input::tests::converts_utf16_offsets ... ok
test filters::tests::a_collapsed_axis_never_divides_by_zero ... ok
test input::tests::walks_char_boundaries ... ok
test filters::tests::a_selection_round_trips_through_its_seat ... ok
test input::tests::walks_words_backwards ... ok
test input::tests::walks_words_forwards ... ok
test motion::tests::expo_easing_has_css_endpoints_and_shape ... ok
test filters::tests::shares_round_trip_through_values ... ok
test filters::tests::a_position_between_stops_lands_on_the_nearer_value ... ok
test palette::tests::finds_the_dominant_hue ... ok
test palette::tests::averages_across_the_bin_boundary ... ok
test scrubber::tests::an_unmeasured_track_reads_zero ... ok
test palette::tests::ignores_a_small_splash_of_colour ... ok
test palette::tests::ignores_greyscale_artwork ... ok
test scrubber::tests::the_bubble_shows_exactly_where_the_grab_lands ... ok
test scrubber::tests::the_ends_clamp ... ok
test scrubber::tests::the_thumb_lands_under_the_pointer ... ok
test table::layout::tests::a_column_is_never_narrower_than_its_header ... ok
test table::layout::tests::a_header_that_cannot_fit_drops_its_column ... ok
test table::layout::tests::a_kept_column_has_room_to_read ... ok
test table::layout::tests::a_saved_order_moves_movable_columns_only ... ok
test table::layout::tests::anchored_columns_cannot_be_stretched ... ok
test table::layout::tests::anchored_columns_keep_their_natural_width ... ok
test table::layout::tests::columns_exactly_fill_the_room ... ok
test table::layout::tests::crowding_evicts_the_least_important_column_first ... ok
test table::layout::tests::dragging_never_enters_the_anchored_prefix ... ok
test table::layout::tests::dragging_past_half_a_neighbour_shifts_by_one ... ok
test table::layout::tests::every_surviving_header_fits_however_tight_the_room ... ok
test table::layout::tests::fill_columns_split_by_share ... ok
test table::layout::tests::hidden_columns_are_dropped ... ok
test table::layout::tests::hiding_everything_keeps_one_column ... ok
test table::layout::tests::narrow_rooms_drop_columns_but_still_fill ... ok
test table::layout::tests::reordering_rewrites_the_movable_keys ... ok
test table::layout::tests::saved_widths_are_honoured ... ok
test table::layout::tests::saved_widths_never_break_the_floor ... ok
test table::layout::tests::stretching_stops_at_the_floors_on_the_right ... ok
test table::layout::tests::stretching_takes_room_from_the_right ... ok
test table::layout::tests::the_last_column_has_no_room_to_take ... ok
test table::layout::tests::columns_leave_in_order_of_rank ... ok
test theme::tests::mixing_adopts_the_target_metrics_immediately ... ok
test theme::tests::mixing_runs_from_one_palette_to_the_other ... ok
test theme::tests::overrides_win_over_the_tint ... ok
test theme::tests::tinting_keeps_surface_contrast ... ok
test theme::tests::tinting_recolours_accents_per_polarity ... ok
test table::layout::tests::widening_never_takes_a_column_away ... ok

test result: ok. 61 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 36 tests
test chrome::aside::tests::a_finished_background_lane_stays_sung_until_its_line_departs ... ok
test chrome::aside::tests::a_finished_line_stays_past_during_a_gap ... ok
test chrome::aside::tests::a_late_first_word_uses_the_whole_lead_in ... ok
test chrome::aside::tests::drops_headers_for_empty_sections ... ok
test chrome::aside::tests::an_empty_queue_has_no_rows ... ok
test chrome::aside::tests::karaoke_uses_spacing_from_the_complete_line ... ok
test chrome::aside::tests::a_long_instrumental_pause_gets_its_own_lyrics_row ... ok
test chrome::aside::tests::lays_out_every_section ... ok
test chrome::aside::tests::lays_out_history_without_a_current_track ... ok
test chrome::aside::tests::lyrics_follow_preserves_a_subpixel_target ... ok
test chrome::aside::tests::lyrics_follow_uses_unscrolled_item_bounds ... ok
test chrome::aside::tests::lyrics_keep_an_oversized_fragment_on_its_own_row ... ok
test chrome::aside::tests::lyrics_row_springs_stagger_without_changing_their_damping_ratio ... ok
test chrome::aside::tests::lyrics_wrap_at_the_active_size_plan ... ok
test chrome::aside::tests::plain_lyrics_keep_spacing_in_breakable_fragments ... ok
test chrome::aside::tests::suggests_similar_tracks_without_anything_up_next ... ok
test chrome::aside::tests::word_timing_exposes_a_pause_hidden_by_the_line_end ... ok
test chrome::sidebar_left::tests::a_section_expands_only_where_it_leads ... ok
test chrome::sidebar_left::tests::content_belongs_to_neither_section ... ok
test screens::library::tests::card_anchor_follows_a_repacked_row ... ok
test screens::library::tests::heading_anchor_survives_a_repack ... ok
test shared::album_grid::tests::a_card_stays_within_its_bounds ... ok
test shared::album_grid::tests::a_row_never_outgrows_the_space_it_was_given ... ok
test shared::album_grid::tests::a_single_column_has_no_gap ... ok
test shared::album_grid::tests::slack_goes_to_the_gaps_once_the_cards_are_capped ... ok
test shared::album_grid::tests::cards_never_touch ... ok
test shared::picks::tests::columns_follow_width_and_stop_at_three ... ok
test shared::picks::tests::pages_include_every_track ... ok
test shared::picks::tests::the_deck_keeps_its_shape_whatever_it_holds ... ok
test shared::tracks::sieve::tests::duration_bounds_are_inclusive ... ok
test shared::tracks::sieve::tests::every_axis_must_pass ... ok
test shared::tracks::sort::tests::cyrillic_keeps_its_own_letter ... ok
test shared::tracks::sort::tests::digits_punctuation_and_emptiness_share_one_bucket ... ok
test shared::tracks::sort::tests::letters_bucket_under_their_uppercase_form ... ok
test shared::tracks::sort::tests::multi_char_uppercase_is_kept_whole ... ok
test shared::cells::tests::groups_count ... ok

test result: ok. 36 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s\n- 