### PR TITLE
fix(home): seed queues from selected tracks

### DIFF
--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -475,16 +475,34 @@ impl Playback {
         }
 
         let origin = Origin::radio(id.clone()).named(seed.name.clone());
-        let seed = seed.clone();
-        self.gather(origin, cx, move |client| {
-            Box::pin(async move {
+        let Some(client) = self.client_for(&id, cx) else {
+            return;
+        };
+
+        self.fetch = None;
+        self.begin(vec![seed.clone()], 0, Some(origin.clone()), cx);
+
+        let seed_id = seed.id.clone();
+        let io = Io::global(cx);
+        self.fetch = Some(cx.spawn(async move |this, cx| {
+            let loaded = join(io.spawn(async move {
                 let mut tracks = client.track_radio(&id).await?;
-                tracks.retain(|track| track.id != seed.id && track.playable);
+                tracks.retain(|track| track.id != seed_id && track.playable);
                 fastrand::shuffle(&mut tracks);
-                tracks.insert(0, seed);
                 Ok(tracks)
+            }))
+            .await;
+
+            this.update(cx, |this, cx| match loaded {
+                Ok(tracks) if this.origin.as_ref() == Some(&origin) => {
+                    this.queue
+                        .update(cx, |queue, cx| queue.extend_context(tracks, cx));
+                }
+                Ok(_) => {}
+                Err(error) => log::error!("playback: cannot load radio queue: {error:#}"),
             })
-        });
+            .ok();
+        }));
     }
 
     fn play_radio_of(&mut self, origin: Origin, cx: &mut Context<Self>) {

--- a/crates/state/src/queue.rs
+++ b/crates/state/src/queue.rs
@@ -501,6 +501,15 @@ impl Queue {
         self.insert_upcoming(self.queued(), tracks, cx);
     }
 
+    pub(crate) fn extend_context(&mut self, tracks: Vec<Track>, cx: &mut Context<Self>) {
+        let at = self.queued();
+        self.source.extend(tracks.iter().cloned());
+        for (offset, track) in tracks.into_iter().enumerate() {
+            self.upcoming.insert(at + offset, track);
+        }
+        self.changed(cx);
+    }
+
     pub fn insert_upcoming(
         &mut self,
         gap: usize,

--- a/crates/views/src/screens/home/mod.rs
+++ b/crates/views/src/screens/home/mod.rs
@@ -157,9 +157,10 @@ impl Render for HomeView {
                 open_menu(&home, &tracks, place, event, cx);
             })
             .on_start(move |place, cx| {
-                playback.update(cx, |playback, cx| {
-                    playback.start(started.as_ref().clone(), place, None, cx)
-                });
+                let Some(track) = started.get(place) else {
+                    return;
+                };
+                playback.update(cx, |playback, cx| playback.play_radio(track, cx));
             })
         });
 
@@ -193,9 +194,10 @@ impl Render for HomeView {
             open_menu(&home, &tracks, place, event, cx);
         })
         .on_start(move |place, cx| {
-            playback.update(cx, |playback, cx| {
-                playback.start(started.as_ref().clone(), place, None, cx)
-            });
+            let Some(track) = started.get(place) else {
+                return;
+            };
+            playback.update(cx, |playback, cx| playback.play_radio(track, cx));
         });
 
         let sections = self.home.read(cx).sections();


### PR DESCRIPTION
## Summary

- build Quick Picks and Listen Again queues from the selected track
- start the selected track immediately before fetching radio recommendations
- append recommendations in the background without restarting playback
- ignore stale radio responses after the playback context changes

## Verification

- `cargo fmt --check`
- `cargo check -p views`
- `cargo test --workspace`