### PR TITLE
refactor(ui): remove redundant artwork downsampling

### DIFF
--- a/crates/ui/src/artwork.rs
+++ b/crates/ui/src/artwork.rs
@@ -25,8 +25,6 @@ pub(crate) const ROUNDED: Pixels = px(4.);
 const CACHE_BYTES: usize = 32 * 1024 * 1024;
 const CACHE_ITEMS: usize = 256;
 const HARD_BYTES: usize = 192 * 1024 * 1024;
-const SAMPLED_BYTES: usize = 64 * 1024 * 1024;
-const SAMPLED_ITEMS: usize = 256;
 const MAX_SAMPLE_EDGE: u32 = 1024;
 const GRACE: Duration = Duration::from_secs(5);
 const KEEP_ITEMS: usize = 96;
@@ -221,19 +219,11 @@ struct Cached {
     used: Instant,
 }
 
-struct Sampled {
-    image: Arc<RenderImage>,
-    bytes: usize,
-    used: Instant,
-}
-
 struct ArtworkCache {
     items: HashMap<ArtworkKey, Cached>,
     pending: HashMap<ArtworkKey, Instant>,
-    sampled: HashMap<(Resource, u32), Sampled>,
     soft: HashMap<(Resource, u32), Arc<RenderImage>>,
     bytes: usize,
-    sampled_bytes: usize,
     _sweep: Task<()>,
 }
 
@@ -247,10 +237,8 @@ impl ArtworkCache {
             let cache = cx.new(|cx| Self {
                 items: HashMap::new(),
                 pending: HashMap::new(),
-                sampled: HashMap::new(),
                 soft: HashMap::new(),
                 bytes: 0,
-                sampled_bytes: 0,
                 _sweep: sweeper(cx),
             });
             cx.set_global(Installed(cache));
@@ -321,14 +309,11 @@ impl ArtworkCache {
         }
     }
 
