### PR TITLE
i18n(pl): add missing tray, menu, settings, confirm  translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,18 +142,18 @@ AI-assisted proofreading and translation of human-written text are permitted.
 
 <!-- i18n:start -->
 
-| Language                     | Translated | Coverage |
-| ---------------------------- | ---------- | -------- |
-| English (`en-US`)            | 514/514    | 100%     |
-| Deutsch (`de`)               | 485/514    | 94%      |
-| Español (`es`)               | 500/514    | 97%      |
-| Français (`fr`)              | 479/514    | 93%      |
-| Italiano (`it`)              | 479/514    | 93%      |
-| 日本語 (`ja`)                | 500/514    | 97%      |
-| Русский (`ru`)               | 486/514    | 95%      |
-| Українська (`uk`)            | 486/514    | 95%      |
-| Polski (`pl`)                | 487/514    | 95%      |
-| Português (Brasil) (`pt-BR`) | 500/514    | 97%      |
+| Language | Translated | Coverage |
+| --- | --- | --- |
+| English (`en-US`) | 517/517 | 100% |
+| Deutsch (`de`) | 485/517 | 94% |
+| Español (`es`) | 500/517 | 97% |
+| Français (`fr`) | 479/517 | 93% |
+| Italiano (`it`) | 479/517 | 93% |
+| 日本語 (`ja`) | 500/517 | 97% |
+| Русский (`ru`) | 486/517 | 94% |
+| Українська (`uk`) | 486/517 | 94% |
+| Polski (`pl`) | 517/517 | 100% |
+| Português (Brasil) (`pt-BR`) | 500/517 | 97% |
 
 <!-- i18n:end -->
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ us quickly locate the relevant parts of the code.
 **However**, using AI cannot act as an excuse for failing to
 understand, review, and test the changes proposed. Furthermore, we expect communication
 with a real person, not a computer. This includes but is not limited to PR/issue text
-generation, comments in discussions, etc. A short summary of minor changes can be 
+generation, comments in discussions, etc. A short summary of minor changes can be
 generated and does not need to be disclosed explicitly, but the reasoning and motivation
 behind a change must come from the contributor and reflect their own understanding.
 
@@ -142,18 +142,18 @@ AI-assisted proofreading and translation of human-written text are permitted.
 
 <!-- i18n:start -->
 
-| Language | Translated | Coverage |
-| --- | --- | --- |
-| English (`en-US`) | 517/517 | 100% |
-| Deutsch (`de`) | 485/517 | 94% |
-| Español (`es`) | 500/517 | 97% |
-| Français (`fr`) | 479/517 | 93% |
-| Italiano (`it`) | 479/517 | 93% |
-| 日本語 (`ja`) | 500/517 | 97% |
-| Русский (`ru`) | 486/517 | 94% |
-| Українська (`uk`) | 486/517 | 94% |
-| Polski (`pl`) | 517/517 | 100% |
-| Português (Brasil) (`pt-BR`) | 500/517 | 97% |
+| Language                     | Translated | Coverage |
+| ---------------------------- | ---------- | -------- |
+| English (`en-US`)            | 517/517    | 100%     |
+| Deutsch (`de`)               | 485/517    | 94%      |
+| Español (`es`)               | 500/517    | 97%      |
+| Français (`fr`)              | 479/517    | 93%      |
+| Italiano (`it`)              | 479/517    | 93%      |
+| 日本語 (`ja`)                 | 500/517    | 97%      |
+| Русский (`ru`)               | 486/517    | 94%      |
+| Українська (`uk`)            | 486/517    | 94%      |
+| Polski (`pl`)                | 517/517    | 100%     |
+| Português (Brasil) (`pt-BR`) | 500/517    | 97%      |
 
 <!-- i18n:end -->
 

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -58,6 +58,11 @@ app-refresh-library = Odśwież bibliotekę
 app-sign-out = Wyloguj się
 app-quit = Zakończ
 
+# tray menu
+tray-show = Pokaż Sonorę
+tray-play = Odtwarzaj
+tray-pause = Wstrzymaj
+
 # table columns
 column-played-at = Odtworzono
 column-index = #
@@ -76,20 +81,61 @@ column-tracks = Utwory
 
 # track menu
 menu-add-to-playlist = Dodaj do playlisty
+menu-add-tracks-to-playlist = { $count ->
+    [one] Dodaj { $count } utwór do playlisty
+    [few] Dodaj { $count } utwory do playlisty
+   *[other] Dodaj { $count } utworów do playlisty
+}
 menu-new-playlist = Nowa playlista
 menu-edit-tags = Edytuj tagi
 menu-no-playlists = Brak playlist
 menu-add-to-library = Dodaj do ulubionych
+menu-add-tracks-to-library = { $count ->
+    [one] Dodaj { $count } utwór do ulubionych
+    [few] Dodaj { $count } utwory do ulubionych
+   *[other] Dodaj { $count } utworów do ulubionych
+}
 menu-remove-from-library = Usuń z ulubionych
