### PR TITLE
feat(views): show compact lyrics in short windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Short windows now show the current synced lyrics line directly above the player bar.
+
 ## [0.29.0] - 2026-09-03
 
 ### Added

--- a/crates/views/src/chrome/player_bar.rs
+++ b/crates/views/src/chrome/player_bar.rs
@@ -10,10 +10,10 @@ use gpui::{
 use gpui::{Window, div, px};
 use i18n::t;
 use input::{ToggleFullscreen, ToggleLyrics, ToggleQueue};
-use state::{AppSettings, Playback, Queue, SideTab, Sonora};
+use state::{AppSettings, Lyrics, Playback, Queue, SideTab, Sonora};
 use ui::{
     Artwork, Button, ExplicitBadge, InlineLink, InlineLinks, Popup, Room, Scrollbar, Scrubber,
-    ScrubberState, clock,
+    ScrubberState, Text, clock,
 };
 
 use crate::chrome::SidebarRight;
@@ -26,9 +26,30 @@ const VOLUME_TIGHT: f32 = 72.;
 const CLOCK_SHORT: f32 = 3.4;
 const CLOCK_LONG: f32 = 5.4;
 
+fn compact_lyrics_line(lyrics: &music::Lyrics, position: Duration) -> Option<SharedString> {
+    let music::Lyrics::Synced { lines } = lyrics else {
+        return None;
+    };
+    let line = lines
+        .get(music::lyrics::active(lines, position)?)?
+        .text
+        .trim();
+    (!line.is_empty()).then(|| SharedString::from(line.to_owned()))
+}
+
+fn compact_lyrics_available(
+    viewport_height: Pixels,
+    title_height: Pixels,
+    player_height: Pixels,
+    cover_size: Pixels,
+) -> bool {
+    viewport_height - title_height - player_height < cover_size * 2.
+}
+
 pub(crate) struct PlayerBar {
     playback: Entity<Playback>,
     queue: Entity<Queue>,
+    lyrics: Entity<Lyrics>,
     settings: Entity<AppSettings>,
     track_menu: ItemMenu,
     context_menu: Option<(music::Track, Point<Pixels>)>,
@@ -44,10 +65,12 @@ pub(crate) struct PlayerBar {
 impl PlayerBar {
     pub fn new(playback: Entity<Playback>, queue: Entity<Queue>, cx: &mut Context<Self>) -> Self {
         let library = Sonora::global(cx).library.clone();
+        let lyrics = Sonora::global(cx).lyrics.clone();
         let settings = Sonora::global(cx).settings.clone();
         cx.observe(&playback, |_, _, cx| cx.notify()).detach();
         cx.observe(&queue, |_, _, cx| cx.notify()).detach();
         cx.observe(&library, |_, _, cx| cx.notify()).detach();
+        cx.observe(&lyrics, |_, _, cx| cx.notify()).detach();
         cx.observe(&settings, |_, _, cx| cx.notify()).detach();
 
         let me = cx.entity_id();
@@ -56,6 +79,7 @@ impl PlayerBar {
         Self {
             playback,
             queue,
+            lyrics,
             settings,
             track_menu: ItemMenu::new(playlist_scrollbar),
             context_menu: None,
@@ -343,12 +367,35 @@ impl PlayerBar {
 }
 
 impl PlayerBar {
-    pub(crate) fn height(window: &Window, cx: &gpui::App) -> Pixels {
+    fn base_height(window: &Window, cx: &gpui::App) -> Pixels {
         let theme = *cx.theme();
         match !Room::of(window.viewport_size().width).fits(Room::Roomy) {
             true => ui::snapped(theme.metrics.player_bar + theme.metrics.pad * 3., window),
             false => ui::snapped(theme.metrics.player_bar, window),
         }
+    }
+
+    fn compact_line(&self, window: &Window, cx: &gpui::App) -> Option<SharedString> {
+        let theme = *cx.theme();
+        if !compact_lyrics_available(
+            window.viewport_size().height,
+            theme.metrics.title_bar,
+            Self::base_height(window, cx),
+            theme.metrics.cover,
+        ) {
+            return None;
+        }
+        let lyrics = self.lyrics.read(cx);
+        let position = self.playback.read(cx).live_position();
+        compact_lyrics_line(&lyrics.current()?.lyrics, position)
+    }
+
+    pub(crate) fn height(&self, window: &Window, cx: &gpui::App) -> Pixels {
+        let theme = *cx.theme();
+        Self::base_height(window, cx)
+            + self
+                .compact_line(window, cx)
+                .map_or(Pixels::ZERO, |_| theme.metrics.list_row)
     }
 }
 
@@ -359,7 +406,8 @@ impl Render for PlayerBar {
         let empty = muted.opacity(0.3);
         let span = Room::of(window.viewport_size().width);
         let stacked = !span.fits(Room::Roomy);
-        let height = Self::height(window, cx);
+        let height = self.height(window, cx);
+        let compact_line = self.compact_line(window, cx);
         let clock_text = theme.text(ui::Text::Tiny);
 
         let show_track = span.fits(Room::Snug);
@@ -425,13 +473,17 @@ impl Render for PlayerBar {
         let base = div()
             .flex()
             .w_full()
-            .h(height)
+            .h(height
+                - compact_line
+                    .as_ref()
+                    .map_or(Pixels::ZERO, |_| theme.metrics.list_row))
             .flex_none()
             .px_5()
             .when(stacked, |this| this.py_2())
             .when(!theme.transparent, |this| this.bg(theme.secondary))
-            .border_t_1()
-            .border_color(theme.border)
+            .when(compact_line.is_none(), |this| {
+                this.border_t_1().border_color(theme.border)
+            })
             .on_mouse_move(cx.listener(Self::hover));
 
         let context_menu = self.context_menu.clone().map(|(track, position)| {
@@ -498,6 +550,111 @@ impl Render for PlayerBar {
                 ),
         };
 
-        content.when_some(context_menu, |this, menu| this.child(menu))
+        div()
+            .flex()
+            .flex_col()
+            .w_full()
+            .h(height)
+            .when_some(compact_line, |this, line| {
+                this.child(
+                    div()
+                        .id("compact-lyrics")
+                        .flex()
+                        .flex_none()
+                        .items_center()
+                        .justify_center()
+                        .h(theme.metrics.list_row)
+                        .px_5()
+                        .border_t_1()
+                        .border_color(theme.border)
+                        .when(!theme.transparent, |this| this.bg(theme.secondary))
+                        .text_size(theme.text(Text::Body))
+                        .child(
+                            div()
+                                .w_full()
+                                .min_w_0()
+                                .truncate()
+                                .text_center()
+                                .child(line),
+                        ),
+                )
+            })
+            .child(content)
+            .when_some(context_menu, |this, menu| this.child(menu))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use music::{Lyrics, LyricsLine, Voice};
+
+    use super::*;
+
+    fn line(start: u64, text: &str) -> LyricsLine {
+        LyricsLine {
+            start: Duration::from_secs(start),
+            end: None,
+            text: text.to_owned(),
+            romanized: None,
+            words: None,
+            secondary: Vec::new(),
+            voice: Voice::Lead,
+        }
+    }
+
+    #[test]
+    fn compact_lyrics_follow_the_current_synced_line() {
+        let lyrics = Lyrics::Synced {
+            lines: Arc::from([line(2, "first"), line(5, "second")]),
+        };
+
+        assert_eq!(compact_lyrics_line(&lyrics, Duration::from_secs(1)), None);
+        assert_eq!(
+            compact_lyrics_line(&lyrics, Duration::from_secs(2)).as_deref(),
+            Some("first")
+        );
+        assert_eq!(
+            compact_lyrics_line(&lyrics, Duration::from_secs(5)).as_deref(),
+            Some("second")
+        );
+    }
+
+    #[test]
+    fn compact_lyrics_ignore_plain_and_empty_lines() {
+        assert_eq!(
+            compact_lyrics_line(&Lyrics::plain("plain"), Duration::ZERO),
+            None
+        );
+        assert_eq!(
+            compact_lyrics_line(
+                &Lyrics::Synced {
+                    lines: Arc::from([line(0, "  ")]),
+                },
+                Duration::ZERO,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn compact_lyrics_use_the_height_left_above_the_player() {
+        let title = px(36.);
+        let player = px(76.);
+        let cover = px(140.);
+
+        assert!(!compact_lyrics_available(
+            title + player + cover * 2.,
+            title,
+            player,
+            cover
+        ));
+        assert!(compact_lyrics_available(
+            title + player + cover * 2. - px(1.),
+            title,
+            player,
+            cover
+        ));
     }
 }

--- a/crates/views/src/shells/workspace.rs
+++ b/crates/views/src/shells/workspace.rs
@@ -4,7 +4,7 @@ use gpui::prelude::*;
 use gpui::{AnyView, App, Context, Entity, FocusHandle, Render, StyleRefinement};
 use gpui::{Window, div};
 use input::WORKSPACE_CONTEXT;
-use state::{Playback, Queue, SideTab};
+use state::{Playback, Queue, SideTab, Sonora};
 use ui::{
     Activate, ActiveTheme as _, Deselect, Remove, SelectNext, SelectPrevious, ease_out_expo,
     entrance_span, shown_listing, veiled,
@@ -62,7 +62,10 @@ impl Workspace {
     ) -> Self {
         let sidebar = cx.new(SidebarLeft::new);
         let sidebar_right = cx.new(|cx| SidebarRight::new(queue.clone(), playback.clone(), cx));
-        let player_bar = cx.new(|cx| PlayerBar::new(playback, queue, cx));
+        let player_bar = cx.new(|cx| PlayerBar::new(playback.clone(), queue, cx));
+        let lyrics = Sonora::global(cx).lyrics.clone();
+        cx.observe(&playback, |_, _, cx| cx.notify()).detach();
+        cx.observe(&lyrics, |_, _, cx| cx.notify()).detach();
 
         Self {
             sidebar,
@@ -172,7 +175,7 @@ impl Render for Workspace {
         Chrome::publish(left, right, cx);
         let covered = self.sidebar_right.read(cx).covers_content(window);
         let overlay = self.sidebar.read(cx).overlays();
-        let bar_height = PlayerBar::height(window, cx);
+        let bar_height = self.player_bar.read(cx).height(window, cx);
         // A cached view is laid out from the style given here and its own root
         // style is never consulted, so it can only be cached while it is in the
         // flow at a width this knows: an overlaid sidebar places itself, and a


### PR DESCRIPTION
## Summary

- I show the current synced lyrics line above the player bar when the window is too short for the regular presentation.
- I keep the compact row in sync with playback and remove it again when the window has enough height.
- I added focused coverage for line selection, unsupported lyrics, empty lines, and the height breakpoint.

## Validation

- I ran `cargo fmt --all -- --check`.
- I ran `cargo test --locked -p views` (47 passed).
- I ran `cargo clippy --locked -p views --all-targets -- -D warnings`.
- I deferred the full workspace checks to CI because this local environment does not have the complete desktop development dependency set.

Fixes #289
