### PR TITLE
feat: opt-out usage ping on the sign-in screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Local Music stays in the sidebar before a folder is picked, and every one of its pages offers a
   Choose folder button so the library can be set up without opening Settings.
 - A toast that names an album, artist, playlist or song turns that name into a link to its page.
+- The sign-in screen carries a one-off checkbox that helps count how many people use Sonora. It is
+  ticked by default and sends a single anonymous ping with your next action on that screen; untick
+  it to send nothing. The checkbox never returns once you have signed in or answered it.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ partial translation is welcome — pick a language below and fill in what it lac
 
 | Language | Translated | Coverage |
 | --- | --- | --- |
-| English (`en-US`) | 493/493 | 100% |
-| Deutsch (`de`) | 472/493 | 96% |
-| Français (`fr`) | 472/493 | 96% |
-| Русский (`ru`) | 472/493 | 96% |
-| Українська (`uk`) | 472/493 | 96% |
-| Polski (`pl`) | 472/493 | 96% |
+| English (`en-US`) | 494/494 | 100% |
+| Deutsch (`de`) | 473/494 | 96% |
+| Français (`fr`) | 473/494 | 96% |
+| Русский (`ru`) | 473/494 | 96% |
+| Українська (`uk`) | 473/494 | 96% |
+| Polski (`pl`) | 473/494 | 96% |
 
 <!-- i18n:end -->
 

--- a/assets/i18n/de/main.ftl
+++ b/assets/i18n/de/main.ftl
@@ -187,6 +187,7 @@ login-use = { $provider } verwenden
 login-guest-title = Gastmodus
 login-guest-use = Gastmodus verwenden
 login-guest-detail = Stöbern und abspielen ohne Konto. Bibliothek, Favoriten und Playlists bleiben außen vor.
+login-usage-consent = Hilf uns zu schätzen, wie viele Menschen Sonora nutzen.
 login-device-code = Gib diesen Code auf { $url } ein
 login-cookie-submit = Weiter
 login-cookie-hint = Füge hier den Cookie-Request-Header ein

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -249,6 +249,7 @@ login-use = Use { $provider }
 login-guest-title = Guest mode
 login-guest-use = Use Guest mode
 login-guest-detail = Browse and play without an account. Your library, likes and playlists stay out of reach.
+login-usage-consent = Help us estimate how many people use Sonora.
 login-device-code = Enter this code at { $url }
 login-cookie-submit = Continue
 login-cookie-hint = Paste the Cookie request header here

--- a/assets/i18n/fr/main.ftl
+++ b/assets/i18n/fr/main.ftl
@@ -187,6 +187,7 @@ login-use = Utiliser { $provider }
 login-guest-title = Mode invité
 login-guest-use = Utiliser le mode invité
 login-guest-detail = Parcourez et écoutez sans compte. Votre bibliothèque, vos likes et vos playlists restent hors de portée.
+login-usage-consent = Aidez-nous à estimer combien de personnes utilisent Sonora.
 login-device-code = Saisissez ce code sur { $url }
 login-cookie-submit = Continuer
 login-cookie-hint = Collez ici l'en-tête de requête Cookie

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -187,6 +187,7 @@ login-use = Otwórz { $provider }
 login-guest-title = Tryb gościa
 login-guest-use = Otwórz tryb gościa
 login-guest-detail = Słuchaj bez konta. Biblioteka, polubienia i playlisty pozostaną niedostępne.
+login-usage-consent = Pomóż nam oszacować, ile osób korzysta z Sonory.
 login-device-code = Wpisz ten kod na stronie { $url }
 login-cookie-submit = Kontynuuj
 login-cookie-hint = Wklej tutaj nagłówek żądania Cookie

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -187,6 +187,7 @@ login-use = Открыть { $provider }
 login-guest-title = Гостевой режим
 login-guest-use = Открыть гостевой режим
 login-guest-detail = Слушайте без аккаунта. Медиатека, лайки и плейлисты будут недоступны.
+login-usage-consent = Помогите нам оценить, сколько людей пользуется Sonora.
 login-device-code = Введите этот код на { $url }
 login-cookie-submit = Продолжить
 login-cookie-hint = Вставьте сюда заголовок запроса Cookie

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -187,6 +187,7 @@ login-use = Відкрити { $provider }
 login-guest-title = Гостьовий режим
 login-guest-use = Відкрити гостьовий режим
 login-guest-detail = Слухайте без акаунта. Медіатека, вподобання та плейлисти будуть недоступні.
