### PR TITLE
fix(playback): size the alsa buffer and survive underruns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Playback no longer falls silent on PipeWire systems with a large graph quantum, such as a
+  default Arch Linux install. The audio stream now keeps 50 ms of buffer regardless of the
+  quantum, and a recovered underrun no longer restarts the player.
+
 ## [0.30.0] - 2026-09-04
 
 ### Added

--- a/crates/music/src/audio.rs
+++ b/crates/music/src/audio.rs
@@ -11,6 +11,7 @@ use rodio::{DeviceSinkBuilder, MixerDeviceSink, Source};
 use crate::spectrum::{Spectrum, Tap};
 
 pub const RAMP: Duration = Duration::from_millis(25);
+const BUFFER: Duration = Duration::from_millis(50);
 
 #[derive(Clone)]
 pub struct Volume(Arc<AtomicU32>);
@@ -58,15 +59,20 @@ impl Output {
         );
 
         let format = default.sample_format();
+        let frames = (BUFFER.as_secs_f64() * default.sample_rate() as f64).round() as u32;
         let failed = Arc::new(AtomicBool::new(false));
         let stream_failed = failed.clone();
         let builder = DeviceSinkBuilder::default()
             .with_device(device)
             .with_config(&default.config())
+            .with_buffer_size(cpal::BufferSize::Fixed(frames))
             .with_sample_format(format)
-            .with_error_callback(move |error| {
-                log::warn!("sink: audio output failed: {error}");
-                stream_failed.store(true, Ordering::Release);
+            .with_error_callback(move |error| match error {
+                cpal::StreamError::BufferUnderrun => log::debug!("sink: buffer underrun"),
+                error => {
+                    log::warn!("sink: audio output failed: {error}");
+                    stream_failed.store(true, Ordering::Release);
+                }
             });
         let mut stream = builder
             .open_stream()


### PR DESCRIPTION
## Summary

- request a fixed 50 ms alsa buffer so pipewire-alsa keeps playing at any graph quantum
- treat a recovered buffer underrun as a debug log instead of a dead output, so playback no longer restarts on every xrun