### PR TITLE
fix(music): batch Spotify track metadata requests

### DIFF
--- a/crates/music/src/spotify/albums.rs
+++ b/crates/music/src/spotify/albums.rs
@@ -2,11 +2,10 @@ use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context as _, Result};
 use librespot_core::Session;
-use librespot_protocol::extended_metadata::{BatchedEntityRequest, EntityRequest, ExtensionQuery};
 use librespot_protocol::extension_kind::ExtensionKind;
 use librespot_protocol::metadata::Album as AlbumMessage;
 use librespot_protocol::metadata::album::Type as AlbumType;
-use protobuf::{EnumOrUnknown, Message as _};
+use protobuf::Message as _;
 
 use crate::spotify::{collection, collection2, pathfinder, wire};
 use crate::{Album, AlbumDetail, ReleaseType, Track};
@@ -50,19 +49,13 @@ pub async fn album(session: &Session, album_id: &str) -> Result<AlbumDetail> {
 
 async fn legacy_album(session: &Session, album_id: &str) -> Result<AlbumDetail> {
     let uri = format!("{ALBUM_PREFIX}{album_id}");
-    let request = batched(std::slice::from_ref(&uri));
-    let response = session
-        .spclient()
-        .get_extended_metadata(request)
-        .await
-        .context("cannot read album metadata")?;
-
-    let message = response
-        .extended_metadata
-        .into_iter()
-        .flat_map(|array| array.extension_data)
-        .find_map(|entity| AlbumMessage::parse_from_bytes(&entity.extension_data.value).ok())
-        .context("album metadata is missing")?;
+    let message =
+        collection::extended(session, std::slice::from_ref(&uri), ExtensionKind::ALBUM_V4)
+            .await
+            .context("cannot read album metadata")?
+            .into_iter()
+            .find_map(|entity| AlbumMessage::parse_from_bytes(&entity.extension_data.value).ok())
+            .context("album metadata is missing")?;
     let album = album_from(&uri, &message);
     let uris: Vec<_> = track_ids(&message)
         .into_iter()
@@ -99,63 +92,36 @@ fn track_ids(album: &AlbumMessage) -> Vec<String> {
         .collect()
 }
 
-fn batched(uris: &[String]) -> BatchedEntityRequest {
-    BatchedEntityRequest {
-        entity_request: uris
-            .iter()
-            .map(|uri| EntityRequest {
-                entity_uri: uri.clone(),
-                query: vec![ExtensionQuery {
-                    extension_kind: EnumOrUnknown::new(ExtensionKind::ALBUM_V4),
-                    ..Default::default()
-                }],
-                ..Default::default()
-            })
-            .collect(),
-        ..Default::default()
-    }
-}
-
 pub(crate) async fn metadata(session: &Session, uris: &[String]) -> Result<HashMap<String, Album>> {
-    let request = batched(uris);
-
-    let response = session
-        .spclient()
-        .get_extended_metadata(request)
+    let entities = collection::extended(session, uris, ExtensionKind::ALBUM_V4)
         .await
         .context("cannot read album metadata")?;
 
     let mut albums = HashMap::new();
-    for array in response.extended_metadata {
-        for entity in array.extension_data {
-            let Ok(message) = AlbumMessage::parse_from_bytes(&entity.extension_data.value) else {
-                continue;
-            };
-            let album = album_from(&entity.entity_uri, &message);
-            albums.insert(entity.entity_uri, album);
-        }
+    for entity in entities {
+        let Ok(message) = AlbumMessage::parse_from_bytes(&entity.extension_data.value) else {
+            continue;
+        };
+        let album = album_from(&entity.entity_uri, &message);
+        albums.insert(entity.entity_uri, album);
     }
     Ok(albums)
 }
 
 pub(crate) async fn track_uris(session: &Session, uris: &[String]) -> Result<Vec<String>> {
-    let response = session
-        .spclient()
-        .get_extended_metadata(batched(uris))
+    let entities = collection::extended(session, uris, ExtensionKind::ALBUM_V4)
         .await
         .context("cannot read album metadata")?;
 
     let mut seen = HashSet::new();
     let mut tracks = Vec::new();
-    for array in response.extended_metadata {
-        for entity in array.extension_data {
-            let Ok(message) = AlbumMessage::parse_from_bytes(&entity.extension_data.value) else {
-                continue;
-            };
-            for id in track_ids(&message) {
-                if seen.insert(id.clone()) {
-                    tracks.push(format!("{TRACK_PREFIX}{id}"));
-                }
+    for entity in entities {
+        let Ok(message) = AlbumMessage::parse_from_bytes(&entity.extension_data.value) else {
+            continue;
+        };
+        for id in track_ids(&message) {
+            if seen.insert(id.clone()) {
+                tracks.push(format!("{TRACK_PREFIX}{id}"));
             }
         }
     }

--- a/crates/music/src/spotify/collection.rs
+++ b/crates/music/src/spotify/collection.rs
@@ -15,6 +15,7 @@ use crate::spotify::{collection2, wire};
 use crate::{ArtistRef, Credit, Track};
 
 const TRACK_PREFIX: &str = "spotify:track:";
+const METADATA_BATCH: usize = 2_800;
 const UNKNOWN: &str = "Unknown";
 
 pub async fn saved_tracks(session: &Session, limit: u32) -> Result<Vec<Track>> {
@@ -50,35 +51,38 @@ pub async fn track(session: &Session, track_id: &str) -> Result<Track> {
 }
 
 pub(crate) async fn metadata(session: &Session, uris: &[String]) -> Result<HashMap<String, Track>> {
-    let request = BatchedEntityRequest {
-        entity_request: uris
-            .iter()
-            .map(|uri| EntityRequest {
-                entity_uri: uri.clone(),
-                query: vec![ExtensionQuery {
-                    extension_kind: EnumOrUnknown::new(ExtensionKind::TRACK_V4),
-                    ..Default::default()
-                }],
-                ..Default::default()
-            })
-            .collect(),
-        ..Default::default()
-    };
-
-    let response = session
-        .spclient()
-        .get_extended_metadata(request)
-        .await
-        .context("cannot read track metadata")?;
-
     let mut tracks = HashMap::new();
-    for array in response.extended_metadata {
-        for entity in array.extension_data {
-            let Ok(message) = TrackMessage::parse_from_bytes(&entity.extension_data.value) else {
-                continue;
-            };
-            let track = track_from(&entity.entity_uri, &message);
-            tracks.insert(entity.entity_uri, track);
+    for batch in uris.chunks(METADATA_BATCH) {
+        let request = BatchedEntityRequest {
+            entity_request: batch
+                .iter()
+                .map(|uri| EntityRequest {
+                    entity_uri: uri.clone(),
+                    query: vec![ExtensionQuery {
+                        extension_kind: EnumOrUnknown::new(ExtensionKind::TRACK_V4),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        };
+
+        let response = session
+            .spclient()
+            .get_extended_metadata(request)
+            .await
+            .context("cannot read track metadata")?;
+
+        for array in response.extended_metadata {
+            for entity in array.extension_data {
+                let Ok(message) = TrackMessage::parse_from_bytes(&entity.extension_data.value)
+                else {
+                    continue;
+                };
+                let track = track_from(&entity.entity_uri, &message);
+                tracks.insert(entity.entity_uri, track);
+            }
         }
     }
     Ok(tracks)

--- a/crates/music/src/spotify/collection.rs
+++ b/crates/music/src/spotify/collection.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use anyhow::{Context as _, Result};
 use librespot_core::Session;
+use librespot_protocol::entity_extension_data::EntityExtensionData;
 use librespot_protocol::extended_metadata::{BatchedEntityRequest, EntityRequest, ExtensionQuery};
 use librespot_protocol::extension_kind::ExtensionKind;
 use librespot_protocol::metadata::image::Size as ImageSize;
@@ -15,8 +16,8 @@ use crate::spotify::{collection2, wire};
 use crate::{ArtistRef, Credit, Track};
 
 const TRACK_PREFIX: &str = "spotify:track:";
-const METADATA_BATCH: usize = 2_800;
 const UNKNOWN: &str = "Unknown";
+const BATCH: usize = 500;
 
 pub async fn saved_tracks(session: &Session, limit: u32) -> Result<Vec<Track>> {
     let items = collection2::saved_items(
@@ -51,15 +52,35 @@ pub async fn track(session: &Session, track_id: &str) -> Result<Track> {
 }
 
 pub(crate) async fn metadata(session: &Session, uris: &[String]) -> Result<HashMap<String, Track>> {
+    let entities = extended(session, uris, ExtensionKind::TRACK_V4)
+        .await
+        .context("cannot read track metadata")?;
+
     let mut tracks = HashMap::new();
-    for batch in uris.chunks(METADATA_BATCH) {
+    for entity in entities {
+        let Ok(message) = TrackMessage::parse_from_bytes(&entity.extension_data.value) else {
+            continue;
+        };
+        let track = track_from(&entity.entity_uri, &message);
+        tracks.insert(entity.entity_uri, track);
+    }
+    Ok(tracks)
+}
+
+pub(crate) async fn extended(
+    session: &Session,
+    uris: &[String],
+    kind: ExtensionKind,
+) -> Result<Vec<EntityExtensionData>> {
+    let mut entities = Vec::with_capacity(uris.len());
+    for batch in uris.chunks(BATCH) {
         let request = BatchedEntityRequest {
             entity_request: batch
                 .iter()
                 .map(|uri| EntityRequest {
                     entity_uri: uri.clone(),
                     query: vec![ExtensionQuery {
-                        extension_kind: EnumOrUnknown::new(ExtensionKind::TRACK_V4),
+                        extension_kind: EnumOrUnknown::new(kind),
                         ..Default::default()
                     }],
                     ..Default::default()
@@ -67,25 +88,15 @@ pub(crate) async fn metadata(session: &Session, uris: &[String]) -> Result<HashM
                 .collect(),
             ..Default::default()
         };
-
-        let response = session
-            .spclient()
-            .get_extended_metadata(request)
-            .await
-            .context("cannot read track metadata")?;
-
-        for array in response.extended_metadata {
-            for entity in array.extension_data {
-                let Ok(message) = TrackMessage::parse_from_bytes(&entity.extension_data.value)
-                else {
-                    continue;
-                };
-                let track = track_from(&entity.entity_uri, &message);
-                tracks.insert(entity.entity_uri, track);
-            }
-        }
+        let response = session.spclient().get_extended_metadata(request).await?;
+        entities.extend(
+            response
+                .extended_metadata
+                .into_iter()
+                .flat_map(|array| array.extension_data),
+        );
     }
-    Ok(tracks)
+    Ok(entities)
 }
 
 fn track_from(uri: &str, track: &TrackMessage) -> Track {

--- a/crates/state/src/home.rs
+++ b/crates/state/src/home.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use gpui::{App, Context, Entity, Task};
 use music::{GenreItem, GenreSection, Track};
 
-use crate::{Io, Library, LibraryState, Session, SessionEvent, join};
+use crate::{Io, Library, LibraryPart, LibraryState, Session, SessionEvent, join};
 
 const GROUP_SIZE: usize = 10;
 const LIMIT: usize = GROUP_SIZE * 3;
@@ -154,7 +154,7 @@ impl Home {
     }
 
     pub fn is_loading(&self, cx: &App) -> bool {
-        self.library.read(cx).is_loading()
+        self.library.read(cx).loading(LibraryPart::Tracks)
     }
 }
 

--- a/crates/state/src/library.rs
+++ b/crates/state/src/library.rs
@@ -10,15 +10,30 @@ use music::{Album, MusicApi, Playlist, SavedArtist, Track};
 use crate::{Io, Outcome, Session, SessionEvent, Target, Toasts, join, mosaic};
 
 const PAGE_LIMIT: u32 = 10000;
+const FATAL: [LibraryPart; 3] = [
+    LibraryPart::Tracks,
+    LibraryPart::Playlists,
+    LibraryPart::Albums,
+];
+const FATAL_LOCAL: [LibraryPart; 2] = [LibraryPart::Tracks, LibraryPart::Albums];
 
-type Loaded = (
-    anyhow::Result<Vec<Track>>,
-    anyhow::Result<Vec<Playlist>>,
-    anyhow::Result<Vec<Album>>,
-    anyhow::Result<Vec<SavedArtist>>,
-);
+enum Landed {
+    Tracks(anyhow::Result<Vec<Track>>),
+    Playlists(anyhow::Result<Vec<Playlist>>),
+    Albums(anyhow::Result<Vec<Album>>),
+    Artists(anyhow::Result<Vec<SavedArtist>>),
+}
 
-type LoadedLocal = Loaded;
+impl Landed {
+    fn part(&self) -> LibraryPart {
+        match self {
+            Self::Tracks(_) => LibraryPart::Tracks,
+            Self::Playlists(_) => LibraryPart::Playlists,
+            Self::Albums(_) => LibraryPart::Albums,
+            Self::Artists(_) => LibraryPart::Artists,
+        }
+    }
+}
 
 struct PlaylistMutation {
     action: &'static str,
@@ -29,35 +44,53 @@ struct PlaylistMutation {
     local: bool,
 }
 
-fn partial(loaded: Loaded) -> LibraryState {
-    let (tracks, playlists, albums, artists) = loaded;
-    if let (Err(tracks), Err(playlists), Err(albums)) = (&tracks, &playlists, &albums) {
-        return LibraryState::Failed(format!("{tracks:#}\n{playlists:#}\n{albums:#}"));
+fn place(
+    state: &mut LibraryState,
+    awaited: &mut Vec<LibraryPart>,
+    landed: Landed,
+    fatal: &[LibraryPart],
+) {
+    awaited.retain(|part| *part != landed.part());
+    if !matches!(state, LibraryState::Ready { .. }) {
+        *state = LibraryState::Ready {
+            tracks: Vec::new(),
+            playlists: Vec::new(),
+            albums: Vec::new(),
+            artists: Vec::new(),
+            problems: Vec::new(),
+        };
     }
 
-    let mut problems = Vec::new();
-    LibraryState::Ready {
-        tracks: take(LibraryPart::Tracks, tracks, &mut problems),
-        playlists: take(LibraryPart::Playlists, playlists, &mut problems),
-        albums: take(LibraryPart::Albums, albums, &mut problems),
-        artists: take(LibraryPart::Artists, artists, &mut problems),
-        problems,
-    }
-}
-
-fn partial_local(loaded: LoadedLocal) -> LibraryState {
-    let (tracks, playlists, albums, artists) = loaded;
-    if let (Err(tracks), Err(albums)) = (&tracks, &albums) {
-        return LibraryState::Failed(format!("{tracks:#}\n{albums:#}"));
-    }
-
-    let mut problems = Vec::new();
-    LibraryState::Ready {
-        tracks: take(LibraryPart::Tracks, tracks, &mut problems),
-        playlists: take(LibraryPart::Playlists, playlists, &mut problems),
-        albums: take(LibraryPart::Albums, albums, &mut problems),
-        artists: take(LibraryPart::Artists, artists, &mut problems),
-        problems,
+    let failure = {
+        let LibraryState::Ready {
+            tracks,
+            playlists,
+            albums,
+            artists,
+            problems,
+        } = state
+        else {
+            return;
+        };
+        let part = landed.part();
+        match landed {
+            Landed::Tracks(result) => *tracks = take(part, result, problems),
+            Landed::Playlists(result) => *playlists = take(part, result, problems),
+            Landed::Albums(result) => *albums = take(part, result, problems),
+            Landed::Artists(result) => *artists = take(part, result, problems),
+        }
+        if !awaited.is_empty() {
+            return;
+        }
+        let reasons: Vec<&str> = fatal
+            .iter()
+            .filter_map(|part| problems.iter().find(|problem| problem.part == *part))
+            .map(|problem| problem.reason.as_str())
+            .collect();
+        (reasons.len() == fatal.len()).then(|| reasons.join("\n"))
+    };
+    if let Some(reason) = failure {
+        *state = LibraryState::Failed(reason);
     }
 }
 
@@ -280,6 +313,8 @@ pub enum LibraryPart {
 }
 
 impl LibraryPart {
+    const ALL: [Self; 4] = [Self::Tracks, Self::Playlists, Self::Albums, Self::Artists];
+
     fn label(self) -> &'static str {
         match self {
             Self::Tracks => "songs",
@@ -314,10 +349,13 @@ pub struct Library {
     state: LibraryState,
     local: LibraryState,
     local_favorites: Vec<Track>,
+    local_favorites_loading: bool,
+    awaited: Vec<LibraryPart>,
+    local_awaited: Vec<LibraryPart>,
     session: Entity<Session>,
     io: Io,
-    task: Option<Task<()>>,
-    local_task: Option<Task<()>>,
+    tasks: Vec<Task<()>>,
+    local_tasks: Vec<Task<()>>,
     playlist_task: Option<Task<()>>,
     pending: HashMap<String, Task<()>>,
     pending_albums: HashMap<String, Task<()>>,
@@ -345,7 +383,8 @@ impl Library {
                 this.contents.clear();
                 this.reading.clear();
                 this.mosaics.clear();
-                this.task = None;
+                this.tasks.clear();
+                this.awaited.clear();
                 this.playlist_task = None;
                 this.pending.clear();
                 this.pending_albums.clear();
@@ -365,9 +404,11 @@ impl Library {
                 match client {
                     Some(client) => this.load_local(client, cx),
                     None => {
-                        this.local_task = None;
+                        this.local_tasks.clear();
+                        this.local_awaited.clear();
                         this.local = LibraryState::Empty;
                         this.local_favorites.clear();
+                        this.local_favorites_loading = false;
                         cx.notify();
                     }
                 }
@@ -381,10 +422,13 @@ impl Library {
             state: LibraryState::Loading,
             local: LibraryState::Empty,
             local_favorites: Vec::new(),
+            local_favorites_loading: false,
+            awaited: Vec::new(),
+            local_awaited: Vec::new(),
             session,
             io,
-            task: None,
-            local_task: None,
+            tasks: Vec::new(),
+            local_tasks: Vec::new(),
             playlist_task: None,
             pending: HashMap::new(),
             pending_albums: HashMap::new(),
@@ -433,12 +477,16 @@ impl Library {
             .update(cx, |session, cx| session.clear_local_folder(cx));
     }
 
-    pub fn is_loading(&self) -> bool {
-        matches!(self.state, LibraryState::Loading)
+    pub fn loading(&self, part: LibraryPart) -> bool {
+        matches!(self.state, LibraryState::Loading) || self.awaited.contains(&part)
     }
 
-    pub fn local_is_loading(&self) -> bool {
-        matches!(self.local, LibraryState::Loading)
+    pub fn local_loading(&self, part: LibraryPart) -> bool {
+        matches!(self.local, LibraryState::Loading) || self.local_awaited.contains(&part)
+    }
+
+    pub fn local_favorites_loading(&self) -> bool {
+        self.local_favorites_loading
     }
 
     pub fn saved(&self, track_id: &str) -> bool {
@@ -1161,67 +1209,116 @@ impl Library {
         self.pending_albums.clear();
         self.pending_artists.clear();
         self.state = LibraryState::Loading;
+        self.awaited = LibraryPart::ALL.to_vec();
         cx.notify();
 
-        let io = self.io.clone();
-        self.task = Some(cx.spawn(async move |this, cx| {
-            let loaded = join(io.spawn(async move {
-                anyhow::Ok(tokio::join!(
-                    client.saved_tracks(PAGE_LIMIT),
-                    client.playlists(PAGE_LIMIT),
-                    client.saved_albums(PAGE_LIMIT),
-                    client.saved_artists(PAGE_LIMIT)
-                ))
-            }))
-            .await;
-
-            this.update(cx, |this, cx| {
-                this.state = match loaded {
-                    Ok(loaded) => partial(loaded),
-                    Err(error) => LibraryState::Failed(format!("{error:#}")),
-                };
-                this.read_playlists(cx);
-                this.build_mosaics(cx);
-                cx.notify();
-            })
-            .ok();
-        }));
+        let tracks = client.clone();
+        let playlists = client.clone();
+        let albums = client.clone();
+        self.tasks = vec![
+            self.fetch(
+                async move { tracks.saved_tracks(PAGE_LIMIT).await },
+                |this, loaded, cx| this.land(Landed::Tracks(loaded), cx),
+                cx,
+            ),
+            self.fetch(
+                async move { playlists.playlists(PAGE_LIMIT).await },
+                |this, loaded, cx| this.land(Landed::Playlists(loaded), cx),
+                cx,
+            ),
+            self.fetch(
+                async move { albums.saved_albums(PAGE_LIMIT).await },
+                |this, loaded, cx| this.land(Landed::Albums(loaded), cx),
+                cx,
+            ),
+            self.fetch(
+                async move { client.saved_artists(PAGE_LIMIT).await },
+                |this, loaded, cx| this.land(Landed::Artists(loaded), cx),
+                cx,
+            ),
+        ];
     }
 
     fn load_local(&mut self, client: Arc<dyn MusicApi>, cx: &mut Context<Self>) {
         self.local = LibraryState::Loading;
+        self.local_awaited = LibraryPart::ALL.to_vec();
+        self.local_favorites_loading = true;
         cx.notify();
 
-        let io = self.io.clone();
-        self.local_task = Some(cx.spawn(async move |this, cx| {
-            let loaded = join(io.spawn(async move {
-                anyhow::Ok(tokio::join!(
-                    client.all_tracks(PAGE_LIMIT),
-                    client.playlists(PAGE_LIMIT),
-                    client.saved_albums(PAGE_LIMIT),
-                    client.saved_artists(PAGE_LIMIT),
-                    client.saved_tracks(PAGE_LIMIT)
-                ))
-            }))
-            .await;
+        let tracks = client.clone();
+        let playlists = client.clone();
+        let albums = client.clone();
+        let artists = client.clone();
+        self.local_tasks = vec![
+            self.fetch(
+                async move { tracks.all_tracks(PAGE_LIMIT).await },
+                |this, loaded, cx| this.land_local(Landed::Tracks(loaded), cx),
+                cx,
+            ),
+            self.fetch(
+                async move { playlists.playlists(PAGE_LIMIT).await },
+                |this, loaded, cx| this.land_local(Landed::Playlists(loaded), cx),
+                cx,
+            ),
+            self.fetch(
+                async move { albums.saved_albums(PAGE_LIMIT).await },
+                |this, loaded, cx| this.land_local(Landed::Albums(loaded), cx),
+                cx,
+            ),
+            self.fetch(
+                async move { artists.saved_artists(PAGE_LIMIT).await },
+                |this, loaded, cx| this.land_local(Landed::Artists(loaded), cx),
+                cx,
+            ),
+            self.fetch(
+                async move { client.saved_tracks(PAGE_LIMIT).await },
+                |this, loaded, cx| {
+                    this.local_favorites = loaded.unwrap_or_else(|error| {
+                        log::warn!("library: cannot load the local favorites: {error:#}");
+                        Vec::new()
+                    });
+                    this.local_favorites_loading = false;
+                    cx.notify();
+                },
+                cx,
+            ),
+        ];
+    }
 
-            this.update(cx, |this, cx| {
-                let (state, favorites) = match loaded {
-                    Ok((tracks, playlists, albums, artists, favorites)) => (
-                        partial_local((tracks, playlists, albums, artists)),
-                        favorites.unwrap_or_else(|error| {
-                            log::warn!("library: cannot load the local favorites: {error:#}");
-                            Vec::new()
-                        }),
-                    ),
-                    Err(error) => (LibraryState::Failed(format!("{error:#}")), Vec::new()),
-                };
-                this.local = state;
-                this.local_favorites = favorites;
-                this.read_local_playlists(cx);
-                cx.notify();
-            })
-            .ok();
-        }));
+    fn fetch<T, R, A>(&self, work: R, apply: A, cx: &mut Context<Self>) -> Task<()>
+    where
+        R: Future<Output = anyhow::Result<T>> + Send + 'static,
+        T: Send + 'static,
+        A: FnOnce(&mut Self, anyhow::Result<T>, &mut Context<Self>) + 'static,
+    {
+        let io = self.io.clone();
+        cx.spawn(async move |this, cx| {
+            let loaded = join(io.spawn(work)).await;
+            this.update(cx, |this, cx| apply(this, loaded, cx)).ok();
+        })
+    }
+
+    fn land(&mut self, landed: Landed, cx: &mut Context<Self>) {
+        let part = landed.part();
+        place(&mut self.state, &mut self.awaited, landed, &FATAL);
+        if part == LibraryPart::Playlists {
+            self.read_playlists(cx);
+            self.build_mosaics(cx);
+        }
+        cx.notify();
+    }
+
+    fn land_local(&mut self, landed: Landed, cx: &mut Context<Self>) {
+        let part = landed.part();
+        place(
+            &mut self.local,
+            &mut self.local_awaited,
+            landed,
+            &FATAL_LOCAL,
+        );
+        if part == LibraryPart::Playlists {
+            self.read_local_playlists(cx);
+        }
+        cx.notify();
     }
 }

--- a/crates/views/src/screens/library/albums.rs
+++ b/crates/views/src/screens/library/albums.rs
@@ -5,7 +5,7 @@ use ui::ActiveTheme as _;
 use gpui::{AnyElement, App, Entity, SharedString, TextAlign};
 use i18n::t;
 use music::Album;
-use state::{Library, LibraryState, Origin, Playback};
+use state::{Library, LibraryPart, LibraryState, Origin, Playback};
 use ui::rank::{HANDY, NICE, SPARE, USEFUL};
 use ui::{Cell, ColumnSpec, Menu, Pin, TableSource, Width};
 
@@ -212,8 +212,8 @@ impl TableSource for AlbumSource {
 
     fn is_loading(&self, cx: &App) -> bool {
         match self.local {
-            true => self.library.read(cx).local_is_loading(),
-            false => self.library.read(cx).is_loading(),
+            true => self.library.read(cx).local_loading(LibraryPart::Albums),
+            false => self.library.read(cx).loading(LibraryPart::Albums),
         }
     }
 

--- a/crates/views/src/screens/library/artists.rs
+++ b/crates/views/src/screens/library/artists.rs
@@ -3,7 +3,7 @@ use ui::ActiveTheme as _;
 
 use gpui::{AnyElement, App, Entity, SharedString};
 use music::SavedArtist;
-use state::{Library, LibraryState, Origin, Playback};
+use state::{Library, LibraryPart, LibraryState, Origin, Playback};
 use ui::rank::{ESSENTIAL, HANDY};
 use ui::{Cell, ColumnSpec, Menu, Pin, TableSource, Width};
 
@@ -118,8 +118,8 @@ impl TableSource for ArtistSource {
 
     fn is_loading(&self, cx: &App) -> bool {
         match self.local {
-            true => self.library.read(cx).local_is_loading(),
-            false => self.library.read(cx).is_loading(),
+            true => self.library.read(cx).local_loading(LibraryPart::Artists),
+            false => self.library.read(cx).loading(LibraryPart::Artists),
         }
     }
 

--- a/crates/views/src/screens/library/mod.rs
+++ b/crates/views/src/screens/library/mod.rs
@@ -213,10 +213,16 @@ impl Tracks for ShelfTracks {
     }
 
     fn is_loading(&self, cx: &App) -> bool {
-        match self.shelf {
-            Shelf::Local => self.library.read(cx).local_is_loading(),
-            Shelf::Saved => self.library.read(cx).is_loading(),
-        }
+        loading(&self.library, self.shelf, self.section, cx)
+    }
+}
+
+fn loading(library: &Entity<Library>, shelf: Shelf, section: Section, cx: &App) -> bool {
+    let library = library.read(cx);
+    match (shelf, section) {
+        (Shelf::Local, Section::Favorites) => library.local_favorites_loading(),
+        (Shelf::Local, _) => library.local_loading(section.part()),
+        (Shelf::Saved, _) => library.loading(section.part()),
     }
 }
 
@@ -536,18 +542,14 @@ impl LibraryView {
         page::store(&self.settings.clone(), self.table(section), key, key, cx);
     }
 
-    pub fn is_loading(&self, cx: &App) -> bool {
-        match self.shelf {
-            Shelf::Local => self.library.read(cx).local_is_loading(),
-            Shelf::Saved => self.library.read(cx).is_loading(),
-        }
-    }
-
     fn unconfigured(&self, cx: &App) -> bool {
         self.shelf.local() && Sonora::global(cx).session.read(cx).local_path().is_none()
     }
 
     fn note(&self, cx: &App) -> Option<Vacancy> {
+        if loading(&self.library, self.shelf, self.section, cx) {
+            return None;
+        }
         let library = self.library.read(cx);
         let table = self.table(self.section);
         let state = match self.shelf {

--- a/crates/views/src/screens/library/playlists.rs
+++ b/crates/views/src/screens/library/playlists.rs
@@ -4,7 +4,7 @@ use ui::ActiveTheme as _;
 use gpui::{AnyElement, App, Entity, TextAlign};
 use music::Playlist;
 use router::Destination;
-use state::{Library, LibraryState, Origin, Playback};
+use state::{Library, LibraryPart, LibraryState, Origin, Playback};
 use ui::rank::{ESSENTIAL, HANDY, NICE, SPARE};
 use ui::{Cell, ColumnSpec, Menu, Pin, TableSource, Width};
 
@@ -142,8 +142,8 @@ impl TableSource for PlaylistSource {
 
     fn is_loading(&self, cx: &App) -> bool {
         match self.local {
-            true => self.library.read(cx).local_is_loading(),
-            false => self.library.read(cx).is_loading(),
+            true => self.library.read(cx).local_loading(LibraryPart::Playlists),
+            false => self.library.read(cx).loading(LibraryPart::Playlists),
         }
     }
 


### PR DESCRIPTION
## Summary

- batch Spotify track metadata requests to prevent large libraries from exceeding payload limits