### PR TITLE
feat(ui): improve windows only caption buttons

### DIFF
--- a/crates/ui/src/controls.rs
+++ b/crates/ui/src/controls.rs
@@ -92,12 +92,17 @@ impl RenderOnce for WindowControls {
             wanted.reverse();
         }
 
+        let is_windows = cfg!(target_os = "windows");
         let mut controls = self
             .base
             .flex()
             .flex_none()
             .items_center()
-            .gap_2()
+            .when_else(
+                is_windows,
+                |this| this.h_full().self_stretch().gap_0(),
+                |this| this.gap_2(),
+            )
             .when(!SYSTEM_ACTS, |this| {
                 this.on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
             })
@@ -111,15 +116,25 @@ impl RenderOnce for WindowControls {
                     .flex_none()
                     .items_center()
                     .justify_center()
-                    .size(BUTTON)
-                    .rounded(theme.radius)
-                    .cursor_pointer()
+                    .when_else(
+                        is_windows,
+                        |this| this.h_full().aspect_square().rounded_none(),
+                        |this| this.size(BUTTON).rounded(theme.radius).cursor_pointer(),
+                    )
                     .occlude()
                     .window_control_area(control.area())
                     .hover(move |style| {
                         style.bg(match danger {
                             true => theme.danger,
                             false => theme.secondary_active,
+                        })
+                    })
+                    .when(is_windows, |this| {
+                        this.active(move |style| {
+                            style.bg(match danger {
+                                true => theme.danger_hover,
+                                false => theme.secondary_hover,
+                            })
                         })
                     })
                     .child(

--- a/crates/views/src/chrome/title_bar.rs
+++ b/crates/views/src/chrome/title_bar.rs
@@ -257,7 +257,15 @@ impl Render for TitleBar {
                 },
             )
             .when(decorated && !leading, |this| {
-                this.child(div().flex_none().pr_2().child(WindowControls::new(false)))
+                this.child(
+                    div()
+                        .flex_none()
+                        .when(cfg!(target_os = "windows"), |this| {
+                            this.h_full().self_stretch()
+                        })
+                        .when(!cfg!(target_os = "windows"), |this| this.pr_2())
+                        .child(WindowControls::new(false)),
+                )
             })
     }
 }


### PR DESCRIPTION
## Summary

Updates the Windows caption buttons to match standard desktop titlebar sizing and hover behavior.

## Changes

- Render minimize, maximize, and close controls as square, full-height buttons on Windows
- Align trailing controls flush against the right window edge by removing container padding
- Add hover and active background highlights for caption buttons
- Use theme danger tokens for close button hover and pressed states
- Keep the circular button style and spacing unchanged on other platforms

## Testing

Tested on Windows 11:

- Minimize, maximize, restore, and close actions
- Titlebar dragging and double-click zoom
- Hover and active transitions when moving the cursor from client content and outside the window

<img width="1062" height="716" alt="image" src="https://github.com/user-attachments/assets/cbb4aea8-50b0-43d7-a7b0-1ecbe5f079e7" />