### PR TITLE
announce releases from the release workflow

### DIFF
--- a/.github/workflows/announce.yml
+++ b/.github/workflows/announce.yml
@@ -1,8 +1,17 @@
 name: Announce release on Discord
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: The release tag to announce
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -14,28 +23,27 @@ jobs:
     steps:
       - name: Send release announcement
         env:
+          GH_TOKEN: ${{ github.token }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
-          RELEASE_NAME: ${{ github.event.release.name }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          RELEASE_URL: ${{ github.event.release.html_url }}
-          RELEASE_BODY: ${{ github.event.release.body }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          REPO: ${{ github.repository }}
         run: |
+          set -euo pipefail
+          release="$(gh release view "$RELEASE_TAG" --repo "$REPO" --json name,body,url)"
           jq -n \
             --arg username "Sonora Releases" \
-            --arg title "${RELEASE_NAME:-$RELEASE_TAG}" \
-            --arg url "$RELEASE_URL" \
-            --arg description "${RELEASE_BODY:0:4000}" \
             --arg version "$RELEASE_TAG" \
+            --argjson release "$release" \
             '{
               username: $username,
               embeds: [{
-                title: $title,
-                url: $url,
+                title: (if $release.name == "" then $version else $release.name end),
+                url: $release.url,
                 description: (
-                  if $description == "" then
+                  if $release.body == "" then
                     "A new Sonora release is available."
                   else
-                    $description
+                    $release.body[0:4000]
                   end
                 ),
                 color: 5793266,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,3 +290,11 @@ jobs:
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}
           fail_on_unmatched_files: true
+
+  announce:
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: ./.github/workflows/announce.yml
+    secrets: inherit
+    with:
+      tag: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

- call the discord announcer as a job in the release workflow, since a release published with GITHUB_TOKEN never triggers the release event
- make the announcer reusable and hand-runnable with a tag input