+login-usage-consent = Допоможіть нам оцінити, скільки людей користується Sonora.
 login-device-code = Введіть цей код на { $url }
 login-cookie-submit = Продовжити
 login-cookie-hint = Вставте сюди заголовок запиту Cookie

--- a/assets/icons/check.svg
+++ b/assets/icons/check.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M20 6 9 17l-5-5" />
+</svg>

--- a/crates/sonora/src/assets.rs
+++ b/crates/sonora/src/assets.rs
@@ -56,6 +56,7 @@ const ICONS: &[(&str, &[u8])] = icons![
     "arrow-up-down",
     "chevron-up",
     "circle-alert",
+    "check",
     "circle-check",
     "clipboard-paste",
     "copy",

--- a/crates/sonora/src/main.rs
+++ b/crates/sonora/src/main.rs
@@ -120,6 +120,7 @@ fn main() {
             queue,
             settings: _,
             updates: _,
+            usage: _,
         } = Sonora::global(cx);
         let (session, library, playback, queue) = (
             session.clone(),

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -20,6 +20,7 @@ mod song;
 mod tags;
 mod toast;
 mod updates;
+mod usage;
 
 pub use artist::ArtistDetail;
 pub use cover::Cover;
@@ -42,6 +43,7 @@ pub use song::SongDetail;
 pub use tags::{TagState, Tags};
 pub use toast::{Outcome, Target, Toast, Toasts};
 pub use updates::{Release, UpdateState, Updates};
+pub use usage::Usage;
 
 use std::future::Future;
 use std::sync::Arc;
@@ -93,6 +95,7 @@ pub struct Sonora {
     pub queue: Entity<Queue>,
     pub settings: Entity<AppSettings>,
     pub updates: Entity<Updates>,
+    pub usage: Entity<Usage>,
 }
 
 impl Global for Sonora {}
@@ -130,7 +133,8 @@ pub fn init(
         )
     });
     let cover = cx.new(|cx| Cover::new(session.clone(), playback.clone(), io.clone(), cx));
-    let updates = cx.new(|cx| Updates::new(settings.clone(), io, cx));
+    let updates = cx.new(|cx| Updates::new(settings.clone(), io.clone(), cx));
+    let usage = cx.new(|cx| Usage::new(session.clone(), io, cx));
 
     cx.set_global(Sonora {
         session,
@@ -142,5 +146,6 @@ pub fn init(
         queue,
         settings,
         updates,
+        usage,
     });
 }