-    fn prepared(&mut self, resource: &Resource, edge: u32, soft: bool) -> Option<Arc<RenderImage>> {
-        let key = (resource.clone(), edge);
-        if soft {
-            return self.soft.get(&key).cloned();
+    fn prepared(&self, resource: &Resource, edge: u32, soft: bool) -> Option<Arc<RenderImage>> {
+        match soft {
+            true => self.soft.get(&(resource.clone(), edge)).cloned(),
+            false => None,
         }
-        let sampled = self.sampled.get_mut(&key)?;
-        sampled.used = Instant::now();
-        Some(sampled.image.clone())
     }
 
     fn prepare(
@@ -340,10 +325,6 @@ impl ArtworkCache {
         window: &mut Window,
         cx: &mut App,
     ) -> Arc<RenderImage> {
-        let image = match edge {
-            0 => image,
-            edge => self.sample(resource, edge, image, window, cx),
-        };
         if !soft {
             return image;
         }
@@ -362,54 +343,6 @@ impl ArtworkCache {
         };
         self.soft.insert(key, softened.clone());
         softened
-    }
-
-    fn sample(
-        &mut self,
-        resource: &Resource,
-        edge: u32,
-        image: Arc<RenderImage>,
-        window: &mut Window,
-        cx: &mut App,
-    ) -> Arc<RenderImage> {
-        let key = (resource.clone(), edge);
-        if let Some(found) = self.sampled.get_mut(&key) {
-            found.used = Instant::now();
-            return found.image.clone();
-        }
-        let Some(image) = downsampled(&image, edge) else {
-            return image;
-        };
-        let bytes = image_bytes(&image);
-        self.sampled_bytes = self.sampled_bytes.saturating_add(bytes);
-        self.sampled.insert(
-            key.clone(),
-            Sampled {
-                image: image.clone(),
-                bytes,
-                used: Instant::now(),
-            },
-        );
-
-        while self.sampled.len() > 1
-            && (self.sampled.len() > SAMPLED_ITEMS || self.sampled_bytes > SAMPLED_BYTES)
-        {
-            let Some(oldest) = self
-                .sampled
-                .iter()
-                .min_by_key(|(_, sampled)| sampled.used)
-                .map(|(key, _)| key.clone())
-            else {
-                break;
-            };
-            let Some(sampled) = self.sampled.remove(&oldest) else {
-                break;
-            };
-            self.sampled_bytes = self.sampled_bytes.saturating_sub(sampled.bytes);
-            cx.drop_image(sampled.image, Some(&mut *window));
-        }
-
-        image
     }
 
     fn sweep(&mut self, cx: &mut App) {
@@ -465,11 +398,9 @@ impl ArtworkCache {
         let big = self.count(BIG_BYTES..);
 
         log::debug!(
-            "artwork: {} originals / {} KiB, {} sampled / {} KiB, dropped {}, idle {idle}, abandoned {}, waiting {}, sizes {tiny}/{small}/{big}",
+            "artwork: {} held / {} KiB, dropped {}, idle {idle}, abandoned {}, waiting {}, sizes {tiny}/{small}/{big}",
             self.items.len(),
             self.bytes / 1024,
-            self.sampled.len(),
-            self.sampled_bytes / 1024,
             held - self.items.len(),
             abandoned.len(),
             self.pending.len()
@@ -590,37 +521,6 @@ fn sample_edge(size: Pixels, window: &Window) -> u32 {
         .unwrap_or(0)
 }
 
-fn downsampled(image: &RenderImage, edge: u32) -> Option<Arc<RenderImage>> {
-    if edge == 0 || image.frame_count() == 0 {
-        return None;
-    }
-    let frames: Vec<Frame> = (0..image.frame_count())
-        .filter_map(|index| {
-            let size = image.size(index);
-            let width = size.width.0.max(0) as u32;
-            let height = size.height.0.max(0) as u32;
-            let side = width.min(height);
-            if side <= edge {
-                return None;
-            }
-            let bytes = image.as_bytes(index)?.to_vec();
-            let whole = RgbaImage::from_raw(width, height, bytes)?;
-            let square =
-                imageops::crop_imm(&whole, (width - side) / 2, (height - side) / 2, side, side);
-            let sampled = match side > edge.saturating_mul(2) {
-                true => imageops::thumbnail(&*square, edge, edge),
-                false => imageops::resize(&*square, edge, edge, imageops::FilterType::Triangle),
-            };
-
-            Some(Frame::from_parts(sampled, 0, 0, image.delay(index)))
-        })
-        .collect();
-    if frames.len() != image.frame_count() {
-        return None;
-    }
-    Some(Arc::new(RenderImage::new(frames)))
-}
-
 pub(crate) fn resource(url: impl Into<SharedString>) -> Resource {
     let url = url.into();
     match url.strip_prefix(FILE_PREFIX) {
@@ -634,8 +534,8 @@ pub fn artwork_usage(cx: &App) -> Option<(usize, usize)> {
     let cache = installed.0.read(cx);
     let soft_bytes: usize = cache.soft.values().map(|image| image_bytes(image)).sum();
     Some((
-        cache.items.len() + cache.sampled.len() + cache.soft.len(),
-        cache.bytes + cache.sampled_bytes + soft_bytes,
+        cache.items.len() + cache.soft.len(),
+        cache.bytes + soft_bytes,
     ))
 }
 
@@ -849,29 +749,6 @@ fn blank(size: Pixels, rounded: Pixels, muted: Hsla, glyph: Hsla, fallback: Shar
 mod tests {
     use super::*;
     use image::{Delay, Rgba, codecs::gif::GifEncoder};
-
-    fn rendered(width: u32, height: u32) -> RenderImage {
-        RenderImage::new(vec![Frame::from_parts(
-            RgbaImage::from_pixel(width, height, Rgba([20, 40, 60, 255])),
-            0,
-            0,
-            Delay::from_numer_denom_ms(80, 1),
-        )])
-    }
-
-    #[test]
-    fn downsampling_crops_to_the_square_artwork_surface() {
-        let sampled = downsampled(&rendered(240, 120), 64).unwrap();
-
-        assert_eq!(sampled.size(0).width.0, 64);
-        assert_eq!(sampled.size(0).height.0, 64);
-        assert_eq!(sampled.delay(0), Delay::from_numer_denom_ms(80, 1));
-    }
-
-    #[test]
-    fn downsampling_never_upscales_a_source() {
-        assert!(downsampled(&rendered(60, 100), 64).is_none());
-    }
 
     #[test]
     fn artwork_loader_targets_the_requested_edge() {


### PR DESCRIPTION
## Summary

- remove the redundant post-load artwork downsampling pass
- rely on the edge-aware artwork loader to decode covers at their requested size
- simplify artwork cache accounting and debug logging