### PR TITLE
fix(state): show a sign-in failure on the provider that failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- A sign-in failure in Settings now appears on the card of the service you were signing in to.
+
 ## [0.28.1] - 2026-09-02
 
 ### Changed

--- a/crates/state/src/session.rs
+++ b/crates/state/src/session.rs
@@ -360,7 +360,6 @@ impl Session {
             this.update(cx, |this, cx| {
                 this.prompt_task = None;
                 this.input = None;
-                this.awaiting = None;
                 match authorized {
                     Ok(session) => this.signed_in(session, index, cx),
                     Err(error) => this.failed(&error, cx),


### PR DESCRIPTION
## Summary

- show a failed sign-in on the card of the service you were signing in to