### PR TITLE
feat(music): add youtube captions as a lyrics fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- YouTube tracks with no lyrics anywhere now fall back to the video's own subtitles, timed line by
+  line, in the language Sonora is set to whenever the video offers one. They stand in only when no
+  lyrics source answered, and being subtitles they carry whatever is said, dialogue included.
+
 ## [0.30.0] - 2026-09-04
 
 ### Added

--- a/crates/music/examples/captions-prober.rs
+++ b/crates/music/examples/captions-prober.rs
@@ -1,0 +1,186 @@
+use anyhow::{Context as _, Result, bail};
+use serde_json::Value;
+use ytmusic::{Client, YtMusic};
+
+const CLIENTS: [(&str, Client); 3] = [
+    ("WEB_REMIX", Client::Music),
+    ("TVHTML5", Client::Tv),
+    ("VISIONOS", Client::VisionOs),
+];
+const LISTED: usize = 8;
+
+struct Caption {
+    language: String,
+    name: String,
+    generated: bool,
+    url: String,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<()> {
+    let Some(link) = std::env::args().nth(1) else {
+        bail!("usage: captions-prober <youtube link or video id> [language]");
+    };
+    let id = video_id(&link).context("cannot read a video id out of that link")?;
+    let language = std::env::args().nth(2);
+    let api = YtMusic::anonymous();
+    let http = reqwest::Client::new();
+
+    println!("video {id}");
+    for (label, client) in CLIENTS {
+        println!();
+        println!("{label}");
+        let found = match captions(&api, &id, client).await {
+            Ok(found) => found,
+            Err(error) => {
+                println!("  no player response: {error:#}");
+                continue;
+            }
+        };
+        if found.is_empty() {
+            println!("  no caption track");
+            continue;
+        }
+        for caption in &found {
+            println!(
+                "  {:<8} {:<28} {}",
+                caption.language,
+                caption.name,
+                match caption.generated {
+                    true => "generated",
+                    false => "authored",
+                }
+            );
+        }
+        let pick = found
+            .iter()
+            .find(|caption| {
+                !caption.generated
+                    && language
+                        .as_deref()
+                        .is_none_or(|wanted| caption.language == wanted)
+            })
+            .or_else(|| found.first());
+        if let Some(caption) = pick {
+            dump(&http, caption).await;
+        }
+    }
+
+    Ok(())
+}
+
+async fn captions(api: &YtMusic, id: &str, client: Client) -> Result<Vec<Caption>> {
+    let response = api.player_response(id, client).await?;
+    let Some(tracks) = response
+        .pointer("/captions/playerCaptionsTracklistRenderer/captionTracks")
+        .and_then(Value::as_array)
+    else {
+        return Ok(Vec::new());
+    };
+    Ok(tracks.iter().filter_map(caption).collect())
+}
+
+fn caption(found: &Value) -> Option<Caption> {
+    Some(Caption {
+        language: found.get("languageCode")?.as_str()?.to_owned(),
+        name: found
+            .pointer("/name/runs/0/text")
+            .or_else(|| found.pointer("/name/simpleText"))
+            .and_then(Value::as_str)
+            .unwrap_or("unnamed")
+            .to_owned(),
+        generated: found.get("kind").and_then(Value::as_str) == Some("asr"),
+        url: found.get("baseUrl")?.as_str()?.to_owned(),
+    })
+}
+
+async fn dump(http: &reqwest::Client, caption: &Caption) {
+    match fetch(http, caption).await {
+        Ok(events) => show(&events),
+        Err(error) => println!("  {} did not come back: {error:#}", caption.language),
+    }
+}
+
+async fn fetch(http: &reqwest::Client, caption: &Caption) -> Result<Vec<Value>> {
+    let body = http
+        .get(format!("{}&fmt=json3", caption.url))
+        .send()
+        .await
+        .context("cannot reach the timed text endpoint")?
+        .error_for_status()
+        .context("the timed text endpoint refused")?
+        .text()
+        .await
+        .context("cannot read the timed text body")?;
+    if body.trim().is_empty() {
+        bail!("empty body, the endpoint served nothing");
+    }
+    let parsed: Value = serde_json::from_str(&body).context("cannot parse the timed text body")?;
+    Ok(parsed
+        .get("events")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default())
+}
+
+fn show(events: &[Value]) {
+    let lines: Vec<(u64, String, bool)> = events.iter().filter_map(line).collect();
+    let Some((last, _, _)) = lines.last() else {
+        println!("  no timed line in the track");
+        return;
+    };
+    let worded = lines.iter().filter(|(_, _, worded)| *worded).count();
+    println!(
+        "  {} lines, {worded} word timed, up to {}",
+        lines.len(),
+        clock(*last)
+    );
+    for (at, text, _) in lines.iter().take(LISTED) {
+        println!("    [{}] {text}", clock(*at));
+    }
+}
+
+fn line(event: &Value) -> Option<(u64, String, bool)> {
+    let at = event.get("tStartMs")?.as_u64()?;
+    let segs = event.get("segs")?.as_array()?;
+    let text: String = segs
+        .iter()
+        .filter_map(|seg| seg.get("utf8").and_then(Value::as_str))
+        .collect();
+    let text = text.trim().to_owned();
+    if text.is_empty() {
+        return None;
+    }
+    let worded = segs
+        .iter()
+        .filter(|seg| seg.get("tOffsetMs").is_some())
+        .count()
+        > 1;
+    Some((at, text, worded))
+}
+
+fn video_id(link: &str) -> Option<String> {
+    if let Some(rest) = link.split("youtu.be/").nth(1) {
+        return Some(cut(rest));
+    }
+    if link.contains("youtube.com") {
+        return link.split("v=").nth(1).map(cut);
+    }
+    let bare = link.len() == 11
+        && link
+            .chars()
+            .all(|glyph| glyph.is_ascii_alphanumeric() || glyph == '-' || glyph == '_');
+    bare.then(|| link.to_owned())
+}
+
+fn cut(rest: &str) -> String {
+    rest.split(['?', '&', '/', '#'])
+        .next()
+        .unwrap_or(rest)
+        .to_owned()
+}
+
+fn clock(ms: u64) -> String {
+    let seconds = ms / 1000;
+    format!("{}:{:02}", seconds / 60, seconds % 60)
+}

--- a/crates/music/examples/lyrics-prober.rs
+++ b/crates/music/examples/lyrics-prober.rs
@@ -5,8 +5,8 @@ use anyhow::{Context as _, Result, bail};
 use music::spotify::{AuthConfig, LibrespotClient, auth};
 use music::youtube::YouTubeClient;
 use music::{
-    Lyrics, LyricsHit, LyricsProvider, LyricsQuery, MusicApi, Track, TrackKey, binimum, kugou,
-    lrclib, musixmatch, netease,
+    Lyrics, LyricsHit, LyricsProvider, LyricsQuery, MusicApi, Track, TrackKey, binimum, captions,
+    kugou, lrclib, musixmatch, netease,
 };
 use ytmusic::YtMusic;
 
@@ -28,13 +28,14 @@ fn providers() -> Vec<Arc<dyn LyricsProvider>> {
         Arc::new(lrclib::LrcLib::new()),
         Arc::new(kugou::Kugou::new()),
         Arc::new(netease::NetEase::new()),
+        Arc::new(captions::Captions::new()),
     ]
 }
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
     let Some(link) = std::env::args().nth(1) else {
-        bail!("usage: lyrics-prober <spotify or youtube link, or a search query>");
+        bail!("usage: lyrics-prober <spotify or youtube link, or a search query> [language]");
     };
 
     let (track, provider, native) = resolve(&link).await?;
