### PR TITLE
fix(playback): open a shuffled context on a random track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Playback no longer falls silent on PipeWire systems with a large graph quantum, such as a
   default Arch Linux install. The audio stream now keeps 50 ms of buffer regardless of the
   quantum, and a recovered underrun no longer restarts the player.
+- Pressing play on an album, playlist or artist with shuffle on now opens with a random track
+  instead of always the first one.
 
 ## [0.30.0] - 2026-09-04
 

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -470,6 +470,29 @@ impl Playback {
         self.begin(tracks, index, origin, cx);
     }
 
+    pub fn start_any(
+        &mut self,
+        tracks: Vec<Track>,
+        origin: Option<Origin>,
+        cx: &mut Context<Self>,
+    ) {
+        let index = self.opener(&tracks, cx).unwrap_or_default();
+        self.start(tracks, index, origin, cx);
+    }
+
+    fn opener(&self, tracks: &[Track], cx: &Context<Self>) -> Option<usize> {
+        let playable = tracks
+            .iter()
+            .enumerate()
+            .filter(|(_, track)| track.playable)
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        match self.queue.read(cx).shuffle() {
+            true => fastrand::choice(&playable).copied(),
+            false => playable.first().copied(),
+        }
+    }
+
     pub fn play_radio(&mut self, seed: &Track, cx: &mut Context<Self>) {
         let Some(id) = seed.id.clone() else {
             return self.failed(format!("{} has no track id", seed.name), cx);
@@ -778,7 +801,10 @@ impl Playback {
             let loaded = join(io.spawn(async move { tracks(client).await })).await;
 
             this.update(cx, |this, cx| match loaded {
-                Ok(tracks) => this.begin(tracks, 0, Some(origin), cx),
+                Ok(tracks) => {
+                    let index = this.opener(&tracks, cx).unwrap_or_default();
+                    this.begin(tracks, index, Some(origin), cx)
+                }
                 Err(error) if this.has_active_playback() => {
                     log::error!("playback: cannot load context: {error:#}");
                 }

--- a/crates/views/src/shared/hero.rs
+++ b/crates/views/src/shared/hero.rs
@@ -173,7 +173,6 @@ impl HeroPlayButton {
 
 impl RenderOnce for HeroPlayButton {
     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
-        let first_playable = self.listing.first(cx);
         let state = {
             let playback = self.playback.read(cx);
             let current = playback.track().and_then(|track| track.id.as_deref());
@@ -187,8 +186,7 @@ impl RenderOnce for HeroPlayButton {
             Some(PlaybackState::Loading) => (t!("play-loading"), "icons/play.svg", true),
             _ => (self.label, "icons/play.svg", false),
         };
-        let disabled = first_playable.is_none() || blocked;
-        let first_playable = first_playable.unwrap_or_default();
+        let disabled = self.listing.first(cx).is_none() || blocked;
         let listing = self.listing;
         let from = self.from;
         let playback = self.playback;
@@ -207,7 +205,7 @@ impl RenderOnce for HeroPlayButton {
                         _ => {
                             let queued = listing.queue(cx);
                             let from = from.clone().or_else(|| listing.whence(cx));
-                            playback.start(queued, first_playable, from, cx)
+                            playback.start_any(queued, from, cx)
                         }
                     });
                 }),


### PR DESCRIPTION
## Summary

- pick a random playable track when play is pressed on an album, playlist or artist with shuffle on
- keep the first playable track as the opener when shuffle is off

Fixes #371