+menu-remove-tracks-from-library = { $count ->
+    [one] Usuń { $count } utwór z ulubionych
+    [few] Usuń { $count } utwory z ulubionych
+   *[other] Usuń { $count } utworów z ulubionych
+}
+
 menu-remove-from-playlist = Usuń z playlisty
+menu-remove-tracks-from-playlist = { $count ->
+    [one] Usuń { $count } utwór z playlisty
+    [few] Usuń { $count } utwory z playlisty
+   *[other] Usuń { $count } utworów z playlisty
+}
+
 menu-remove-from-history = Usuń z historii
+menu-remove-tracks-from-history = { $count ->
+    [one] Usuń { $count } utwór z historii
+    [few] Usuń { $count } utwory z historii
+   *[other] Usuń { $count } utworów z historii
+}
 menu-play-next = Odtwórz jako następny
+menu-play-tracks-next = { $count ->
+    [one] Odtwórz { $count } utwór jako następny
+    [few] Odtwórz { $count } utwory jako następne
+   *[other] Odtwórz { $count } utworów jako następne
+}
 menu-add-to-queue = Dodaj do kolejki
+menu-add-tracks-to-queue = { $count ->
+    [one] Dodaj { $count } utwór do kolejki
+    [few] Dodaj { $count } utwory do kolejki
+   *[other] Dodaj { $count } utworów do kolejki
+}
 menu-song-radio = Radio utworu
 menu-go-to-album = Przejdź do albumu
 menu-go-to-artist = Przejdź do wykonawcy
 menu-view-details = Szczegóły
 menu-copy-link = Kopiuj link
+menu-cut = Wytnij
+menu-copy = Kopiuj
+menu-paste = Wklej
+menu-select-all = Zaznacz wszystko
 menu-remove-from-queue = Usuń z kolejki
 menu-open-playlist = Otwórz playlistę
 menu-play-playlist = Odtwórz playlistę
@@ -112,6 +158,41 @@ playlist-delete-confirm = Usunąć „{ $name }”? Tej operacji nie można cofn
 playlist-again-title = Dodać ponownie?
 playlist-again-confirm = Ten utwór jest już w „{ $name }”. Dodać kopię?
 playlist-again-add = Dodaj ponownie
+
+# confirm
+confirm-remove-library-title = Usuń z biblioteki
+confirm-remove-playlist-title = Usuń z playlisty
+confirm-remove-history-title = Usuń z historii
+confirm-unfollow-title = Przestań obserwować
+confirm-remove-songs = { $count ->
+    [one] Usunąć ten utwór z biblioteki?
+    [few] Usunąć { $count } utwory z biblioteki?
+   *[other] Usunąć { $count } utworów z biblioteki?
+}
+confirm-remove-playlist-songs = { $count ->
+    [one] Usunąć ten utwór z playlisty?
+    [few] Usunąć { $count } utwory z playlisty?
+   *[other] Usunąć { $count } utworów z playlisty?
+}
+confirm-remove-history-songs = { $count ->
+    [one] Usunąć ten utwór z historii odtwarzania?
+    [few] Usunąć { $count } utwory z historii odtwarzania?
+   *[other] Usunąć { $count } utworów z historii odtwarzania?
+}
+confirm-remove-albums = { $count ->
+    [one] Usunąć ten album z biblioteki?
+    [few] Usunąć { $count } albumy z biblioteki?
+   *[other] Usunąć { $count } albumów z biblioteki?
+}
+confirm-unfollow-artists = { $count ->
+    [one] Przestać obserwować tego artystę?
+   *[other] Przestać obserwować { $count } artystów?
+}
+confirm-remove-playlists = { $count ->
+    [one] Usunąć tę playlistę z biblioteki?
+    [few] Usunąć { $count } playlisty z biblioteki?
+   *[other] Usunąć { $count } playlist z biblioteki?
+}
 
 # queue panel
 queue-title = Kolejka
@@ -419,6 +500,8 @@ settings-window-controls = Przyciski okna
 settings-window-controls-detail = Rysuj minimalizację, maksymalizację i zamknięcie na pasku tytułu
 settings-controls-side = Strona przycisków
 settings-controls-side-detail = Po której stronie paska tytułu znajdują się przyciski
+settings-close-to-tray = Kontynuuj odtwarzanie po zamknięciu
+settings-close-to-tray-detail = Pozostaw Sonorę w zasobniku systemowym i kontynuuj odtwarzanie po zamknięciu okna
 settings-normalisation = Normalizacja głośności
 settings-normalisation-detail = Utrzymuje stałą głośność utworów
 settings-gapless = Odtwarzanie bez przerw
@@ -443,6 +526,7 @@ settings-romanization-greek = Pismo greckie
 settings-romanization-arabic = Pismo arabskie
 settings-romanization-other = Inne systemy pisma
 settings-advanced = Zaawansowane
+settings-group-window = Okno
 settings-group-accounts = Konta
 settings-group-library = Biblioteka
 settings-group-text = Tekst


### PR DESCRIPTION
**Description:**  
Adds missing Polish strings for the system tray, pluralized context menu actions, confirmation dialogs, and the close-to-tray setting, updated README with the i18n-coverage script.