@@ -44,6 +45,7 @@ async fn main() -> Result<()> {
         album: (!track.album.is_empty()).then(|| track.album.clone()),
         duration: track.duration,
         track: track.id.clone().map(|id| TrackKey { provider, id }),
+        language: std::env::args().nth(2),
     };
 
     println!(
@@ -64,7 +66,7 @@ async fn main() -> Result<()> {
     probes.sort_by_key(|probe| probe.elapsed);
 
     println!(
-        "{:<12} {:>6} {:>5}  {:>6} {:>4} {:<8} matched title / artist",
+        "{:<16} {:>6} {:>5}  {:>6} {:>5} {:<8} matched title / artist",
         "provider", "ms", "hits", "score", "keep", "kind"
     );
     for found in &probes {
@@ -89,7 +91,7 @@ async fn main() -> Result<()> {
             println!("ranked:");
             for (place, hit) in ranked.iter().enumerate() {
                 println!(
-                    "  {:>2}. {:<12} {:>6} {:<8} {}",
+                    "  {:>2}. {:<16} {:>6} {:<8} {}",
                     place + 1,
                     hit.source,
                     music::lyrics::score(&query, hit),
@@ -201,11 +203,11 @@ async fn probe(query: &LyricsQuery, native: Option<Arc<LibrespotClient>>) -> Vec
 fn report(query: &LyricsQuery, found: &Probe) {
     let millis = found.elapsed.as_millis();
     if let Some(error) = &found.error {
-        println!("{:<12} {millis:>6} {:>5}  {error}", found.source, "—");
+        println!("{:<16} {millis:>6} {:>5}  {error}", found.source, "—");
         return;
     }
     if found.hits.is_empty() {
-        println!("{:<12} {millis:>6} {:>5}", found.source, 0);
+        println!("{:<16} {millis:>6} {:>5}", found.source, 0);
         return;
     }
 
@@ -218,14 +220,15 @@ fn report(query: &LyricsQuery, found: &Probe) {
 
     for (place, (score, hit)) in scored.iter().take(LISTED).enumerate() {
         let head = match place {
-            0 => format!("{:<12} {millis:>6} {:>5}", found.source, found.hits.len()),
-            _ => format!("{:<12} {:>6} {:>5}", "", "", ""),
+            0 => format!("{:<16} {millis:>6} {:>5}", found.source, found.hits.len()),
+            _ => format!("{:<16} {:>6} {:>5}", "", "", ""),
         };
         println!(
-            "{head}  {score:>6} {:>4} {:<8} {} — {}{}",
-            match music::lyrics::eligible(query, hit) {
-                true => "yes",
-                false => "no",
+            "{head}  {score:>6} {:>5} {:<8} {} — {}{}",
+            match (music::lyrics::eligible(query, hit), hit.fallback) {
+                (false, _) => "no",
+                (true, true) => "spare",
+                (true, false) => "yes",
             },
             kind(&hit.lyrics),
             hit.title,
@@ -236,7 +239,7 @@ fn report(query: &LyricsQuery, found: &Probe) {
         );
     }
     if let Some(rest) = scored.len().checked_sub(LISTED).filter(|rest| *rest > 0) {
-        println!("{:<12} {:>6} {:>5}  {rest:>6} more", "", "", "");
+        println!("{:<16} {:>6} {:>5}  {rest:>6} more", "", "", "");
     }
 }
 
@@ -246,6 +249,7 @@ fn own(lyrics: Lyrics, query: &LyricsQuery) -> LyricsHit {
         trust: OWN_TRUST,
         lyrics,
         instrumental: false,
+        fallback: false,
         title: query.title.clone(),
         artist: query.artist.clone(),
         album: query.album.clone(),

--- a/crates/music/examples/lyrics_bench.rs
+++ b/crates/music/examples/lyrics_bench.rs
@@ -135,6 +135,7 @@ async fn measure(
             provider: "spotify",
             id: id.clone(),
         }),
+        language: None,
     };
 
     let mut tasks = tokio::task::JoinSet::new();
@@ -216,6 +217,7 @@ fn own(lyrics: Lyrics, query: &LyricsQuery) -> LyricsHit {
         trust: OWN_TRUST,
         lyrics,
         instrumental: false,
+        fallback: false,
         title: query.title.clone(),
         artist: query.artist.clone(),
         album: query.album.clone(),

--- a/crates/music/examples/lyrics_voices.rs
+++ b/crates/music/examples/lyrics_voices.rs
@@ -43,6 +43,7 @@ async fn main() {
             album: (!album.is_empty()).then(|| album.to_owned()),
             duration: Duration::from_secs(seconds),
             track: None,
+            language: None,
         };
         println!("\n== {title} — {artist}");
         let mut gathered = Vec::new();

--- a/crates/music/src/binimum/mod.rs
+++ b/crates/music/src/binimum/mod.rs
@@ -144,6 +144,7 @@ impl LyricsProvider for Binimum {
             trust: TRUST,
             lyrics: sheet.lyrics,
             instrumental: false,
+            fallback: false,
             title: best.track_name.clone(),
             artist: best.artist_name.clone(),
             album: (!best.album_name.is_empty()).then(|| best.album_name.clone()),

--- a/crates/music/src/captions/mod.rs
+++ b/crates/music/src/captions/mod.rs
@@ -1,0 +1,190 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context as _, Result, bail};
+use async_trait::async_trait;
+use serde_json::Value;
+use ytmusic::{Client, YtMusic};
+
+use crate::lyrics::lrc;
+use crate::{Lyrics, LyricsHit, LyricsLine, LyricsProvider, LyricsQuery, Voice};
+
+const SOURCE: &str = "YouTube Captions";
+const PROVIDER: &str = "youtube";
+const CLIENT: Client = Client::VisionOs;
+const TRUST: u32 = 0;
+const ASR: &str = "asr";
+const TRACKS: &str = "/captions/playerCaptionsTracklistRenderer/captionTracks";
+const AUDIO: &str = "/captions/playerCaptionsTracklistRenderer/audioTracks";
+const SPOKEN: &str = "/captions/playerCaptionsTracklistRenderer/defaultAudioTrackIndex";
+
+pub struct Captions {
+    api: Arc<YtMusic>,
+    http: reqwest::Client,
+}
+
+struct Written {
+    generated: bool,
+    language: String,
+    url: String,
+}
+
+impl Captions {
+    pub fn new() -> Self {
+        Self {
+            api: Arc::new(YtMusic::anonymous()),
+            http: reqwest::Client::new(),
+        }
+    }
+
+    async fn read(&self, written: &Written) -> Result<Vec<LyricsLine>> {
+        let body = self
+            .http
+            .get(format!("{}&fmt=json3", written.url))
+            .send()
+            .await
+            .context("cannot reach the timed text endpoint")?
+            .error_for_status()
+            .context("the timed text endpoint refused")?
+            .text()
+            .await
+            .context("cannot read the timed text body")?;
+        if body.trim().is_empty() {
+            bail!("the timed text endpoint served nothing");
+        }
+        let timed: Value = serde_json::from_str(&body).context("cannot parse the timed text")?;
+        let mut lines: Vec<LyricsLine> = timed
+            .get("events")
+            .and_then(Value::as_array)
+            .map(|events| events.iter().filter_map(line).collect())
+            .unwrap_or_default();
+        lrc::normalize(&mut lines);
+        Ok(lines)
+    }
+}
+
+impl Default for Captions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl LyricsProvider for Captions {
+    fn name(&self) -> &'static str {
+        SOURCE
+    }
+
+    async fn search(&self, query: &LyricsQuery) -> Result<Vec<LyricsHit>> {
+        let Some(id) = query.id_for(PROVIDER) else {
+            return Ok(Vec::new());
+        };
+        let response = self
+            .api
+            .player_response(id, CLIENT)
+            .await
+            .context("cannot ask for the player response")?;
+        let Some(written) = pick(&response, query.language.as_deref()) else {
+            return Ok(Vec::new());
+        };
+        let lines = self.read(&written).await?;
+        if lines.is_empty() {
+            return Ok(Vec::new());
+        }
+        Ok(vec![LyricsHit {
+            source: SOURCE,
+            trust: TRUST,
+            lyrics: Lyrics::Synced {
+                lines: lines.into(),
+            },
+            instrumental: false,
+            fallback: true,
+            title: query.title.clone(),
+            artist: query.artist.clone(),
+            album: query.album.clone(),
+            duration: (!query.duration.is_zero()).then_some(query.duration),
+            writers: Vec::new(),
+        }])
+    }
+}
+
+fn pick(response: &Value, language: Option<&str>) -> Option<Written> {
+    let found: Vec<Written> = response
+        .pointer(TRACKS)?
+        .as_array()?
+        .iter()
+        .filter_map(written)
+        .collect();
+    let authored = |written: &Written| !written.generated;
+    let read = |written: &Written| language.is_some_and(|wanted| alike(&written.language, wanted));
+    let index = found
+        .iter()
+        .position(|written| authored(written) && read(written))
+        .or_else(|| spoken(response).filter(|index| found.get(*index).is_some_and(authored)))
+        .or_else(|| found.iter().position(authored))
+        .or_else(|| found.iter().position(read))
+        .unwrap_or_default();
+    found.into_iter().nth(index)
+}
+
+fn alike(code: &str, language: &str) -> bool {
+    primary(code).eq_ignore_ascii_case(primary(language))
+}
+
+fn primary(tag: &str) -> &str {
+    tag.split(['-', '_']).next().unwrap_or(tag)
+}
+
+fn spoken(response: &Value) -> Option<usize> {
+    let chosen = response
+        .pointer(SPOKEN)
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    response
+        .pointer(AUDIO)?
+        .as_array()?
+        .get(chosen as usize)?
+        .get("defaultCaptionTrackIndex")?
+        .as_u64()
+        .map(|index| index as usize)
+}
+
+fn written(found: &Value) -> Option<Written> {
+    Some(Written {
+        generated: found.get("kind").and_then(Value::as_str) == Some(ASR),
+        language: found
+            .get("languageCode")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_owned(),
+        url: found.get("baseUrl")?.as_str()?.to_owned(),
+    })
+}
+
+fn line(event: &Value) -> Option<LyricsLine> {
+    let start = event.get("tStartMs")?.as_u64()?;
+    let text = event
+        .get("segs")?
+        .as_array()?
+        .iter()
+        .filter_map(|seg| seg.get("utf8").and_then(Value::as_str))
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<&str>>()
+        .join(" ");
+    if text.is_empty() {
+        return None;
+    }
+    Some(LyricsLine {
+        start: Duration::from_millis(start),
+        end: event
+            .get("dDurationMs")
+            .and_then(Value::as_u64)
+            .map(|span| Duration::from_millis(start + span)),
+        text,
+        romanized: None,
+        words: None,
+        secondary: Vec::new(),
+        voice: Voice::Lead,
+    })
+}

--- a/crates/music/src/kugou/mod.rs
+++ b/crates/music/src/kugou/mod.rs
@@ -281,6 +281,7 @@ fn hit(song: &Song, krc: &str, title: &str) -> Option<LyricsHit> {
             },
         },
         instrumental: quiet,
+        fallback: false,
         title: song.name.clone(),
         artist: song.singer.clone(),
         album: (!song.album.is_empty()).then(|| song.album.clone()),

--- a/crates/music/src/lib.rs
+++ b/crates/music/src/lib.rs
@@ -1,5 +1,6 @@
 mod audio;
 pub mod binimum;
+pub mod captions;
 pub mod kugou;
 #[cfg(test)]
 mod live_tests;

--- a/crates/music/src/lrclib/mod.rs
+++ b/crates/music/src/lrclib/mod.rs
@@ -137,6 +137,7 @@ fn hit(found: Found) -> Option<LyricsHit> {
         trust: 0,
         lyrics,
         instrumental: found.instrumental,
+        fallback: false,
         title: found.track_name.unwrap_or_default(),
         artist: found.artist_name.unwrap_or_default(),
         album: found.album_name.filter(|name| !name.is_empty()),

--- a/crates/music/src/lyrics/mod.rs
+++ b/crates/music/src/lyrics/mod.rs
@@ -22,9 +22,13 @@ const TRUNCATED: u32 = 500;
 const TRUSTED: u32 = 25;
 
 pub fn rank(query: &LyricsQuery, hits: Vec<LyricsHit>) -> Vec<LyricsHit> {
-    let mut scored: Vec<(i64, LyricsHit)> = hits
+    let declared = instrumental(query, &hits);
+    let kept = hits
         .into_iter()
         .filter(|hit| eligible(query, hit))
+        .collect();
+    let mut scored: Vec<(i64, LyricsHit)> = preferred(kept, declared)
+        .into_iter()
         .map(|hit| (score(query, &hit), hit))
         .collect();
     scored.sort_by(|(left_score, left), (right_score, right)| {
@@ -40,6 +44,13 @@ pub fn rank(query: &LyricsQuery, hits: Vec<LyricsHit>) -> Vec<LyricsHit> {
         .map(|(_, hit)| hit)
         .filter(|hit| seen.insert(fingerprint(&hit.lyrics)))
         .collect()
+}
+
+fn preferred(hits: Vec<LyricsHit>, instrumental: bool) -> Vec<LyricsHit> {
+    match instrumental || hits.iter().any(|hit| !hit.fallback) {
+        true => hits.into_iter().filter(|hit| !hit.fallback).collect(),
+        false => hits,
+    }
 }
 
 pub fn reshape(hits: &mut [LyricsHit]) {
@@ -75,7 +86,8 @@ pub fn eligible(query: &LyricsQuery, hit: &LyricsHit) -> bool {
 
 pub fn instrumental(query: &LyricsQuery, hits: &[LyricsHit]) -> bool {
     let matching = || hits.iter().filter(|hit| matched(query, hit));
-    matching().any(|hit| hit.instrumental) && !matching().any(|hit| !hit.lyrics.is_empty())
+    matching().any(|hit| hit.instrumental)
+        && !matching().any(|hit| !hit.fallback && !hit.lyrics.is_empty())
 }
 
 fn matched(query: &LyricsQuery, hit: &LyricsHit) -> bool {
@@ -267,6 +279,7 @@ mod tests {
                 false => Lyrics::plain(format!("la {title}")),
             },
             instrumental: false,
+            fallback: false,
             title: title.to_owned(),
             artist: artist.to_owned(),
             album: None,
@@ -294,6 +307,7 @@ mod tests {
             album: None,
             duration: Duration::from_secs(263),
             track: None,
+            language: None,
         }
     }
 
@@ -375,6 +389,7 @@ mod tests {
             album: Some("In Waves".to_owned()),
             duration: Duration::from_secs(302),
             track: None,
+            language: None,
         };
         let ranked = rank(&query, vec![noisy, hit("In Waves", "Trivium", 302, true)]);
 
@@ -402,6 +417,7 @@ mod tests {
             album: Some("Nautical Antiques".to_owned()),
             duration: Duration::from_secs(213),
             track: None,
+            language: None,
         };
 
         let ranked = rank(

--- a/crates/music/src/models.rs
+++ b/crates/music/src/models.rs
@@ -390,6 +390,7 @@ pub struct LyricsQuery {
     pub album: Option<String>,
     pub duration: Duration,
     pub track: Option<TrackKey>,
+    pub language: Option<String>,
 }
 
 impl LyricsQuery {
@@ -407,6 +408,7 @@ pub struct LyricsHit {
     pub trust: u32,
     pub lyrics: Lyrics,
     pub instrumental: bool,
+    pub fallback: bool,
     pub title: String,
     pub artist: String,
     pub album: Option<String>,

--- a/crates/music/src/musixmatch/mod.rs
+++ b/crates/music/src/musixmatch/mod.rs
@@ -212,6 +212,7 @@ fn hit(calls: &Calls) -> Option<LyricsHit> {
             },
         },
         instrumental: quiet,
+        fallback: false,
         title: track.track_name.clone(),
         artist: track.artist_name.clone(),
         album: (!track.album_name.is_empty()).then(|| track.album_name.clone()),

--- a/crates/music/src/netease/mod.rs
+++ b/crates/music/src/netease/mod.rs
@@ -210,6 +210,7 @@ fn hit(song: &Song, sheet: &Sheet) -> Option<LyricsHit> {
         trust: 0,
         lyrics,
         instrumental: quiet,
+        fallback: false,
         title: song.name.clone(),
         artist: song
             .artists

--- a/crates/sonora/src/main.rs
+++ b/crates/sonora/src/main.rs
@@ -74,6 +74,7 @@ fn main() {
             Arc::new(music::lrclib::LrcLib::new()),
             Arc::new(music::kugou::Kugou::new()),
             Arc::new(music::netease::NetEase::new()),
+            Arc::new(music::captions::Captions::new()),
         ];
         state::init(cx, io, providers, local_provider, lyrics);
         let start = opened_start.unwrap_or_else(|| {

--- a/crates/state/src/lyrics.rs
+++ b/crates/state/src/lyrics.rs
@@ -518,6 +518,7 @@ fn query_for(track: &Track, key: Option<TrackKey>) -> LyricsQuery {
         album: (!track.album.is_empty()).then(|| track.album.clone()),
         duration: track.duration,
         track: key,
+        language: Some(i18n::language().id().to_owned()),
     }
 }
 
@@ -565,6 +566,7 @@ async fn own(native: Native, query: LyricsQuery) -> Vec<LyricsHit> {
         trust: OWN_TRUST,
         lyrics,
         instrumental: false,
+        fallback: false,
         title: query.title,
         artist: query.artist,
         album: query.album,
@@ -587,6 +589,7 @@ mod tests {
             trust: 0,
             lyrics,
             instrumental: false,
+            fallback: false,
             title: "title".to_owned(),
             artist: "artist".to_owned(),
             album: None,

--- a/crates/state/src/sheets.rs
+++ b/crates/state/src/sheets.rs
@@ -34,6 +34,8 @@ struct Held {
     lyrics: Sheet,
     #[serde(default)]
     instrumental: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    fallback: bool,
     #[serde(default)]
     title: String,
     #[serde(default)]
@@ -191,6 +193,7 @@ impl Held {
             trust: hit.trust,
             lyrics: hit.lyrics.clone(),
             instrumental: hit.instrumental,
+            fallback: hit.fallback,
             title: hit.title.clone(),
             artist: hit.artist.clone(),
             album: hit.album.clone(),
@@ -206,6 +209,7 @@ impl Held {
             trust: self.trust,
             lyrics: self.lyrics.clone(),
             instrumental: self.instrumental,
+            fallback: self.fallback,
             title: self.title.clone(),
             artist: self.artist.clone(),
             album: self.album.clone(),


### PR DESCRIPTION
- add a youtube captions lyrics provider, timed line by line from the video's own subtitle track
- prefer the caption track in the app's language, then the spoken one, then any authored one
- add a \allback\ flag to lyrics hits so captions are dropped whenever a real lyrics source answers
- keep a track marked instrumental instrumental, rather than standing in with its dialogue captions
- carry the active language on the lyrics query so a language change is followed
- add a captions prober example and teach the lyrics prober the new provider