### PR TITLE
fix(playback): restart when audio output changes

### DIFF
--- a/crates/music/src/audio.rs
+++ b/crates/music/src/audio.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context as _, Result};
@@ -31,6 +31,8 @@ impl Volume {
 pub struct Output {
     sink: Arc<rodio::Sink>,
     volume: Volume,
+    device: String,
+    failed: Arc<AtomicBool>,
     _stream: OutputStream,
 }
 
@@ -45,19 +47,26 @@ impl Output {
             .default_output_config()
             .map_err(|error| anyhow::anyhow!("cannot read the output config: {error}"))?;
 
+        let device_name = device.name().unwrap_or_else(|_| "unknown".to_owned());
         log::info!(
             "sink: using {} at {} Hz, {} channels, {}",
-            device.name().unwrap_or_else(|_| "unknown".to_owned()),
+            device_name,
             default.sample_rate().0,
             default.channels(),
             default.sample_format()
         );
 
         let format = default.sample_format();
+        let failed = Arc::new(AtomicBool::new(false));
+        let stream_failed = failed.clone();
         let builder = OutputStreamBuilder::default()
             .with_device(device)
             .with_config(&default.config())
-            .with_sample_format(format);
+            .with_sample_format(format)
+            .with_error_callback(move |error| {
+                log::warn!("sink: audio output failed: {error}");
+                stream_failed.store(true, Ordering::Release);
+            });
         let mut stream = builder
             .open_stream()
             .map_err(|error| anyhow::anyhow!("cannot open the audio output: {error}"))?;
@@ -73,6 +82,8 @@ impl Output {
         Ok(Self {
             sink: Arc::new(sink),
             volume,
+            device: device_name,
+            failed,
             _stream: stream,
         })
     }
@@ -83,6 +94,17 @@ impl Output {
 
     pub fn set_volume(&self, gain: f32) {
         self.volume.set(gain);
+    }
+
+    pub fn failed(&self) -> bool {
+        self.failed.load(Ordering::Acquire)
+    }
+
+    pub fn changed(&self) -> bool {
+        cpal::default_host()
+            .default_output_device()
+            .and_then(|device| device.name().ok())
+            .is_none_or(|device| device != self.device)
     }
 }
 

--- a/crates/music/src/lib.rs
+++ b/crates/music/src/lib.rs
@@ -171,6 +171,7 @@ pub enum PlaybackEvent {
     Unavailable,
     Refused,
     Gated,
+    OutputChanged,
 }
 
 pub trait Player: Send + Sync {

--- a/crates/music/src/local/playback.rs
+++ b/crates/music/src/local/playback.rs
@@ -157,6 +157,7 @@ async fn engine_loop(
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let report_every = (config.position_interval.as_millis() / POLL.as_millis()).max(1) as u32;
     let mut ticks = 0u32;
+    let mut output_ticks = 0u32;
 
     let mut playing = false;
     let mut current: Option<Slot> = None;
@@ -227,6 +228,10 @@ async fn engine_loop(
                         }
                     }
                     Command::Play => {
+                        if output.failed() || output.changed() {
+                            events.send(PlaybackEvent::OutputChanged).ok();
+                            return;
+                        }
                         if current.is_some() {
                             sink.play();
                             playing = true;
@@ -251,6 +256,14 @@ async fn engine_loop(
                 }
             }
             _ = ticker.tick() => {
+                output_ticks += 1;
+                if playing && (output.failed() || output_ticks >= report_every && output.changed()) {
+                    events.send(PlaybackEvent::OutputChanged).ok();
+                    return;
+                }
+                if output_ticks >= report_every {
+                    output_ticks = 0;
+                }
                 let len = sink.len();
                 ticks += 1;
                 if current.is_some() && playing && len < prev_len {

--- a/crates/music/src/spotify/playback.rs
+++ b/crates/music/src/spotify/playback.rs
@@ -7,7 +7,7 @@ use librespot_core::{Session, SpotifyUri};
 use librespot_playback::config::{Bitrate, PlayerConfig};
 use librespot_playback::mixer::NoOpVolume;
 use librespot_playback::player::{Player, PlayerEvent};
-use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
 
 use crate::audio::Volume;
 use crate::spectrum::Spectrum;
@@ -18,14 +18,25 @@ use crate::{
 
 const TRACK_PREFIX: &str = "spotify:track:";
 
-pub struct Events(UnboundedReceiver<PlayerEvent>);
+pub struct Events {
+    player: UnboundedReceiver<PlayerEvent>,
+    output: UnboundedReceiver<()>,
+}
 
 #[async_trait]
 impl PlaybackEvents for Events {
     async fn next(&mut self) -> Option<PlaybackEvent> {
         loop {
-            if let Some(event) = translate(self.0.recv().await?) {
-                return Some(event);
+            tokio::select! {
+                event = self.player.recv() => {
+                    if let Some(event) = translate(event?) {
+                        return Some(event);
+                    }
+                }
+                changed = self.output.recv() => {
+                    changed?;
+                    return Some(PlaybackEvent::OutputChanged);
+                }
             }
         }
     }
@@ -71,11 +82,15 @@ impl Engine {
         let sink_volume = volume.clone();
         let sink_flush = flush.clone();
         let sink_spectrum = spectrum.clone();
+        let (output_tx, output_rx) = unbounded_channel();
         let player = Player::new(player_config, session, Box::new(NoOpVolume), move || {
-            BlazingSink::boxed(sink_flush, sink_volume, sink_spectrum)
+            BlazingSink::boxed(sink_flush, sink_volume, sink_spectrum, output_tx.clone())
         });
 
-        let events = Events(player.get_player_event_channel());
+        let events = Events {
+            player: player.get_player_event_channel(),
+            output: output_rx,
+        };
         let engine = Self {
             player,
             volume,

--- a/crates/music/src/spotify/sink.rs
+++ b/crates/music/src/spotify/sink.rs
@@ -1,17 +1,19 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use librespot_playback::audio_backend::{Sink, SinkError, SinkResult};
 use librespot_playback::convert::Converter;
 use librespot_playback::decoder::AudioPacket;
 use librespot_playback::{NUM_CHANNELS, SAMPLE_RATE};
+use tokio::sync::mpsc::UnboundedSender;
 
 use crate::audio::{Output, Volume};
 use crate::spectrum::Spectrum;
 
 const QUEUED_CHUNKS: usize = 26;
 const DRAIN_POLL: Duration = Duration::from_millis(10);
+const DEVICE_POLL: Duration = Duration::from_millis(500);
 
 #[derive(Clone, Default)]
 pub struct Flush(Arc<AtomicBool>);
@@ -29,19 +31,36 @@ impl Flush {
 pub struct BlazingSink {
     output: Output,
     flush: Flush,
+    changed: UnboundedSender<()>,
+    checked_at: Instant,
 }
 
 impl BlazingSink {
-    pub fn open(flush: Flush, volume: Volume, spectrum: Spectrum) -> Result<Self, SinkError> {
+    pub fn open(
+        flush: Flush,
+        volume: Volume,
+        spectrum: Spectrum,
+        changed: UnboundedSender<()>,
+    ) -> Result<Self, SinkError> {
         let output = Output::open(volume, spectrum)
             .map_err(|error| SinkError::ConnectionRefused(error.to_string()))?;
         output.sink().pause();
 
-        Ok(Self { output, flush })
+        Ok(Self {
+            output,
+            flush,
+            changed,
+            checked_at: Instant::now(),
+        })
     }
 
-    pub fn boxed(flush: Flush, volume: Volume, spectrum: Spectrum) -> Box<dyn Sink> {
-        match Self::open(flush, volume, spectrum) {
+    pub fn boxed(
+        flush: Flush,
+        volume: Volume,
+        spectrum: Spectrum,
+        changed: UnboundedSender<()>,
+    ) -> Box<dyn Sink> {
+        match Self::open(flush, volume, spectrum, changed) {
             Ok(sink) => Box::new(sink),
             Err(error) => {
                 log::error!("sink: cannot open an output device: {error}");
@@ -49,10 +68,28 @@ impl BlazingSink {
             }
         }
     }
+
+    fn output_changed(&mut self) -> bool {
+        let now = Instant::now();
+        let changed = self.output.failed()
+            || now.duration_since(self.checked_at) >= DEVICE_POLL && self.output.changed();
+        if now.duration_since(self.checked_at) >= DEVICE_POLL {
+            self.checked_at = now;
+        }
+        changed
+    }
+
+    fn disconnected(&self) -> SinkError {
+        self.changed.send(()).ok();
+        SinkError::OnWrite("audio output changed".to_owned())
+    }
 }
 
 impl Sink for BlazingSink {
     fn start(&mut self) -> SinkResult<()> {
+        if self.output.failed() || self.output.changed() {
+            return Err(self.disconnected());
+        }
         self.output.sink().play();
         Ok(())
     }
@@ -63,6 +100,10 @@ impl Sink for BlazingSink {
     }
 
     fn write(&mut self, packet: AudioPacket, converter: &mut Converter) -> SinkResult<()> {
+        if self.output_changed() {
+            return Err(self.disconnected());
+        }
+
         if self.flush.take() {
             self.output.sink().clear();
             self.output.sink().play();
@@ -80,6 +121,9 @@ impl Sink for BlazingSink {
         ));
 
         while self.output.sink().len() > QUEUED_CHUNKS {
+            if self.output_changed() {
+                return Err(self.disconnected());
+            }
             std::thread::sleep(DRAIN_POLL);
         }
         Ok(())

--- a/crates/music/src/youtube/playback.rs
+++ b/crates/music/src/youtube/playback.rs
@@ -194,6 +194,7 @@ async fn engine_loop(
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let report_every = (config.position_interval.as_millis() / POLL.as_millis()).max(1) as u32;
     let mut ticks = 0u32;
+    let mut output_ticks = 0u32;
 
     let mut playing = false;
     let mut autostart = true;
@@ -240,6 +241,10 @@ async fn engine_loop(
                                 Some(spawn(&api, id.clone(), epoch, Kind::Play, &fetched));
                         }
                         events.send(PlaybackEvent::Loading(at.unwrap_or_default())).ok();
+                        if output.failed() || output.changed() {
+                            events.send(PlaybackEvent::OutputChanged).ok();
+                            return;
+                        }
                         silence(&sink, current.as_ref()).await;
                         current = None;
                         queued = None;
@@ -272,6 +277,10 @@ async fn engine_loop(
                     }
                     Command::Play => {
                         autostart = true;
+                        if output.failed() || output.changed() {
+                            events.send(PlaybackEvent::OutputChanged).ok();
+                            return;
+                        }
                         if let Some(slot) = &current {
                             sink.play();
                             slot.unmute();
@@ -357,6 +366,14 @@ async fn engine_loop(
                 }
             }
             _ = ticker.tick() => {
+                output_ticks += 1;
+                if playing && (output.failed() || output_ticks >= report_every && output.changed()) {
+                    events.send(PlaybackEvent::OutputChanged).ok();
+                    return;
+                }
+                if output_ticks >= report_every {
+                    output_ticks = 0;
+                }
                 let len = sink.len();
                 ticks += 1;
                 if current.is_some() && playing && len < prev_len {

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -1331,6 +1331,40 @@ impl Playback {
         }
     }
 
+    fn restart_output(&mut self, cx: &mut Context<Self>) {
+        let Some(track) = self.track.clone() else {
+            return;
+        };
+        let Some(id) = track.id.as_deref() else {
+            return;
+        };
+        let at = self.live_position();
+        let local = music::is_local_id(id);
+        let playback = match local {
+            true => self.session.read(cx).local_playback(),
+            false => self.session.read(cx).playback(),
+        };
+        let Some(playback) = playback else {
+            return;
+        };
+
+        log::info!("playback: restarting after the audio output changed");
+        match local {
+            true => {
+                self.local_task = None;
+                self.local_engine = None;
+                self.start_local_engine(playback, cx);
+            }
+            false => {
+                self.task = None;
+                self.engine = None;
+                self.start_engine(playback, cx);
+            }
+        }
+        self.load_after(&track, Start::Pick, cx);
+        self.seek_on_play = Some(at);
+    }
+
     fn ask_for_reconnect(&mut self, cx: &mut Context<Self>) -> bool {
         if self.track.is_none() {
             return false;
@@ -1415,6 +1449,7 @@ impl Playback {
             return;
         }
         match event {
+            BackendEvent::OutputChanged => self.restart_output(cx),
             BackendEvent::Unavailable | BackendEvent::Refused if self.resume_ready => {
                 self.resume_ready = false;
                 self.state = PlaybackState::Paused;


### PR DESCRIPTION
## Summary

- detect audio output changes across Spotify, YouTube, and local playback
- restart playback on the new output device without losing position
- fixes #339