--- a/crates/state/src/usage.rs
+++ b/crates/state/src/usage.rs
@@ -1,0 +1,223 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{Context as _, Result};
+use gpui::{Context, Entity, Task};
+use rusqlite::params;
+
+use crate::{Io, Session, SessionEvent, join};
+
+const ENDPOINT: &str = "https://sonora-stats.nolight.dev/install";
+const RUNNING: &str = env!("CARGO_PKG_VERSION");
+const AGENT: &str = concat!(
+    "sonora/",
+    env!("CARGO_PKG_VERSION"),
+    " (https://github.com/nolight132/sonora)"
+);
+const REPORTED: &str = "reported_usage";
+const LOGGED_IN: &str = "logged_in_once";
+const PATIENCE: Duration = Duration::from_secs(10);
+
+#[derive(Clone)]
+struct Store {
+    path: PathBuf,
+}
+
+impl Store {
+    fn new() -> Self {
+        let path = dirs::data_local_dir()
+            .unwrap_or_else(std::env::temp_dir)
+            .join("sonora")
+            .join("flags.sqlite3");
+        Self { path }
+    }
+
+    fn open(&self) -> Result<rusqlite::Connection> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent).context("cannot create the flag directory")?;
+        }
+        let connection = rusqlite::Connection::open(&self.path).context("cannot open flags")?;
+        connection
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS flags (
+                    key TEXT PRIMARY KEY,
+                    value INTEGER NOT NULL
+                );",
+            )
+            .context("cannot prepare flags")?;
+        Ok(connection)
+    }
+
+    fn read(&self) -> Result<(bool, bool)> {
+        let connection = self.open()?;
+        let mut query = connection
+            .prepare("SELECT key, value FROM flags WHERE key IN (?, ?)")
+            .context("cannot prepare a flag read")?;
+        let rows = query
+            .query_map(params![REPORTED, LOGGED_IN], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+            })
+            .context("cannot read flags")?;
+
+        let mut settled = false;
+        let mut logged_in = false;
+        for row in rows {
+            let (key, value) = row.context("cannot decode a flag")?;
+            match key.as_str() {
+                REPORTED => settled = true,
+                LOGGED_IN => logged_in = value != 0,
+                _ => {}
+            }
+        }
+        Ok((settled, logged_in))
+    }
+
+    fn write(&self, key: &str, value: bool) -> Result<()> {
+        self.open()?
+            .execute(
+                "INSERT INTO flags (key, value) VALUES (?, ?)
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                params![key, i64::from(value)],
+            )
+            .context("cannot save a flag")?;
+        Ok(())
+    }
+}
+
+pub struct Usage {
+    loaded: bool,
+    settled: bool,
+    logged_in: bool,
+    consented: bool,
+    store: Store,
+    http: reqwest::Client,
+    io: Io,
+    load: Option<Task<()>>,
+    task: Option<Task<()>>,
+    mark: Option<Task<()>>,
+}
+
+impl Usage {
+    pub fn new(session: Entity<Session>, io: Io, cx: &mut Context<Self>) -> Self {
+        cx.subscribe(&session, |this, _, event, cx| match event {
+            SessionEvent::SignedIn => this.connected(cx),
+            SessionEvent::Reconnected | SessionEvent::SignedOut | SessionEvent::LocalChanged => {}
+        })
+        .detach();
+
+        let mut usage = Self {
+            loaded: false,
+            settled: false,
+            logged_in: false,
+            consented: true,
+            store: Store::new(),
+            http: reqwest::Client::new(),
+            io,
+            load: None,
+            task: None,
+            mark: None,
+        };
+        usage.recall(cx);
+        usage
+    }
+
+    pub fn asking(&self) -> bool {
+        self.loaded && !self.settled && !self.logged_in
+    }
+
+    pub fn consented(&self) -> bool {
+        self.consented
+    }
+
+    pub fn consent(&mut self, consented: bool, cx: &mut Context<Self>) {
+        self.consented = consented;
+        cx.notify();
+    }
+
+    pub fn report(&mut self, cx: &mut Context<Self>) {
+        if !self.asking() {
+            return;
+        }
+        let consented = self.consented;
+        self.settled = true;
+        cx.notify();
+
+        let store = self.store.clone();
+        let http = self.http.clone();
+        let io = self.io.clone();
+        self.task = Some(cx.spawn(async move |this, cx| {
+            let sent = join(io.spawn(async move {
+                if consented {
+                    send(&http).await?;
+                }
+                tokio::task::spawn_blocking(move || store.write(REPORTED, consented)).await?
+            }))
+            .await;
+            if let Err(error) = sent {
+                log::warn!("usage: cannot report usage: {error:#}");
+            }
+            this.update(cx, |this, _| this.task = None).ok();
+        }));
+    }
+
+    fn connected(&mut self, cx: &mut Context<Self>) {
+        if self.logged_in {
+            return;
+        }
+        self.logged_in = true;
+        cx.notify();
+
+        let store = self.store.clone();
+        let io = self.io.clone();
+        self.mark = Some(cx.spawn(async move |this, cx| {
+            let saved = join(io.spawn(async move {
+                tokio::task::spawn_blocking(move || store.write(LOGGED_IN, true)).await?
+            }))
+            .await;
+            if let Err(error) = saved {
+                log::warn!("usage: cannot remember the first sign in: {error:#}");
+            }
+            this.update(cx, |this, _| this.mark = None).ok();
+        }));
+    }
+
+    fn recall(&mut self, cx: &mut Context<Self>) {
+        let store = self.store.clone();
+        let io = self.io.clone();
+        self.load = Some(cx.spawn(async move |this, cx| {
+            let flags = join(
+                io.spawn(async move { tokio::task::spawn_blocking(move || store.read()).await? }),
+            )
+            .await;
+            this.update(cx, |this, cx| {
+                this.load = None;
+                match flags {
+                    Ok((settled, logged_in)) => {
+                        this.settled = settled;
+                        this.logged_in = logged_in;
+                    }
+                    Err(error) => {
+                        log::warn!("usage: cannot read flags: {error:#}");
+                        this.settled = true;
+                    }
+                }
+                this.loaded = true;
+                cx.notify();
+            })
+            .ok();
+        }));
+    }
+}
+
+async fn send(http: &reqwest::Client) -> Result<()> {
+    http.post(ENDPOINT)
+        .header(reqwest::header::USER_AGENT, AGENT)
+        .timeout(PATIENCE)
+        .json(&serde_json::json!({ "version": RUNNING, "os": std::env::consts::OS }))
+        .send()
+        .await
+        .context("cannot reach the usage endpoint")?
+        .error_for_status()
+        .context("the usage endpoint refused the report")?;
+    Ok(())
+}

