### PR TITLE
fix(local): avoid duplicate cover art for tracks in the same folder

### DIFF
--- a/crates/music/src/local/wire.rs
+++ b/crates/music/src/local/wire.rs
@@ -3,7 +3,7 @@ use std::hash::{Hash, Hasher};
 use std::path::Path;
 
 use lofty::file::{AudioFile, TaggedFileExt};
-use lofty::picture::{MimeType, Picture};
+use lofty::picture::{MimeType, Picture, PictureType};
 use lofty::prelude::Accessor;
 use lofty::probe::Probe;
 use lofty::tag::Tag;
@@ -199,23 +199,24 @@ fn extract_cover(
     album_dir: Option<&Path>,
     cache_dir: &Path,
 ) -> Option<String> {
-    if let Some(cover) = path
-        .parent()
-        .and_then(folder_cover)
-        .or_else(|| album_dir.and_then(folder_cover))
-    {
-        return Some(cover);
-    }
-
-    if let Some(picture) = tag.and_then(|tag| tag.pictures().first())
-        && let Some(cached) = cache_picture(picture, path, cache_dir)
+    let picture = tag.and_then(|tag| {
+        tag.pictures()
+            .iter()
+            .find(|picture| picture.pic_type() == PictureType::CoverFront)
+            .or_else(|| tag.pictures().first())
+    });
+    if let Some(picture) = picture
+        && let Some(cached) = cache_picture(picture, cache_dir)
     {
         return Some(cached);
     }
-    None
+
+    path.parent()
+        .and_then(folder_cover)
+        .or_else(|| album_dir.and_then(folder_cover))
 }
 
-fn cache_picture(picture: &Picture, source: &Path, cache_dir: &Path) -> Option<String> {
+fn cache_picture(picture: &Picture, cache_dir: &Path) -> Option<String> {
     let extension = match picture.mime_type() {
         Some(MimeType::Png) => "png",
         Some(MimeType::Gif) => "gif",
@@ -225,7 +226,7 @@ fn cache_picture(picture: &Picture, source: &Path, cache_dir: &Path) -> Option<S
     };
 
     let mut hasher = DefaultHasher::new();
-    source.parent()?.hash(&mut hasher);
+    picture.data().hash(&mut hasher);
     let hash = hasher.finish();
 
     let dir = cache_dir.join("local-covers");


### PR DESCRIPTION
Fixes #400 

## Summary

Fixes a bug where local songs in the same folder all displayed the cover art of whichever file was scanned first.

## Changes

- Hash the actual picture bytes instead of the parent directory path when caching embedded covers
- Look for embedded tag pictures before falling back to folder art
- Prefer the front cover picture when a file contains multiple tagged images

## Testing

- Scanned a local library folder containing songs from different albums and verified each gets its own cover
- Confirmed tracks sharing identical album art still deduplicate to a single cached file
- Verified `cargo check --workspace` and `cargo fmt --check` pass cleanly

| Before | After |
|:----:|:----:|
|  <img width="1342" height="531" alt="image" src="https://github.com/user-attachments/assets/156a5eb6-1c8a-4fac-9c62-218f4fb827a2" /> | <img width="795" height="542" alt="image" src="https://github.com/user-attachments/assets/284e881c-bcef-44f2-9f79-d81e72915369" />|