### PR TITLE
Test live album library mutations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9431,7 +9431,7 @@ dependencies = [
 [[package]]
 name = "ytmusic"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/ytmusic-rs?rev=31e2c2e79ea2da7fd41c448371dbd4d91879d09d#31e2c2e79ea2da7fd41c448371dbd4d91879d09d"
+source = "git+https://github.com/nolight132/ytmusic-rs?rev=2f237e0251981ea577fb4103319bf6cd12a8dca4#2f237e0251981ea577fb4103319bf6cd12a8dca4"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ souvlaki = "0.8"
 sys-locale = "0.3"
 unic-langid = { version = "0.9", features = ["macros"] }
 unicode-segmentation = "1.12"
-ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "31e2c2e79ea2da7fd41c448371dbd4d91879d09d" }
+ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "2f237e0251981ea577fb4103319bf6cd12a8dca4" }
 
 librespot-core = { version = "0.8.0", default-features = false, features = [
   "rustls-tls-native-roots",

--- a/crates/music/src/album_tests.rs
+++ b/crates/music/src/album_tests.rs
@@ -1,0 +1,110 @@
+use std::time::Duration;
+
+use anyhow::{Context as _, Result, anyhow, bail};
+
+use crate::spotify::SpotifyProvider;
+use crate::youtube::YouTubeProvider;
+use crate::{Album, MusicApi, MusicProvider, ProviderSession};
+
+const SPOTIFY_ALBUMS: &[&str] = &["1vHPNtDfd0V29ol70EMqP8", "2Ef2E0yk88zQfjvOJunK8A"];
+const YOUTUBE_ALBUMS: &[&str] = &["MPREb_vupB1BNh7XE", "MPREb_3SWMG6RbCTQ"];
+const LIBRARY_LIMIT: u32 = 10_000;
+const VERIFY_ATTEMPTS: usize = 30;
+
+#[tokio::test]
+#[ignore = "changes the saved albums of the connected Spotify account"]
+async fn spotify_can_add_and_remove_an_album_for_the_connected_account() -> Result<()> {
+    let provider = SpotifyProvider::from_env();
+    let session = connected(&provider).await?;
+
+    exercise_album_cycles("Spotify", session.api.as_ref(), SPOTIFY_ALBUMS).await
+}
+
+#[tokio::test]
+#[ignore = "changes the saved albums of the connected YouTube Music account"]
+async fn youtube_can_add_and_remove_an_album_for_the_connected_account() -> Result<()> {
+    let provider = YouTubeProvider::new();
+    let session = connected(&provider).await?;
+
+    exercise_album_cycles("YouTube Music", session.api.as_ref(), YOUTUBE_ALBUMS).await
+}
+
+async fn exercise_album_cycles(
+    provider: &str,
+    api: &dyn MusicApi,
+    album_ids: &[&str],
+) -> Result<()> {
+    for album_id in album_ids {
+        exercise_album_cycle(provider, api, album_id).await?;
+    }
+    Ok(())
+}
+
+async fn connected(provider: &dyn MusicProvider) -> Result<ProviderSession> {
+    let session = provider
+        .restore()
+        .await?
+        .with_context(|| format!("{} has no stored Sonora session", provider.name()))?;
+    if !session.authenticated {
+        bail!(
+            "{} restored a guest session, not an account",
+            provider.name()
+        );
+    }
+    Ok(session)
+}
+
+async fn exercise_album_cycle(provider: &str, api: &dyn MusicApi, album_id: &str) -> Result<()> {
+    let album = api
+        .album(album_id)
+        .await
+        .with_context(|| format!("{provider} could not load album {album_id}"))?
+        .album;
+    let originally_saved = album_is_saved(api, &album.id).await?;
+    let changed = !originally_saved;
+
+    let exercise = async {
+        api.set_album_saved(&album.id, changed).await?;
+        wait_until_saved(api, &album, changed).await
+    }
+    .await;
+
+    let restore = async {
+        api.set_album_saved(&album.id, originally_saved).await?;
+        wait_until_saved(api, &album, originally_saved).await
+    }
+    .await;
+
+    match (exercise, restore) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) => Err(error.context("album cycle failed; original state restored")),
+        (Ok(()), Err(error)) => Err(error.context("album cycle passed but restoring it failed")),
+        (Err(exercise), Err(restore)) => Err(anyhow!(
+            "album cycle failed: {exercise:#}; restoring it also failed: {restore:#}"
+        )),
+    }
+}
+
+async fn wait_until_saved(api: &dyn MusicApi, album: &Album, expected: bool) -> Result<()> {
+    for _ in 0..VERIFY_ATTEMPTS {
+        if album_is_saved(api, &album.id).await? == expected {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    bail!(
+        "album {:?} ({}) did not become {}",
+        album.name,
+        album.id,
+        if expected { "saved" } else { "unsaved" }
+    )
+}
+
+async fn album_is_saved(api: &dyn MusicApi, album_id: &str) -> Result<bool> {
+    Ok(api
+        .saved_albums(LIBRARY_LIMIT)
+        .await?
+        .iter()
+        .any(|album| album.id == album_id))
+}

--- a/crates/music/src/lib.rs
+++ b/crates/music/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+mod album_tests;
 mod audio;
 pub mod binimum;
 pub mod kugou;


### PR DESCRIPTION
## Summary

- update `ytmusic-rs` to the revision that fixes album library mutations
- add opt-in live album tests for connected Spotify and YouTube Music accounts
- verify multiple fixed album IDs and restore every album's original saved state

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p music --no-fail-fast` (88 passed, 2 ignored live tests)
- `cargo clippy -p music --all-targets -- -D warnings`
- `cargo test -p music album_tests -- --ignored --nocapture --test-threads=1` (2 passed)