### PR TITLE
fix(sonora): hide native windows chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the Sonora repository once (`flatpak install --user https://nolight132.github.io/sonora/sonora.flatpakref`)
   keeps it current through `flatpak update`.
 
+### Changed
+
+- Windows uses Sonora's window controls without the native system control strip.
+
 ### Fixed
 
 - Content no longer shows through an overlaid sidebar when window transparency is enabled.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6837,6 +6837,7 @@ dependencies = [
  "tokio",
  "ui",
  "views",
+ "windows-sys 0.61.2",
  "winresource",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ gpui_platform = { git = "https://github.com/nolight132/gpui", rev = "fc81ff8044c
 ] }
 http = "1.3"
 winresource = "0.1"
+windows-sys = { version = "0.61", features = ["Win32_Graphics_Dwm"] }
 interprocess = "2.4"
 image = { version = "0.25", default-features = false, features = [
   "jpeg",

--- a/crates/sonora/Cargo.toml
+++ b/crates/sonora/Cargo.toml
@@ -35,6 +35,7 @@ libc.workspace = true
 [target.'cfg(windows)'.dependencies]
 raw-window-handle.workspace = true
 state = { workspace = true, features = ["bundled-sqlite"] }
+windows-sys.workspace = true
 
 [build-dependencies]
 embed.workspace = true

--- a/crates/sonora/src/main.rs
+++ b/crates/sonora/src/main.rs
@@ -210,3 +210,8 @@ fn platform_handle(window: &gpui::Window) -> Option<*mut std::ffi::c_void> {
     }
     Some(handle)
 }
+
+#[cfg(not(target_os = "windows"))]
+fn platform_handle(_window: &gpui::Window) -> Option<*mut std::ffi::c_void> {
+    None
+}

--- a/crates/sonora/src/main.rs
+++ b/crates/sonora/src/main.rs
@@ -210,8 +210,3 @@ fn platform_handle(window: &gpui::Window) -> Option<*mut std::ffi::c_void> {
     }
     Some(handle)
 }
-
-#[cfg(not(target_os = "windows"))]
-fn platform_handle(_window: &gpui::Window) -> Option<*mut std::ffi::c_void> {
-    None
-}

--- a/crates/sonora/src/main.rs
+++ b/crates/sonora/src/main.rs
@@ -180,7 +180,7 @@ fn open_window(
         },
         |window, cx| {
             window.set_rem_size(cx.theme().font_size);
-            state::attach_remote(window_handle(window), cx);
+            state::attach_remote(platform_handle(window), cx);
             state::remember_window(window, cx);
             cx.new(|cx| Root::new(session, library, playback, queue, window, cx))
         },
@@ -189,16 +189,29 @@ fn open_window(
 }
 
 #[cfg(target_os = "windows")]
-fn window_handle(window: &gpui::Window) -> Option<*mut std::ffi::c_void> {
+fn platform_handle(window: &gpui::Window) -> Option<*mut std::ffi::c_void> {
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+    use windows_sys::Win32::Graphics::Dwm::{
+        DWMNCRP_DISABLED, DWMWA_NCRENDERING_POLICY, DwmSetWindowAttribute,
+    };
 
-    match HasWindowHandle::window_handle(window).ok()?.as_raw() {
-        RawWindowHandle::Win32(handle) => Some(handle.hwnd.get() as *mut std::ffi::c_void),
-        _ => None,
+    let RawWindowHandle::Win32(handle) = HasWindowHandle::window_handle(window).ok()?.as_raw()
+    else {
+        return None;
+    };
+    let handle = handle.hwnd.get() as *mut std::ffi::c_void;
+    unsafe {
+        DwmSetWindowAttribute(
+            handle,
+            DWMWA_NCRENDERING_POLICY as u32,
+            &DWMNCRP_DISABLED as *const _ as *const std::ffi::c_void,
+            size_of_val(&DWMNCRP_DISABLED) as u32,
+        );
     }
+    Some(handle)
 }
 
 #[cfg(not(target_os = "windows"))]
-fn window_handle(_window: &gpui::Window) -> Option<*mut std::ffi::c_void> {
+fn platform_handle(_window: &gpui::Window) -> Option<*mut std::ffi::c_void> {
     None
 }


### PR DESCRIPTION
## Summary

- hide the native Windows control strip while preserving Sonora's window controls
- preserve taskbar, resize, minimize, maximize, and snap behaviour