### PR TITLE
release 0.28.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
             os: macos-15-intel
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+            features: --features bundled-sqlite
     steps:
       - uses: actions/checkout@v5
 
@@ -69,7 +70,7 @@ jobs:
           cache-targets: false
           cache-on-failure: true
       - name: build
-        run: cargo build --release --locked --package sonora --target ${{ matrix.target }}
+        run: cargo build --release --locked --package sonora --target ${{ matrix.target }} ${{ matrix.features }}
 
       - name: sccache stats
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             build-essential pkg-config mold \
-            libasound2-dev libfontconfig1-dev libfreetype-dev \
+            libasound2-dev libfontconfig1-dev libfreetype-dev libsqlite3-dev \
             libx11-dev libxcb1-dev libxcursor-dev libxi-dev \
             libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev \
             libvulkan-dev libdbus-1-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.28.1] - 2026-09-02
+
+### Changed
+
+- Sonora now uses the SQLite library your system provides instead of compiling in its own copy, so
+  SQLite fixes reach it through a normal system update. Windows still carries its own.
+
 ## [0.28.0] - 2026-09-01
 
 ### Added
@@ -1210,7 +1217,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Initial release: a native Spotify client with playback, an interactive queue, the saved library,
 search, album, playlist, artist and song pages, context menus and adaptive theming.
 
-[unreleased]: https://github.com/nolight132/sonora/compare/v0.28.0...HEAD
+[unreleased]: https://github.com/nolight132/sonora/compare/v0.28.1...HEAD
+[0.28.1]: https://github.com/nolight132/sonora/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/nolight132/sonora/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/nolight132/sonora/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/nolight132/sonora/compare/v0.25.0...v0.26.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ sonora → views → state → music
 
 The GPUI renderer is Vulkan-based, so a Vulkan ICD is a **runtime** requirement, not just a build
 one. Link-time deps: `vulkan-loader`, `wayland`, `libxkbcommon`, `libxcb`, `libx11`, `libxcursor`,
-`libxi`, `fontconfig`, `freetype`, `alsa-lib`, `dbus`, plus `pkg-config`.
+`libxi`, `fontconfig`, `freetype`, `alsa-lib`, `dbus`, `sqlite`, plus `pkg-config`.
 
 `.cargo/config.toml` passes `-fuse-ld=mold` for `x86_64-unknown-linux-gnu`, so **mold must be on
 PATH** for that target. If it isn't, either install mold or build with
@@ -95,7 +95,7 @@ per-target `hash` values follow the release assets instead, and only move when a
 ### Arch / CachyOS
 
 ```sh
-sudo pacman -S --needed base-devel rust pkgconf alsa-lib dbus fontconfig freetype2 \
+sudo pacman -S --needed base-devel rust pkgconf alsa-lib dbus fontconfig freetype2 sqlite \
   libx11 libxcb libxcursor libxi libxkbcommon libxkbcommon-x11 wayland \
   vulkan-icd-loader mold
 # plus a Vulkan driver: vulkan-radeon | vulkan-intel | nvidia-utils
@@ -111,13 +111,13 @@ Not exercised in this repo; package sets translated from the dependency list abo
 ```sh
 # Debian/Ubuntu
 sudo apt install build-essential pkg-config mold libasound2-dev libfontconfig1-dev \
-  libfreetype-dev libx11-dev libxcb1-dev libxcursor-dev libxi-dev \
+  libfreetype-dev libsqlite3-dev libx11-dev libxcb1-dev libxcursor-dev libxi-dev \
   libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev libvulkan-dev libdbus-1-dev \
   mesa-vulkan-drivers
 
 # Fedora
 sudo dnf install @development-tools pkgconf-pkg-config mold alsa-lib-devel fontconfig-devel \
-  freetype-devel libX11-devel libxcb-devel libXcursor-devel libXi-devel \
+  freetype-devel sqlite-devel libX11-devel libxcb-devel libXcursor-devel libXi-devel \
   libxkbcommon-devel libxkbcommon-x11-devel wayland-devel vulkan-loader-devel dbus-devel \
   mesa-vulkan-drivers
 ```
@@ -136,7 +136,9 @@ binary runnable on Apple Silicon — it does not satisfy Gatekeeper, so an unnot
 needs `xattr -dr com.apple.quarantine` on first launch. Do not add `--deep`; Apple deprecates it for
 signing and the bundle has no nested code.
 
-Windows embeds `assets/windows/sonora.ico` through `crates/sonora/build.rs` and `winresource`.
+Windows embeds `assets/windows/sonora.ico` through `crates/sonora/build.rs` and `winresource`. It is
+also the one target that compiles SQLite instead of linking the system one: `crates/music/Cargo.toml`
+turns on rusqlite's `bundled` under `cfg(windows)`, because MSVC has no `libsqlite3` to find.
 
 ### Checks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Arch and derivatives:
 
 ```sh
 sudo pacman -S --needed base-devel pkgconf mold \
-  alsa-lib dbus fontconfig freetype2 \
+  alsa-lib dbus fontconfig freetype2 sqlite \
   libx11 libxcb libxcursor libxi libxkbcommon libxkbcommon-x11 wayland \
   vulkan-icd-loader
 ```
@@ -31,7 +31,7 @@ Debian and Ubuntu:
 
 ```sh
 sudo apt install build-essential pkg-config mold \
-  libasound2-dev libdbus-1-dev libfontconfig-dev libfreetype-dev \
+  libasound2-dev libdbus-1-dev libfontconfig-dev libfreetype-dev libsqlite3-dev \
   libx11-dev libxcb1-dev libxcursor-dev libxi-dev \
   libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev \
   libvulkan-dev mesa-vulkan-drivers
