### PR TITLE
pin rust toolchain via rust-toolchain.toml and rust-overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,28 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788419040,
+        "narHash": "sha256-Itdv4WV5z+U0VpseZ/f4uvYmULVPxsV3Hc2l9HrCyY4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "1af4dd0db58d4adde06f0840ce28da90f9c66c50",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,17 +3,36 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
-    { nixpkgs, ... }:
+    {
+      nixpkgs,
+      rust-overlay,
+      ...
+    }:
     let
       systems = [
         "x86_64-linux"
         "aarch64-linux"
       ];
 
-      forEachSystem = fn: nixpkgs.lib.genAttrs systems (system: fn nixpkgs.legacyPackages.${system});
+      forEachSystem =
+        fn:
+        nixpkgs.lib.genAttrs systems (
+          system:
+          let
+            pkgs = import nixpkgs {
+              inherit system;
+              overlays = [ (import rust-overlay) ];
+            };
+          in
+          fn pkgs
+        );
 
       release = {
         version = "0.29.0";
@@ -117,6 +136,7 @@
       devShells = forEachSystem (
         pkgs:
         let
+          rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
           runtimeLibraries = with pkgs; [
             vulkan-loader
             wayland
@@ -137,9 +157,7 @@
             nativeBuildInputs = with pkgs; [
               mold
               pkg-config
-              rustc
-              rust-analyzer
-              rustfmt
+              rustToolchain
               sccache
             ];
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,10 @@
+[toolchain]
+channel = "1.97.1"
+components = [
+  "cargo",
+  "rustc",
+  "rustfmt",
+  "rust-analyzer",
+  "rust-src",
+]
+profile = "minimal"


### PR DESCRIPTION
same as the title.
This pins the development Rust toolchain to `1.97.1` and uses the same toolchain for both Nix and standalone rustup setups.
Note: the reason i used rust `1.97.1` because the nix environment used this version before this change , this can be changed later