### PR TITLE
feat(i18n): add japanese translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Sonora speaks Spanish. Pick Español under Settings > General > Language, or leave the language on
   System and it follows a Spanish desktop on its own.
+- Sonora speaks Japanese. Pick 日本語 under Settings > General > Language, or leave the language on
+  System and it follows a Japanese desktop on its own.
 
 ## [0.29.0] - 2026-09-03
 

--- a/README.md
+++ b/README.md
@@ -139,17 +139,18 @@ AI-assisted proofreading and translation of human-written text are permitted.
 
 <!-- i18n:start -->
 
-| Language                     | Translated | Coverage |
-| ---------------------------- | ---------- | -------- |
-| English (`en-US`)            | 496/496    | 100%     |
-| Deutsch (`de`)               | 475/496    | 96%      |
-| Español (`es`)               | 496/496    | 100%     |
-| Français (`fr`)              | 475/496    | 96%      |
-| Italiano (`it`)              | 475/496    | 96%      |
-| Русский (`ru`)               | 475/496    | 96%      |
-| Українська (`uk`)            | 475/496    | 96%      |
-| Polski (`pl`)                | 475/496    | 96%      |
-| Português (Brasil) (`pt-BR`) | 496/496    | 100%     |
+| Language | Translated | Coverage |
+| --- | --- | --- |
+| English (`en-US`) | 496/496 | 100% |
+| Deutsch (`de`) | 475/496 | 96% |
+| Español (`es`) | 496/496 | 100% |
+| Français (`fr`) | 475/496 | 96% |
+| Italiano (`it`) | 475/496 | 96% |
+| 日本語 (`ja`) | 496/496 | 100% |
+| Русский (`ru`) | 475/496 | 96% |
+| Українська (`uk`) | 475/496 | 96% |
+| Polski (`pl`) | 475/496 | 96% |
+| Português (Brasil) (`pt-BR`) | 496/496 | 100% |
 
 <!-- i18n:end -->
 