@@ -41,7 +41,7 @@ Fedora:
 
 ```sh
 sudo dnf install @development-tools pkgconf-pkg-config mold \
-  alsa-lib-devel dbus-devel fontconfig-devel freetype-devel \
+  alsa-lib-devel dbus-devel fontconfig-devel freetype-devel sqlite-devel \
   libX11-devel libxcb-devel libXcursor-devel libXi-devel \
   libxkbcommon-devel libxkbcommon-x11-devel wayland-devel \
   vulkan-loader-devel mesa-vulkan-drivers

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9452,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "ytmusic"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/ytmusic-rs?rev=aae034085dddce4b5e085e966491a222c1180948#aae034085dddce4b5e085e966491a222c1180948"
+source = "git+https://github.com/nolight132/ytmusic-rs?rev=0b2b13a32c16e4245b6c9001f8088a75c83a638c#0b2b13a32c16e4245b6c9001f8088a75c83a638c"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,7 @@ checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "embed"
-version = "0.28.0"
+version = "0.28.1"
 
 [[package]]
 name = "embed-resource"
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "i18n"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "fluent-bundle",
  "gpui",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "icons"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "embed",
@@ -3397,7 +3397,7 @@ dependencies = [
 
 [[package]]
 name = "input"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "gpui",
  "ui",
@@ -4231,7 +4231,7 @@ dependencies = [
 
 [[package]]
 name = "music"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6068,7 +6068,7 @@ dependencies = [
 
 [[package]]
 name = "router"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "gpui",
  "ui",
@@ -6814,7 +6814,7 @@ dependencies = [
 
 [[package]]
 name = "sonora"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -6946,7 +6946,7 @@ dependencies = [
 
 [[package]]
 name = "state"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7969,7 +7969,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "gpui",
  "gpui_platform",
@@ -8297,7 +8297,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "views"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "gpui",
  "i18n",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 raw-window-handle = "0.6"
 roxmltree = "0.21"
 rodio = { version = "0.21", default-features = false, features = ["playback"] }
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { version = "0.32" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 serde_norway = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ souvlaki = "0.8"
 sys-locale = "0.3"
 unic-langid = { version = "0.9", features = ["macros"] }
 unicode-segmentation = "1.12"
-ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "aae034085dddce4b5e085e966491a222c1180948" }
+ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "0b2b13a32c16e4245b6c9001f8088a75c83a638c" }
 
 librespot-core = { version = "0.8.0", default-features = false, features = [
   "rustls-tls-native-roots",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.28.0"
+version = "0.28.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/nolight132/sonora"

--- a/README.md
+++ b/README.md
@@ -66,7 +66,14 @@ xattr -dr com.apple.quarantine /Applications/Sonora.app
 
 Install from the AUR with your AUR helper of choice:
 
+```sh
+yay -S sonora-bin
 ```
+
+`sonora-bin` installs the prebuilt release binary. `sonora` builds the same version from source
+instead, which takes a while on a Rust and GPUI tree but links against your own system libraries:
+
+```sh
 yay -S sonora
 ```
 
@@ -102,14 +109,14 @@ partial translation is welcome — pick a language below and fill in what it lac
 
 <!-- i18n:start -->
 
-| Language | Translated | Coverage |
-| --- | --- | --- |
-| English (`en-US`) | 496/496 | 100% |
-| Deutsch (`de`) | 475/496 | 96% |
-| Français (`fr`) | 475/496 | 96% |
-| Русский (`ru`) | 475/496 | 96% |
-| Українська (`uk`) | 475/496 | 96% |
-| Polski (`pl`) | 475/496 | 96% |
+| Language          | Translated | Coverage |
+| ----------------- | ---------- | -------- |
+| English (`en-US`) | 496/496    | 100%     |
+| Deutsch (`de`)    | 475/496    | 96%      |
+| Français (`fr`)   | 475/496    | 96%      |
+| Русский (`ru`)    | 475/496    | 96%      |
+| Українська (`uk`) | 475/496    | 96%      |
+| Polski (`pl`)     | 475/496    | 96%      |
 
 <!-- i18n:end -->
 

--- a/crates/music/Cargo.toml
+++ b/crates/music/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+bundled-sqlite = ["rusqlite/bundled", "ytmusic/bundled-sqlite"]
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
@@ -32,6 +35,3 @@ serde_json.workspace = true
 serde_norway.workspace = true
 tokio.workspace = true
 ytmusic.workspace = true
-
-[target.'cfg(windows)'.dependencies]
-rusqlite = { workspace = true, features = ["bundled"] }

--- a/crates/music/Cargo.toml
+++ b/crates/music/Cargo.toml
@@ -32,3 +32,6 @@ serde_json.workspace = true
 serde_norway.workspace = true
 tokio.workspace = true
 ytmusic.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+rusqlite = { workspace = true, features = ["bundled"] }

--- a/crates/sonora/Cargo.toml
+++ b/crates/sonora/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [features]
 # the gpui frame overlay and repaint wash, off in normal builds
 profiler = ["gpui/profiler"]
+bundled-sqlite = ["state/bundled-sqlite"]
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+bundled-sqlite = ["rusqlite/bundled", "music/bundled-sqlite"]
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
             freetype
             alsa-lib
             dbus
+            sqlite
           ];
 
           asset = release.assets.${pkgs.stdenv.hostPlatform.system};
@@ -130,6 +131,7 @@
             freetype
             alsa-lib
             dbus
+            sqlite
           ];
         in
         {


### PR DESCRIPTION
## Summary

- link the system sqlite instead of compiling a bundled copy, with windows opting back in through the new `bundled-sqlite` feature
- bump the ytmusic pin so it stops forcing `rusqlite/bundled` on the whole graph
- release 0.28.1