--- a/crates/ui/src/checkbox.rs
+++ b/crates/ui/src/checkbox.rs
@@ -1,0 +1,159 @@
+use gpui::prelude::*;
+use gpui::{
+    App, ClickEvent, Div, ElementId, Interactivity, SharedString, Stateful, StyleRefinement,
+    Window, div, px, svg,
+};
+
+use crate::metrics::Text;
+use crate::motion::{Motion, Motioned as _, Movement, mix};
+use crate::theme::ActiveTheme as _;
+
+const SCALE: f32 = 0.66;
+const MARK: f32 = 0.68;
+const GAP: f32 = 8.;
+
+type Click = Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>;
+
+#[derive(IntoElement)]
+pub struct Checkbox {
+    id: ElementId,
+    base: Stateful<Div>,
+    checked: bool,
+    disabled: bool,
+    label: Option<SharedString>,
+    on_click: Option<Click>,
+}
+
+impl Checkbox {
+    #[track_caller]
+    pub fn new(id: impl Into<ElementId>, checked: bool) -> Self {
+        let id = id.into();
+
+        Self {
+            base: div().id(id.clone()),
+            id,
+            checked,
+            disabled: false,
+            label: None,
+            on_click: None,
+        }
+    }
+
+    pub fn label(mut self, label: impl Into<SharedString>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    pub fn on_click(
+        mut self,
+        handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_click = Some(Box::new(handler));
+        self
+    }
+}
+
+impl Styled for Checkbox {
+    fn style(&mut self) -> &mut StyleRefinement {
+        self.base.style()
+    }
+}
+
+impl InteractiveElement for Checkbox {
+    fn interactivity(&mut self) -> &mut Interactivity {
+        self.base.interactivity()
+    }
+}
+
+impl RenderOnce for Checkbox {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let Self {
+            id,
+            mut base,
+            checked,
+            disabled,
+            label,
+            on_click,
+        } = self;
+        let theme = *cx.theme();
+        let side = px((theme.metrics.control_small / px(1.) * SCALE).round());
+        let radius = theme.radius.min(side / 3.);
+        let overrides = std::mem::take(base.style());
+
+        let (box_was, box_is) = match checked {
+            true => (theme.muted, theme.primary),
+            false => (theme.primary, theme.muted),
+        };
+        let (edge_was, edge_is) = match checked {
+            true => (theme.border, theme.primary),
+            false => (theme.primary, theme.border),
+        };
+        let (mark_was, mark_is) = match checked {
+            true => (theme.muted, theme.primary_foreground),
+            false => (theme.primary_foreground, theme.muted),
+        };
+
+        let movement = window.use_keyed_state((id, "movement"), cx, |_, _| Movement::new(checked));
+        let animates = movement.update(cx, |movement, _| movement.turning(checked));
+        let mark = svg()
+            .path("icons/check.svg")
+            .size(px((side / px(1.) * MARK).round()))
+            .flex_none();
+        let mark = match animates {
+            true => mark
+                .motion(
+                    ("mark", usize::from(checked)),
+                    Motion::Control,
+                    move |mark, t| mark.text_color(mix(mark_was, mark_is, t)),
+                )
+                .into_any_element(),
+            false => mark.text_color(mark_is).into_any_element(),
+        };
+        let square = div()
+            .flex()
+            .flex_none()
+            .items_center()
+            .justify_center()
+            .size(side)
+            .rounded(radius)
+            .border_1()
+            .child(mark);
+
+        let square = match animates {
+            true => square
+                .motion(
+                    ("box", usize::from(checked)),
+                    Motion::Control,
+                    move |square, t| {
+                        square
+                            .bg(mix(box_was, box_is, t))
+                            .border_color(mix(edge_was, edge_is, t))
+                    },
+                )
+                .into_any_element(),
+            false => square.bg(box_is).border_color(edge_is).into_any_element(),
+        };
+
+        let mut checkbox = base
+            .flex()
+            .items_center()
+            .gap(px(GAP))
+            .text_size(theme.text(Text::Small))
+            .text_color(theme.foreground)
+            .when(disabled, |this| this.opacity(0.4))
+            .when(!disabled, |this| this.cursor_pointer())
+            .child(square)
+            .children(label.map(|label| div().child(label)));
+
+        checkbox.style().refine(&overrides);
+        if !disabled && let Some(handler) = on_click {
+            checkbox = checkbox.on_click(handler);
+        }
+        checkbox
+    }
+}

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -1,6 +1,7 @@
 mod artwork;
 mod button;
 mod card;