--- a/assets/i18n/ja/main.ftl
+++ b/assets/i18n/ja/main.ftl
@@ -1,0 +1,572 @@
+# common
+common-on = オン
+common-off = オフ
+common-left = 左
+common-right = 右
+common-search = 検索
+common-unknown = 不明
+common-not-provided = 情報なし
+common-not-available = データなし
+common-cancel = キャンセル
+common-save = 保存
+common-delete = 削除
+common-play = 再生
+common-more = その他
+common-previous = 前へ
+common-next = 次へ
+common-dismiss = 閉じる
+common-clear = クリア
+number-group = { "," }
+
+# navigation
+nav-history = 履歴
+nav-home = ホーム
+nav-search = 検索
+nav-library = ライブラリ
+nav-settings = 設定
+nav-songs = 曲
+nav-favorites = お気に入り
+nav-albums = アルバム
+nav-playlists = プレイリスト
+nav-artists = アーティスト
+nav-local = ローカル音楽
+nav-back = 戻る
+nav-forward = 進む
+nav-sidebar = サイドバーを切り替え
+nav-sidebar-right = 歌詞と再生キューを表示・非表示
+nav-pinned = ピン留め
+nav-unpin = ピン留めを解除
+nav-pin-hint = ここにドロップしてピン留め
+library-liked-songs = お気に入り
+library-play-liked-songs = 再生
+library-no-songs = お気に入りはまだありません
+library-no-albums = 保存したアルバムはまだありません
+library-no-playlists = プレイリストはまだありません
+library-no-artists = フォロー中のアーティストはまだいません
+library-no-local-songs = インポートされた曲が見つかりません
+library-no-local-favorites = ローカルのお気に入りはまだありません
+library-no-local-albums = インポートされたアルバムが見つかりません
+library-no-local-artists = インポートされたアーティストが見つかりません
+library-no-local-playlists = ローカルのプレイリストはまだありません
+library-no-matches = 一致する項目がありません
+library-not-loaded = ライブラリを読み込めませんでした
+library-part-not-loaded = ライブラリのこの部分を読み込めませんでした
+library-local-unconfigured = ローカルライブラリを設定する
+
+# app menu
+app-refresh-library = ライブラリを更新
+app-sign-out = サインアウト
+app-quit = 終了
+
+# table columns
+column-played-at = 再生日時
+column-index = #
+column-title = タイトル
+column-artist = アーティスト
+column-album = アルバム
+column-date-added = 追加日
+column-added-by = 追加者
+column-modified = 更新日
+column-length = 長さ
+column-plays = 再生数
+column-name = 名前
+column-owner = 所有者
+column-year = 年
+column-tracks = 曲数
+
+# track menu
+menu-add-to-playlist = プレイリストに追加
+menu-add-tracks-to-playlist = { $count }曲をプレイリストに追加
+menu-new-playlist = 新しいプレイリスト
+menu-edit-tags = タグを編集
+menu-no-playlists = プレイリストがありません
+menu-add-to-library = お気に入りに追加
+menu-add-tracks-to-library = { $count }曲をお気に入りに追加
+menu-remove-from-library = お気に入りから削除
+menu-remove-tracks-from-library = { $count }曲をお気に入りから削除
+menu-remove-from-playlist = プレイリストから削除
+menu-remove-tracks-from-playlist = { $count }曲をプレイリストから削除
+menu-remove-from-history = 履歴から削除
+menu-remove-tracks-from-history = { $count }曲を履歴から削除
+menu-play-next = 次に再生
+menu-play-tracks-next = { $count }曲を次に再生
+menu-add-to-queue = 再生キューに追加
+menu-add-tracks-to-queue = { $count }曲を再生キューに追加
+menu-song-radio = 曲のラジオを開く
+menu-go-to-album = アルバムを表示
+menu-go-to-artist = アーティストを表示
+menu-view-details = 詳細を表示
+menu-copy-link = リンクをコピー
+menu-cut = 切り取り
+menu-copy = コピー
+menu-paste = 貼り付け
+menu-select-all = すべて選択
+menu-remove-from-queue = 再生キューから削除
+menu-open-playlist = プレイリストを開く
+menu-play-playlist = プレイリストを再生
+menu-rename-playlist = プレイリストの名前を変更
+menu-delete-playlist = プレイリストを削除
+menu-add-playlist-to-library = ライブラリに追加
+menu-remove-playlist-from-library = ライブラリから削除
+menu-make-playlist-public = 公開する
+menu-make-playlist-private = 非公開にする
+menu-open-album = アルバムを開く
+menu-play-album = アルバムを再生
+menu-play-artist = アーティストを再生
+
+# playlist editor
+playlist-name-placeholder = プレイリスト名
+playlist-create-title = プレイリストを作成
+playlist-rename-title = プレイリストの名前を変更
+playlist-delete-title = プレイリストを削除
+playlist-delete-confirm = 「{ $name }」を削除しますか？この操作は取り消せません。
+playlist-again-title = もう一度追加しますか？
+playlist-again-confirm = この曲は既に「{ $name }」にあります。もう一度追加しますか？
+playlist-again-add = 再度追加
+
+# confirm
+confirm-remove-library-title = ライブラリから削除
+confirm-remove-playlist-title = プレイリストから削除
+confirm-remove-history-title = 履歴から削除
+confirm-unfollow-title = フォロー解除
+confirm-remove-songs = { $count }曲をライブラリから削除しますか？
+confirm-remove-playlist-songs = { $count }曲をプレイリストから削除しますか？
+confirm-remove-history-songs = { $count }曲を再生履歴から削除しますか？
+confirm-remove-albums = { $count }枚のアルバムをライブラリから削除しますか？
+confirm-unfollow-artists = { $count }人のアーティストのフォローを解除しますか？
+confirm-remove-playlists = { $count }件のプレイリストをライブラリから削除しますか？
+
+# queue panel
+queue-title = 再生キュー
+queue-history = 履歴
+queue-now-playing = 再生中
+queue-from = 再生元
+queue-up-next = 次に再生
+queue-reset = リセット
+queue-clear = クリア
+queue-empty = 再生キューは空です
+queue-similar = 似ている曲
+queue-radio = 似ている曲を自動再生
+
+# player bar
+player-nothing-playing = 再生中の曲はありません
+player-percent = { $value }%
+player-shuffle = シャッフル
+player-repeat = リピート
+player-repeat-all = 全曲リピート
+player-repeat-one = 1曲リピート
+player-mute = ミュート
+player-unmute = ミュート解除
+player-previous = 前の曲
+player-next = 次の曲
+player-fullscreen = フルスクリーン
+player-fullscreen-leave = フルスクリーンを終了
+fullscreen-artwork = アートワーク
+
+# filters
+filter-history = 再生履歴を絞り込む
+history-empty = 再生した曲がここに表示されます。
+history-not-loaded = 再生履歴を読み込めませんでした。
+history-clear = 履歴をクリア
+history-clear-title = 再生履歴をクリア
+history-clear-confirm = このデバイスからすべての再生記録が削除されます。この操作は取り消せません。
+filter-library = ライブラリを絞り込む
+filter-album = アルバムの曲を絞り込む
+filter-reset = フィルターをリセット
+filter-duration = 長さ
+filter-year = 年
+filter-explicit = 露骨な表現を含む曲のみ
+filter-playable = 再生可能な曲のみ
+
+# view
+view-list = リスト
+view-cards = グリッド
+
+# toolbar
+tool-columns = 列
+tool-sort = 並べ替え
+tool-filters = フィルター
+
+# login
+login-signed-out = サインインして音楽ライブラリを読み込む
+login-restoring = 保存されたセッションを確認しています…
+login-authorizing = ブラウザでの承認を待っています…
+login-signed-in = { $name } としてサインイン中
+login-failed-title = サインインに失敗しました
+login-problem-region = 現在いる国からは Spotify のセッションを開始できません。居住国からサインインするか、Spotify アカウントの国設定を変更してください。
+login-problem-credentials = 保存された Spotify のセッションは無効になっています。続けるにはもう一度サインインしてください。
+login-problem-network = Spotify に接続できませんでした。インターネット接続を確認してもう一度お試しください。
+login-problem-cancelled = サインインを承認する前にブラウザのページが閉じられました。最初からやり直してください。
+login-problem-refused = Spotify がサインインを拒否しました。しばらく待ってからもう一度お試しください。
+login-problem-premium = Sonora は Spotify Premium でストリーミングしますが、このアカウントは Premium プランに加入していません。続けるには Premium アカウントでサインインしてください。
+login-sign-in = { $provider } でサインイン
+login-connect-cookies = Cookie を手動で貼り付け
+login-import-browser = ブラウザからインポート*
+login-import-browser-plain = ブラウザからインポート
+login-browser-firefox = *Firefox 系ブラウザのみ
+login-browser-title = ブラウザを選択
+login-browser-detail = 選んだブラウザから YouTube Music のセッションを読み取ります。セッションはこのデバイスの外に出ません。
+login-use = { $provider } を使う
+login-guest-title = ゲストモード
+login-guest-use = ゲストモードを使う
+login-guest-detail = アカウントなしで再生・閲覧できます。ライブラリ、お気に入り、プレイリストは利用できません。
+login-usage-consent = Sonora の利用者数の推計にご協力ください。
+login-device-code = { $url } でこのコードを入力してください
+login-cookie-submit = 続行
+login-cookie-hint = Cookie リクエストヘッダーをここに貼り付け
+login-cookie-detail = 1. music.youtube.com を開き、サインインしていることを確認します。2. F12 を押して Network タブを開き、ページを再読み込みします。3. 「browse」または「next」という名前のリクエストを選択します。4. Headers の Request Headers にある Cookie を右クリックし、その値をコピーします。値全体を下に貼り付けてください。リクエストの Cookies パネルでは不十分で、値に SAPISID と __Secure-3PAPISID が含まれている必要があります。
+login-cookie-title = YouTube Music の Cookie を貼り付けてサインインを完了
+login-account-title = アカウントを選択
+login-account-detail = このセッションは複数の Google アカウントにサインインしています。Sonora が使うアカウントを選んでください。
+
+# album and playlist pages
+detail-album = アルバム
+detail-playlist = プレイリスト
+detail-play-album = アルバムを再生
+detail-play-playlist = プレイリストを再生
+
+# play button
+play-pause = 一時停止
+play-resume = 再開
+play-loading = 読み込み中…
+
+# artist page
+artist-eyebrow = アーティスト
+artist-monthly-listeners = { $count ->
+   *[other] 月間リスナー { $value }人
+}
+artist-play = 今すぐ再生
+artist-follow = フォロー
+artist-unfollow = フォロー解除
+artist-popular = 人気の曲
+artist-popular-eyebrow = このアーティストを知る
+artist-popular-empty = このアーティストにはまだ再生できる曲がありません
+artist-popular-more = すべて表示
+artist-popular-less = 折りたたむ
+artist-releases = リリース
+artist-releases-more = すべて表示
+artist-releases-less = 折りたたむ
+artist-filter-all = すべて
+artist-filter-albums = アルバム
+artist-filter-singles = シングル
+artist-filter-eps = EP
+
+# user profile page
+user-eyebrow = プロフィール
+user-followers = { $count ->
+   *[other] フォロワー { $value }人
+}
+user-following = { $count ->
+   *[other] フォロー中 { $value }人
+}
+user-playlists = 公開プレイリスト
+user-playlists-empty = 公開プレイリストはまだありません
+
+# release kinds
+release-album = アルバム
+release-single = シングル
+release-compilation = コンピレーション
+release-ep = EP
+release-audiobook = オーディオブック
+release-podcast = ポッドキャスト
+release-meta = { $year } • { $kind }
+
+# home page
+home-quick-picks = クイックピック
+home-listen-again = もう一度聴く
+home-quick-picks-eyebrow = 好きな1曲から始める
+home-quick-picks-empty = 何曲かお気に入りに追加するとここに表示されます
+
+# search page
+search-placeholder = 何を聴きたいですか？
+search-browse = すべてのジャンル
+genre-empty = ここにはまだ何もありません
+search-best-match = ベストマッチ
+search-no-matches = 一致する項目がありません
+search-results = 検索結果
+search-songs = 曲
+search-artists = アーティスト
+search-albums-playlists = アルバムとプレイリスト
+search-tag = { $kind } ·
+search-saved =
+    { $count ->
+       *[other] ライブラリに { $count }曲
+    }
+kind-song = 曲
+kind-artist = アーティスト
+kind-album = アルバム
+kind-playlist = プレイリスト
+
+# song page
+song-eyebrow = 曲
+song-play = 曲を再生
+song-view-album = アルバムを表示
+song-loading = 曲の情報を読み込んでいます…
+song-about = この曲について
+song-album = アルバム
+song-released = リリース日
+song-streams = 再生回数
+song-position = 順位
+song-label = レーベル
+song-popularity = 人気度
+song-popularity-value = { $value }%
+song-disc-track = ディスク { $disc }、トラック { $track }
+song-track = トラック { $track }
+song-credits = クレジット
+song-performed-by = 演奏者
+song-details = ジャンルと詳細
+song-genres = ジャンル
+song-language = 言語
+song-content = コンテンツ
+song-explicit = 露骨な表現あり
+song-clean = 露骨な表現なし
+artist-about = アーティストについて
+artist-about-fallback = アーティストの人気曲やリリースを見てみましょう。
+artist-about-open = アーティストを表示
+song-copyright = © { $notice }
+
+# song languages
+language-ar = アラビア語
+language-de = ドイツ語
+language-en = 英語
+language-es = スペイン語
+language-fr = フランス語
+language-hi = ヒンディー語
+language-it = イタリア語
+language-ja = 日本語
+language-ko = 韓国語
+language-pt = ポルトガル語
+language-ru = ロシア語
+language-tr = トルコ語
+language-uk = ウクライナ語
+language-zh = 中国語
+language-zxx = 歌詞なし
+
+# counts
+count-songs =
+    { $count ->
+       *[other] { $count }曲
+    }
+count-tracks =
+    { $count ->
+       *[other] { $count }曲
+    }
+
+# dates
+date-just-now = たった今
+date-minute-ago = 1分前
+date-minutes-ago = { $count }分前
+date-today = 今日 { $time }
+date-yesterday = 昨日 { $time }
+date-time = { $date } { $time }
+date-full = { $year }年{ $month }{ $day }日
+month-1 = 1月
+month-2 = 2月
+month-3 = 3月
+month-4 = 4月
+month-5 = 5月
+month-6 = 6月
+month-7 = 7月
+month-8 = 8月
+month-9 = 9月
+month-10 = 10月
+month-11 = 11月
+month-12 = 12月
+
+# settings
+settings-tab-general = 一般
+settings-tab-appearance = 外観
+settings-tab-playback = 再生
+settings-theme = テーマ
+settings-theme-detail = アプリのカラーパレットを選ぶ
+settings-opacity = 不透明度
+settings-opacity-detail = アプリ背景の不透明度を調整する
+settings-opacity-value = { $percent }%
+settings-theme-config = 設定ファイルを開く
+settings-adaptive = アダプティブテーマ
+settings-adaptive-detail = 再生中のアルバムのアートワークでパレットを彩る
+settings-icons = アイコンパック
+settings-icons-detail = インターフェースが使うアイコンセットを選ぶ
+settings-motion = アニメーションを減らす
+settings-motion-detail = インターフェースのアニメーションや画面切り替え効果を省略する
+settings-pace = アニメーション速度
+settings-pace-detail = インターフェースのアニメーションの速さ
+settings-saver = バッテリー節約
+settings-saver-detail = Sonora が非アクティブの間アニメーションのフレームレートを制限する。次回起動時から適用
+settings-corners = 角の丸み
+settings-corners-detail = 面やコントロールの角をどれだけ丸めるか
+settings-font = フォントサイズ
+settings-font-detail = 基準の文字サイズ。他のすべてがこれに合わせて拡大縮小する
+settings-font-value = { $size } px
+settings-startup = 起動時に表示
+settings-startup-detail = 起動時に Sonora が開く画面
+settings-entries = サイドバー項目
+settings-entries-detail = サイドバーに表示するセクション
+settings-entries-pick = 項目を選ぶ
+settings-language = 言語
+settings-language-detail = インターフェース全体で Sonora が使う言語
+settings-language-system = システム
+settings-language-search = 言語を検索
+settings-language-none = 言語が見つかりません
+settings-typeface = フォント
+settings-typeface-detail = インターフェース全体で Sonora が使う書体
+settings-typeface-system = デフォルト
+settings-typeface-search = フォントを検索
+settings-typeface-none = フォントが見つかりません
+settings-window-controls = ウィンドウコントロール
+settings-window-controls-detail = タイトルバーに最小化・最大化・閉じるを表示する
+settings-controls-side = コントロールの位置
+settings-controls-side-detail = タイトルバーのどちら側にコントロールを置くか
+settings-normalisation = 音量を平準化
+settings-normalisation-detail = 曲ごとの音量を一定に保つ
+settings-gapless = ギャップレス再生
+settings-gapless-detail = アルバムの曲順どおり、間を置かずに次の曲へつなげる
+settings-karaoke-lyrics = カラオケ歌詞
+settings-karaoke-lyrics-detail = タイミング情報があるとき歌詞を単語ごとにハイライトする
+settings-romanized-lyrics = ローマ字歌詞
+settings-romanized-lyrics-detail = 選択した文字体系の発音表記を、このデバイス上で生成して表示する
+settings-romanization-writing-systems = 文字体系
+settings-romanization-japanese = 日本語
+settings-romanization-chinese = 中国語
+settings-romanization-korean = 韓国語
+settings-romanization-cyrillic = キリル文字
+settings-romanization-greek = ギリシャ文字
+settings-romanization-arabic = アラビア文字
+settings-romanization-other = その他の文字体系
+settings-advanced = 詳細設定
+settings-group-accounts = アカウント
+settings-group-library = ライブラリ
+settings-group-text = テキスト
+settings-group-motion = モーション
+settings-group-title-bar = タイトルバー
+settings-group-lyrics = 歌詞
+settings-group-project = プロジェクト
+settings-adaptive-menu = アダプティブコンテキストメニュー
+settings-adaptive-menu-detail = アルバムやアーティストなど、行に既に表示されている項目を省く
+settings-accounts = アカウント管理
+settings-accounts-detail = このデバイスで再生に使えるサービス
+settings-provider-none = 未接続
+settings-provider-connected = 接続済み
+settings-provider-current = このサービスから再生中
+settings-provider-guest = ゲストとして再生中
+settings-provider-switch = 切り替える
+settings-sign-out = サインアウト
+settings-local-folder = インポートする音楽フォルダ
+settings-local-folder-empty = 未設定
+settings-choose-folder = フォルダを選択…
+settings-rescan = 再スキャン
+settings-clear-folder = クリア
+settings-tab-about = 情報
+settings-version = バージョン
+settings-version-detail = 実行中の Sonora のビルド
+settings-license = ライセンス
+settings-license-detail = GNU General Public License バージョン 3 以降
+settings-license-view = ライセンスを読む
+settings-source = ソースコード
+settings-source-detail = このビルドの対応ソース
+settings-source-view = リポジトリを開く
+settings-team = チーム
+settings-team-github = GitHub
+settings-role-lead-maintainer = リードメンテナー
+settings-role-maintainer = メンテナー
+settings-role-contributor = コントリビューター
+settings-notice = Copyright © 2026 Sonora Contributors. Sonora は完全に無保証です。フリーソフトウェアであり、GNU General Public License バージョン 3 以降の条件のもとで自由に再配布できます。Sonora は非公式であり、Spotify AB とは無関係です。
+
+# themes
+theme-system = システム
+theme-dark = ダーク
+theme-light = ライト
+theme-midnight = ミッドナイト
+theme-forest = フォレスト
+theme-ocean = オーシャン
+theme-rose = ローズ
+theme-lavender = ラベンダー
+theme-amber = アンバー
+
+# corners
+corners-square = 四角
+corners-subtle = 控えめ
+corners-rounded = 丸め
+corners-round = 丸
+
+# motion
+motion-system = システム
+motion-always = 常に
+motion-never = なし
+pace-slow = ゆっくり
+pace-base = 標準
+pace-quick = 速い
+saver-off = オフ
+saver-light = 弱 ({ $fps } FPS)
+saver-medium = 中 ({ $fps } FPS)
+saver-strong = 強 ({ $fps } FPS)
+
+toast-playlist-created = プレイリストを作成しました
+toast-playlist-renamed = プレイリストの名前を変更しました
+toast-playlist-deleted = プレイリストを削除しました
+toast-playlist-added = プレイリストをライブラリに追加しました
+toast-playlist-removed = プレイリストをライブラリから削除しました
+toast-playlist-visibility = プレイリストの公開設定を変更しました
+toast-track-added = { $name } に追加しました
+toast-track-removed = { $name } から削除しました
+toast-playlist-failed = 変更を保存できませんでした
+toast-playlist-busy = 別の変更を処理中です
+toast-playlist-signed-out = プレイリストを変更するにはサインインしてください
+toast-queued-track = { $name } を再生キューに追加しました
+toast-next-track = { $name } を次に再生します
+toast-queued-album = アルバムを再生キューに追加しました
+toast-next-album = アルバムを次に再生します
+toast-queued-playlist = プレイリストを再生キューに追加しました
+toast-next-playlist = プレイリストを次に再生します
+toast-queued-artist = アーティストを再生キューに追加しました
+toast-next-artist = アーティストを次に再生します
+toast-queue-failed = 再生キューに追加できませんでした
+toast-keys-refused = Spotify がこのアカウントに再生キーを発行していません
+toast-sign-in-to-play = { $name } のストリーミングにはサインインが必要です
+toast-track-unplayable = { $name } を再生できませんでした
+toast-library-add-failed = { $name } をライブラリに追加できませんでした
+toast-library-remove-failed = { $name } をライブラリから削除できませんでした
+
+# lyrics
+lyrics-title = 歌詞
+lyrics-idle = 何か再生すると歌詞が表示されます
+lyrics-loading = 歌詞を探しています…
+lyrics-missing = 歌詞が見つかりませんでした
+lyrics-instrumental = この曲はインストゥルメンタルです
+lyrics-failed = 歌詞サービスに接続できませんでした
+lyrics-follow = 歌詞の自動スクロールを再開
+lyrics-source = 歌詞の提供元: { $source }
+lyrics-writers = 作詞: { $writers }
+
+update-available = Sonora { $version } が公開されました
+update-detail = 現在のバージョンは { $running } です。変更点を読むか、今すぐ更新できます。
+update-detail-notes = 現在のバージョンは { $running } です。変更点を読んでから、インストールした方法で Sonora を更新してください。
+update-notes = 変更点
+update-now = 更新
+update-later = 後で
+update-working = 更新をダウンロードしています…
+update-failed = 更新をインストールできませんでした。リリースページからもう一度お試しください。
+settings-check-updates = 更新を確認
+settings-check-updates-detail = 起動時に一度、新しいバージョンがあるか GitHub に確認する。Sonora が自動で更新するのは Windows のみで、他の環境では変更点を案内する
+
+# tags
+tags-edit-title = タグを編集
+tags-sheet-song = 曲
+tags-sheet-album = アルバム
+tags-sheet-details = 詳細
+tags-title = タイトル
+tags-artist = アーティスト
+tags-track = トラック番号
+tags-track-total = リリースの曲数
+tags-disc = ディスク番号
+tags-disc-total = リリースのディスク数
+tags-album = アルバム
+tags-album-artist = アルバムアーティスト
+tags-year = 年
+tags-genre = ジャンル
+tags-composer = 作曲者
+tags-publisher = 発行元
+tags-isrc = ISRC
+tags-comment = コメント
+toast-tags-saved = { $name } のタグを保存しました
+toast-tags-failed = タグを保存できませんでした

