### PR TITLE
flake: add Vulkan runtime deps audio runtime dependencies to the dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -119,21 +119,12 @@
         let
           runtimeLibraries = with pkgs; [
             vulkan-loader
-            mesa
-            libGL
             wayland
-            wayland-protocols
-            alsa-plugins
-            pipewire
-            libpulseaudio
-
             libxkbcommon
-
             libxcb
             libx11
             libxcursor
             libxi
-            libxrandr
             fontconfig
             freetype
             alsa-lib
@@ -153,7 +144,9 @@
             ];
 
             buildInputs = runtimeLibraries;
+
             LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath runtimeLibraries;
+
             ALSA_PLUGIN_DIR = "${pkgs.symlinkJoin {
               name = "alsa-plugins-combined";
               paths = [
@@ -162,6 +155,11 @@
               ];
             }}";
 
+            shellHook = ''
+              if [ ! -d /run/opengl-driver ]; then
+                export XDG_DATA_DIRS="${pkgs.mesa}/share''${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
+              fi
+            '';
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -157,7 +157,8 @@
 
             shellHook = ''
               if [ ! -d /run/opengl-driver ]; then
-                export XDG_DATA_DIRS="${pkgs.mesa}/share''${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
+                export VK_DRIVER_FILES="${pkgs.mesa}/share/vulkan/icd.d"
+                export VK_IMPLICIT_LAYER_PATH="${pkgs.mesa}/share/vulkan/implicit_layer.d"
               fi
             '';
           };

--- a/flake.nix
+++ b/flake.nix
@@ -124,7 +124,6 @@
             wayland
             wayland-protocols
             alsa-plugins
-            alsa-lib
             pipewire
             libpulseaudio
 

--- a/flake.nix
+++ b/flake.nix
@@ -91,9 +91,7 @@
             postFixup = ''
               patchelf \
                 --set-interpreter "${pkgs.stdenv.cc.bintools.dynamicLinker}" \
-                --add-rpath "${
-                  pkgs.lib.makeLibraryPath (runtimeLibraries ++ [ pkgs.stdenv.cc.cc.lib ])
-                }" \
+                --add-rpath "${pkgs.lib.makeLibraryPath (runtimeLibraries ++ [ pkgs.stdenv.cc.cc.lib ])}" \
                 "$out/bin/sonora"
             '';
 
@@ -121,12 +119,16 @@
         let
           runtimeLibraries = with pkgs; [
             vulkan-loader
+            mesa
+            libGL
             wayland
+            wayland-protocols
             libxkbcommon
             libxcb
             libx11
             libxcursor
             libxi
+            libxrandr
             fontconfig
             freetype
             alsa-lib
@@ -148,6 +150,7 @@
             buildInputs = runtimeLibraries;
 
             LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath runtimeLibraries;
+
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -123,7 +123,13 @@
             libGL
             wayland
             wayland-protocols
+            alsa-plugins
+            alsa-lib
+            pipewire
+            libpulseaudio
+
             libxkbcommon
+
             libxcb
             libx11
             libxcursor
@@ -148,8 +154,14 @@
             ];
 
             buildInputs = runtimeLibraries;
-
             LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath runtimeLibraries;
+            ALSA_PLUGIN_DIR = "${pkgs.symlinkJoin {
+              name = "alsa-plugins-combined";
+              paths = [
+                "${pkgs.alsa-plugins}/lib/alsa-lib"
+                "${pkgs.pipewire}/lib/alsa-lib"
+              ];
+            }}";
 
           };
         }


### PR DESCRIPTION
`cargo run` was failing to create a window from the `dev-shell` because the vulkan runtime dependencies weren't available there. This adds Mesa, vulkan, and the other Linux graphics/runtime libraries to the `dev-shell`.
Also adds Linux audio stack dependencies and configures ALSA_PLUGIN_DIR so ALSA can discover the required audio plugins.