+mod checkbox;
 mod controls;
 mod deck;
 mod drag;
@@ -44,6 +45,7 @@ pub use artwork::{Artwork, Avatar, artwork_usage};
 pub use button::Button;
 pub use card::CARD_GROUP;
 pub use card::Card;
+pub use checkbox::Checkbox;
 pub use controls::WindowControls;
 pub use deck::Deck;
 pub use drag::{Edge, drop_gap, drop_marker};

--- a/crates/ui/src/motion.rs
+++ b/crates/ui/src/motion.rs
@@ -1,5 +1,5 @@
 use std::sync::atomic::{AtomicU8, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use gpui::{
     Animation, AnimationElement, AnimationExt as _, App, ElementId, Hsla, IntoElement, Pixels,
@@ -321,6 +321,30 @@ pub fn apply(stillness: Stillness, pace: Pace, cx: &mut App) {
 
 pub fn animates(cx: &App) -> bool {
     !cx.reduce_motion()
+}
+
+pub(crate) struct Movement {
+    drawn: bool,
+    turned: Option<Instant>,
+}
+
+impl Movement {
+    pub(crate) fn new(checked: bool) -> Self {
+        Self {
+            drawn: checked,
+            turned: None,
+        }
+    }
+
+    pub(crate) fn turning(&mut self, checked: bool) -> bool {
+        if self.drawn != checked {
+            self.drawn = checked;
+            self.turned = Some(Instant::now());
+        }
+
+        self.turned
+            .is_some_and(|turned| turned.elapsed() < Motion::Control.span())
+    }
 }
 
 fn system_still() -> bool {

--- a/crates/ui/src/switch.rs
+++ b/crates/ui/src/switch.rs
@@ -1,11 +1,9 @@
-use std::time::Instant;
-
 use gpui::prelude::*;
 use gpui::{
     App, ClickEvent, Div, ElementId, Interactivity, Stateful, StyleRefinement, Window, div, px,
 };
 
-use crate::motion::{Motion, Motioned as _};
+use crate::motion::{Motion, Motioned as _, Movement};
 use crate::theme::ActiveTheme as _;
 
 const SCALE: f32 = 0.85;
@@ -166,29 +164,5 @@ impl RenderOnce for Switch {
                 })
                 .into_any_element(),
         }
-    }
-}
-
-struct Movement {
-    drawn: bool,
-    turned: Option<Instant>,
-}
-
-impl Movement {
-    fn new(checked: bool) -> Self {
-        Self {
-            drawn: checked,
-            turned: None,
-        }
-    }
-
-    fn turning(&mut self, checked: bool) -> bool {
-        if self.drawn != checked {
-            self.drawn = checked;
-            self.turned = Some(Instant::now());
-        }
-
-        self.turned
-            .is_some_and(|turned| turned.elapsed() < Motion::Control.span())
     }
 }

--- a/crates/views/src/screens/login.rs
+++ b/crates/views/src/screens/login.rs
@@ -6,9 +6,9 @@ use gpui::{
 };
 use i18n::t;
 use music::{AccountChoice, SignIn, SignInPrompt};
-use state::{Session, SessionState};
+use state::{Session, SessionState, Sonora, Usage};
 use ui::ActiveTheme as _;