--- a/crates/i18n/src/language.rs
+++ b/crates/i18n/src/language.rs
@@ -10,6 +10,7 @@ pub enum Language {
     Spanish,
     French,
     Italian,
+    Japanese,
     Russian,
     Ukrainian,
     Polish,
@@ -17,12 +18,13 @@ pub enum Language {
 }
 
 impl Language {
-    pub const ALL: [Self; 9] = [
+    pub const ALL: [Self; 10] = [
         Self::English,
         Self::German,
         Self::Spanish,
         Self::French,
         Self::Italian,
+        Self::Japanese,
         Self::Russian,
         Self::Ukrainian,
         Self::Polish,
@@ -36,6 +38,7 @@ impl Language {
             Self::Spanish => "es",
             Self::French => "fr",
             Self::Italian => "it",
+            Self::Japanese => "ja",
             Self::Russian => "ru",
             Self::Ukrainian => "uk",
             Self::Polish => "pl",
@@ -50,6 +53,7 @@ impl Language {
             Self::Spanish => "Español",
             Self::French => "Français",
             Self::Italian => "Italiano",
+            Self::Japanese => "日本語",
             Self::Russian => "Русский",
             Self::Ukrainian => "Українська",
             Self::Polish => "Polski",
@@ -80,6 +84,7 @@ impl Language {
             Self::Spanish => langid!("es"),
             Self::French => langid!("fr"),
             Self::Italian => langid!("it"),
+            Self::Japanese => langid!("ja"),
             Self::Russian => langid!("ru"),
             Self::Ukrainian => langid!("uk"),
             Self::Polish => langid!("pl"),
@@ -94,6 +99,7 @@ impl Language {
             Self::Spanish => include_str!("../../../assets/i18n/es/main.ftl"),
             Self::French => include_str!("../../../assets/i18n/fr/main.ftl"),
             Self::Italian => include_str!("../../../assets/i18n/it/main.ftl"),
+            Self::Japanese => include_str!("../../../assets/i18n/ja/main.ftl"),
             Self::Russian => include_str!("../../../assets/i18n/ru/main.ftl"),
             Self::Ukrainian => include_str!("../../../assets/i18n/uk/main.ftl"),
             Self::Polish => include_str!("../../../assets/i18n/pl/main.ftl"),


### PR DESCRIPTION
## Summary

- translate all 496 keys into Japanese
- add 日本語 to the language picker in Settings > General

Translated with Claude Code (Fable 5.0), then reviewed by hand — I went through every string myself
as a native Japanese speaker.
