### PR TITLE
feat(nix): add home manager module

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,26 @@ Every release also attaches a standalone `.flatpak` bundle for x86_64 and aarch6
 
 ### Nix
 
-Just use the flake in the project root:
+The flake packages the latest tagged release and exposes `programs.sonora` for Home Manager.
 
-```sh
-inputs.sonora.packages.${system}.default
+```nix
+inputs.sonora.url = "github:nolight132/sonora";
 ```
 
-The flake installs the latest tagged release binary.
+Home Manager:
+
+```nix
+{
+  imports = [ inputs.sonora.homeManagerModules.default ];
+  programs.sonora = {
+    enable = true;
+    settings = {
+      provider = "youtube";
+      appearance.theme = "dark";
+    };
+  };
+}
+```
 
 ### Windows
 

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,14 @@
 
           asset = release.assets.${pkgs.stdenv.hostPlatform.system};
 
+          alsaPluginDirectory = pkgs.symlinkJoin {
+            name = "sonora-alsa-plugins";
+            paths = [
+              "${pkgs.pipewire}/lib/alsa-lib"
+              "${pkgs.alsa-plugins}/lib/alsa-lib"
+            ];
+          };
+
           sonora-bin = pkgs.stdenv.mkDerivation {
             pname = "sonora-bin";
             inherit (release) version;
@@ -81,6 +89,8 @@
 
             dontUnpack = true;
             dontStrip = true;
+
+            nativeBuildInputs = [ pkgs.makeWrapper ];
 
             installPhase = ''
               runHook preInstall
@@ -113,6 +123,8 @@
                 --set-interpreter "${pkgs.stdenv.cc.bintools.dynamicLinker}" \
                 --add-rpath "${pkgs.lib.makeLibraryPath (runtimeLibraries ++ [ pkgs.stdenv.cc.cc.lib ])}" \
                 "$out/bin/sonora"
+              wrapProgram "$out/bin/sonora" \
+                --set ALSA_PLUGIN_DIR ${alsaPluginDirectory}
             '';
 
             meta = {

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
 
   outputs =
     {
+      self,
       nixpkgs,
       rust-overlay,
       ...
@@ -183,5 +184,16 @@
           };
         }
       );
+
+      overlays.default = final: _prev: {
+        sonora = self.packages.${final.stdenv.hostPlatform.system}.default;
+      };
+
+      homeManagerModules = {
+        default = import ./nix/modules/hm-module.nix self;
+        sonora = import ./nix/modules/hm-module.nix self;
+      };
+
+      homeModules = self.homeManagerModules;
     };
 }

--- a/nix/modules/hm-module.nix
+++ b/nix/modules/hm-module.nix
@@ -1,0 +1,6 @@
+self:
+{ pkgs, lib, ... }:
+{
+  imports = [ ./hm/sonora.nix ];
+  programs.sonora.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+}

--- a/nix/modules/hm/sonora.nix
+++ b/nix/modules/hm/sonora.nix
@@ -24,18 +24,24 @@ let
     '';
   };
   merge = "${lib.getExe apply} ${generated}";
-  package =
-    if cfg.settings == { } then
-      cfg.package
-    else
-      pkgs.symlinkJoin {
-        name = "sonora";
-        paths = [ cfg.package ];
-        nativeBuildInputs = [ pkgs.makeWrapper ];
-        postBuild = ''
-          wrapProgram $out/bin/sonora --run ${lib.escapeShellArg merge}
-        '';
-      };
+  alsaPluginDir = pkgs.symlinkJoin {
+    name = "sonora-alsa-plugins";
+    paths = [
+      "${pkgs.pipewire}/lib/alsa-lib"
+      "${pkgs.alsa-plugins}/lib/alsa-lib"
+    ];
+  };
+  package = pkgs.symlinkJoin {
+    name = "sonora";
+    paths = [ cfg.package ];
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+    postBuild = ''
+      rm -f $out/bin/sonora
+      makeWrapper ${lib.getExe cfg.package} $out/bin/sonora \
+        --set ALSA_PLUGIN_DIR ${alsaPluginDir} \
+        ${lib.optionalString (cfg.settings != { }) "--run ${lib.escapeShellArg merge}"}
+    '';
+  };
 in
 {
   options.programs.sonora = {

--- a/nix/modules/hm/sonora.nix
+++ b/nix/modules/hm/sonora.nix
@@ -1,0 +1,77 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.sonora;
+  json = pkgs.formats.json { };
+  generated = json.generate "sonora-settings.json" ({ version = 1; } // cfg.settings);
+  apply = pkgs.writeShellApplication {
+    name = "sonora-apply-settings";
+    runtimeInputs = [ pkgs.jq ];
+    text = ''
+      generated=$1
+      dest="''${XDG_CONFIG_HOME:-$HOME/.config}/sonora/settings.json"
+      mkdir -p "$(dirname "$dest")"
+      if [[ -f "$dest" ]]; then
+        jq --indent 2 -s '.[0] * .[1]' "$dest" "$generated" > "$dest.tmp"
+        mv "$dest.tmp" "$dest"
+      else
+        cp "$generated" "$dest"
+      fi
+    '';
+  };
+  merge = "${lib.getExe apply} ${generated}";
+  package =
+    if cfg.settings == { } then
+      cfg.package
+    else
+      pkgs.symlinkJoin {
+        name = "sonora";
+        paths = [ cfg.package ];
+        nativeBuildInputs = [ pkgs.makeWrapper ];
+        postBuild = ''
+          wrapProgram $out/bin/sonora --run ${lib.escapeShellArg merge}
+        '';
+      };
+in
+{
+  options.programs.sonora = {
+    enable = lib.mkEnableOption "Sonora, a native music streaming client";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+    };
+
+    settings = lib.mkOption {
+      type = json.type;
+      default = { };
+      example = {
+        provider = "youtube";
+        gapless = true;
+        appearance = {
+          theme = "dark";
+          icons = "solar";
+        };
+      };
+      description = ''
+        Configuration written to {file}`$XDG_CONFIG_HOME/sonora/settings.json`.
+        Same JSON keys as the app. Set keys are merged on switch and again each
+        launch; omitted keys, including resume and window bounds, are kept.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ package ];
+
+    # write nix keys on switch; the wrapper merges them again on each launch
+    home.activation.sonoraSettings = lib.mkIf (cfg.settings != { }) (
+      lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        $DRY_RUN_CMD ${merge}
+      ''
+    );
+  };
+}


### PR DESCRIPTION
## Changes

now it possible to configure sonora using nix,  any changes that are made through the settings section in sonora will be applied only for the current session the next time the app is launched it will use the settings set with nix.

```nix
{ inputs, ... }:

{
  imports = [
    inputs.sonora.homeManagerModules.default
  ];

  programs.sonora = {
    enable = true;

    settings = {
      provider = "youtube";
      gapless = true;
      check_updates = false;
      hidden_nav = [ "history" ];

      appearance = {
        theme = "dark";
        adaptive_theme = true;
        icons = "solar";
        rounding = "rounded";
        font_size = 14;
      };
    };
  };
}

```

as soon as the PR to [nixpkgs](https://github.com/NixOS/nixpkgs/pull/559258) will be merge i will also make a PR to [home-manager](https://github.com/nix-community/home-manager) so there wont be a need for

```nix
imports = [
    inputs.sonora.homeManagerModules.default
];
```

Closes #377 