### PR TITLE
chore: release 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-08-31
+
 ### Added
 
 - Local Music is its own sidebar entry that expands into Songs, Favorites, Albums, Artists and
@@ -1169,7 +1171,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Initial release: a native Spotify client with playback, an interactive queue, the saved library,
 search, album, playlist, artist and song pages, context menus and adaptive theming.
 
-[unreleased]: https://github.com/nolight132/sonora/compare/v0.25.0...HEAD
+[unreleased]: https://github.com/nolight132/sonora/compare/v0.26.0...HEAD
+[0.26.0]: https://github.com/nolight132/sonora/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/nolight132/sonora/compare/v0.24.1...v0.25.0
 [0.24.1]: https://github.com/nolight132/sonora/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/nolight132/sonora/compare/v0.23.0...v0.24.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "i18n"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "fluent-bundle",
  "gpui",
@@ -3383,7 +3383,7 @@ dependencies = [
 
 [[package]]
 name = "input"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "gpui",
  "ui",
@@ -4217,7 +4217,7 @@ dependencies = [
 
 [[package]]
 name = "music"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6054,7 +6054,7 @@ dependencies = [
 
 [[package]]
 name = "router"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "gpui",
  "ui",
@@ -6800,7 +6800,7 @@ dependencies = [
 
 [[package]]
 name = "sonora"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -6930,7 +6930,7 @@ dependencies = [
 
 [[package]]
 name = "state"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7952,7 +7952,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "gpui",
  "i18n",
@@ -8278,7 +8278,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "views"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "gpui",
  "i18n",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.25.0"
+version = "0.26.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/nolight132/sonora"


### PR DESCRIPTION
## Summary

- promote the current Unreleased notes to 0.26.0
- update the workspace package version to 0.26.0
- refresh all eight workspace package versions in Cargo.lock