### PR TITLE
fix(playback): skip unavailable queue tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Playback now skips deleted or unavailable playlist songs when moving forward or backward.
 - Installing the standalone `.flatpak` bundle now registers the Sonora repository, so `flatpak update`
   keeps it current, and it can replace an install made from the repository.
 

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -930,7 +930,7 @@ impl Playback {
             Repeat::All if !self.queue.read(cx).has_next() => {
                 self.fetch = None;
                 if let Some(track) = self.queue.update(cx, |queue, cx| queue.rewind(cx)) {
-                    self.load_after(&track, Start::Segue, cx);
+                    self.follow_after(track, Start::Segue, cx);
                 }
             }
             _ if self.radio && !self.queue.read(cx).has_next() => {
@@ -987,6 +987,16 @@ impl Playback {
         let Some(track) = self.queue.update(cx, |queue, cx| queue.next(cx)) else {
             return;
         };
+        self.follow_after(track, start, cx);
+    }
+
+    fn follow_after(&mut self, mut track: Track, start: Start, cx: &mut Context<Self>) {
+        while !track.playable {
+            let Some(next) = self.queue.update(cx, |queue, cx| queue.next(cx)) else {
+                return;
+            };
+            track = next;
+        }
         self.load_after(&track, start, cx);
     }
 

--- a/crates/state/src/queue.rs
+++ b/crates/state/src/queue.rs
@@ -581,9 +581,9 @@ impl Queue {
     }
 
     pub fn previous(&mut self, cx: &mut Context<Self>) -> Option<Track> {
-        let previous = self.past.pop()?;
-        if let Some(playing) = self.current.replace(previous) {
-            self.upcoming.push_front(playing);
+        let index = self.past.iter().rposition(|track| track.playable)?;
+        if !select_past(&mut self.past, &mut self.current, &mut self.upcoming, index) {
+            return None;
         }
         self.changed(cx);
         self.current.clone()


### PR DESCRIPTION
## Summary

- skip deleted or unavailable playlist songs when moving forward or backward
- preserve the current queue position when no playable previous song exists
- fix #370