-use ui::{Button, Input, Modal, TabBar, Text};
+use ui::{Button, Checkbox, Input, Modal, TabBar, Text};
 
 const COLUMN: Pixels = px(280.);
 const LOGO: Pixels = px(48.);
@@ -23,6 +23,7 @@ struct Column {
 
 pub struct LoginView {
     session: Entity<Session>,
+    usage: Entity<Usage>,
     secret: Entity<Input>,
     browsers: Option<(&'static str, Vec<SharedString>)>,
     tab: usize,
@@ -31,15 +32,35 @@ pub struct LoginView {
 impl LoginView {
     pub fn new(session: Entity<Session>, cx: &mut Context<Self>) -> Self {
         cx.observe(&session, |_, _, cx| cx.notify()).detach();
+        let usage = Sonora::global(cx).usage.clone();
+        cx.observe(&usage, |_, _, cx| cx.notify()).detach();
         Self {
             session,
+            usage,
             secret: cx.new(|cx| Input::new("login-cookie-hint", cx)),
             browsers: None,
             tab: 0,
         }
     }
 
+    fn acted(&self, cx: &mut Context<Self>) {
+        self.usage.update(cx, |usage, cx| usage.report(cx));
+    }
+
+    fn consent(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let checked = self.usage.read(cx).consented();
+        Checkbox::new("usage-consent", checked)
+            .label(t!("login-usage-consent"))
+            .max_w(COLUMN)
+            .text_color(cx.theme().muted_foreground)
+            .on_click(cx.listener(move |this, _, _, cx| {
+                this.usage
+                    .update(cx, |usage, cx| usage.consent(!checked, cx));
+            }))
+    }
+
     fn submit(&mut self, cx: &mut Context<Self>) {
+        self.acted(cx);
         let text = self.secret.read(cx).text().to_string();
         if text.trim().is_empty() {
             return;
@@ -50,12 +71,14 @@ impl LoginView {
     }
 
     fn abandon(&mut self, cx: &mut Context<Self>) {
+        self.acted(cx);
         self.secret.update(cx, |input, cx| input.set_text("", cx));
         self.session
             .update(cx, |session, cx| session.cancel_sign_in(cx));
     }
 
     fn start(&self, slug: &'static str, method: SignIn, cx: &mut Context<Self>) {
+        self.acted(cx);
         self.session
             .update(cx, |session, cx| session.sign_in(slug, method, cx));
     }
@@ -130,6 +153,7 @@ impl LoginView {
     }
 
     fn open_browsers(&mut self, slug: &'static str, cx: &mut Context<Self>) {
+        self.acted(cx);
         let names = self
             .session
             .read(cx)
@@ -287,6 +311,7 @@ impl LoginView {
     ) -> impl IntoElement {
         AccountPicker::new(accounts)
             .on_pick(cx.listener(|this, id: &SharedString, _, cx| {
+                this.acted(cx);
                 let id = id.to_string();
                 this.session
                     .update(cx, |session, cx| session.submit_input(id, cx));
@@ -344,6 +369,7 @@ impl Render for LoginView {
                     .selected(index == self.tab)
                     .flex_1()
                     .on_click(cx.listener(move |this, _, _, cx| {
+                        this.acted(cx);
                         this.tab = index;
                         cx.notify();
                     }))
@@ -389,6 +415,8 @@ impl Render for LoginView {
 
         let theme = *cx.theme();
         let browsers = self.browsers.clone();
+        let asking = self.usage.read(cx).asking();
+        let orphan = asking && guest.is_none();
 
         div()
             .relative()
@@ -442,9 +470,11 @@ impl Render for LoginView {
                                 .text_size(theme.text(Text::Small))
                                 .text_color(theme.muted_foreground)
                                 .child(t!("login-guest-detail")),
-                        ),
+                        )
+                        .when(asking, |this| this.child(self.consent(cx))),
                 )
             })
+            .when(orphan, |this| this.child(self.consent(cx)))
             .when(secret, |this| {
                 this.child(self.secret_prompt(cx).into_any_element())
             })


### PR DESCRIPTION
## Summary

- add a `ui::Checkbox` element with a label, sharing the switch's toggle animation
- count installs with an opt-out ping to sonora-stats.nolight.dev, settled by the next action on the sign-in screen
- remember `reported_usage` and `logged_in_once` in a local sqlite store so the checkbox is offered once and never after a sign-in