### PR TITLE
fix(playback): resolve silent audio on rapid track switching

### DIFF
--- a/crates/music/src/audio.rs
+++ b/crates/music/src/audio.rs
@@ -111,7 +111,7 @@ impl Output {
         cpal::default_host()
             .default_output_device()
             .map(|device| ident(&device))
-            .is_none_or(|device| device != self.device)
+            .is_some_and(|device| device != "unknown" && device != self.device)
     }
 }
 

--- a/crates/music/src/lib.rs
+++ b/crates/music/src/lib.rs
@@ -161,18 +161,52 @@ pub struct PlaybackConfig {
     pub gain: f32,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum PlaybackEvent {
-    Loading(Duration),
-    Playing(Duration),
-    Paused(Duration),
-    Position(Duration),
-    Length(Duration),
-    Ended,
-    Unavailable,
+    Loading {
+        id: Option<String>,
+        at: Duration,
+    },
+    Playing {
+        id: Option<String>,
+        at: Duration,
+    },
+    Paused {
+        id: Option<String>,
+        at: Duration,
+    },
+    Position {
+        id: Option<String>,
+        at: Duration,
+    },
+    Length {
+        id: Option<String>,
+        duration: Duration,
+    },
+    Ended {
+        id: Option<String>,
+    },
+    Unavailable {
+        id: Option<String>,
+    },
     Refused,
     Gated,
     OutputChanged,
+}
+
+impl PlaybackEvent {
+    pub fn id(&self) -> Option<&str> {
+        match self {
+            Self::Loading { id, .. }
+            | Self::Playing { id, .. }
+            | Self::Paused { id, .. }
+            | Self::Position { id, .. }
+            | Self::Length { id, .. }
+            | Self::Ended { id, .. }
+            | Self::Unavailable { id, .. } => id.as_deref(),
+            _ => None,
+        }
+    }
 }
 
 pub trait Player: Send + Sync {
@@ -185,7 +219,7 @@ pub trait Player: Send + Sync {
         Ok(())
     }
 
-    fn preload(&self, track_id: &str) -> Result<()>;
+    fn preload(&self, track_id: &str, segue: bool) -> Result<()>;
     fn play(&self);
     fn pause(&self);
     fn seek(&self, position: Duration);

--- a/crates/music/src/local/playback.rs
+++ b/crates/music/src/local/playback.rs
@@ -20,6 +20,7 @@ enum Command {
     },
     Preload {
         id: String,
+        segue: bool,
     },
     Play,
     Pause,
@@ -75,10 +76,11 @@ impl Player for Engine {
             .context("cannot reach local playback engine")
     }
 
-    fn preload(&self, track_id: &str) -> Result<()> {
+    fn preload(&self, track_id: &str, segue: bool) -> Result<()> {
         self.commands
             .send(Command::Preload {
                 id: track_id.to_owned(),
+                segue,
             })
             .context("cannot reach local playback engine")
     }
@@ -177,12 +179,21 @@ async fn engine_loop(
                             playing = true;
                             sink.play();
                             if let Some(length) = current.as_ref().and_then(|slot| slot.length) {
-                                events.send(PlaybackEvent::Length(length)).ok();
+                                events.send(PlaybackEvent::Length {
+                                    id: Some(id.clone()),
+                                    duration: length,
+                                }).ok();
                             }
-                            events.send(PlaybackEvent::Playing(sink.get_pos())).ok();
+                            events.send(PlaybackEvent::Playing {
+                                id: Some(id),
+                                at: sink.get_pos(),
+                            }).ok();
                             continue;
                         }
-                        events.send(PlaybackEvent::Loading(at.unwrap_or_default())).ok();
+                        events.send(PlaybackEvent::Loading {
+                            id: Some(id.clone()),
+                            at: at.unwrap_or_default(),
+                        }).ok();
                         sink.clear();
                         current = None;
                         queued = None;
@@ -195,7 +206,10 @@ async fn engine_loop(
                                     None => sink.play(),
                                 }
                                 if let Some(length) = slot.length {
-                                    events.send(PlaybackEvent::Length(length)).ok();
+                                    events.send(PlaybackEvent::Length {
+                                        id: Some(id.clone()),
+                                        duration: length,
+                                    }).ok();
                                 }
                                 prev_len = sink.len();
                                 current = Some(slot);
@@ -203,18 +217,27 @@ async fn engine_loop(
                                 let position = at.unwrap_or_default();
                                 events
                                     .send(match playing {
-                                        true => PlaybackEvent::Playing(position),
-                                        false => PlaybackEvent::Paused(position),
+                                        true => PlaybackEvent::Playing {
+                                            id: Some(id),
+                                            at: position,
+                                        },
+                                        false => PlaybackEvent::Paused {
+                                            id: Some(id),
+                                            at: position,
+                                        },
                                     })
                                     .ok();
                             }
                             Err(error) => {
                                 log::warn!("playback: cannot load {id}: {error:#}");
-                                events.send(PlaybackEvent::Unavailable).ok();
+                                events.send(PlaybackEvent::Unavailable { id: Some(id) }).ok();
                             }
                         }
                     }
-                    Command::Preload { id } => {
+                    Command::Preload { id, segue } => {
+                        if !segue {
+                            continue;
+                        }
                         let known = current.as_ref().is_some_and(|slot| slot.id == id);
                         if known || current.is_none() || queued.is_some() {
                             continue;
@@ -232,24 +255,35 @@ async fn engine_loop(
                             events.send(PlaybackEvent::OutputChanged).ok();
                             return;
                         }
-                        if current.is_some() {
+                        if let Some(slot) = &current {
                             sink.play();
                             playing = true;
-                            events.send(PlaybackEvent::Playing(sink.get_pos())).ok();
+                            events.send(PlaybackEvent::Playing {
+                                id: Some(slot.id.clone()),
+                                at: sink.get_pos(),
+                            }).ok();
                         }
                     }
                     Command::Pause => {
                         playing = false;
                         let position = sink.get_pos();
                         sink.pause();
-                        events.send(PlaybackEvent::Paused(position)).ok();
+                        if let Some(slot) = &current {
+                            events.send(PlaybackEvent::Paused {
+                                id: Some(slot.id.clone()),
+                                at: position,
+                            }).ok();
+                        }
                     }
                     Command::Seek(position) => {
-                        if current.is_some() {
+                        if let Some(slot) = &current {
                             if let Err(error) = sink.try_seek(position) {
                                 log::warn!("playback: cannot seek: {error}");
                             }
-                            events.send(PlaybackEvent::Position(sink.get_pos())).ok();
+                            events.send(PlaybackEvent::Position {
+                                id: Some(slot.id.clone()),
+                                at: sink.get_pos(),
+                            }).ok();
                         }
                     }
                     Command::Gain(level) => output.set_volume(level),
@@ -268,18 +302,31 @@ async fn engine_loop(
                 ticks += 1;
                 if current.is_some() && playing && len < prev_len {
                     ticks = 0;
-                    events.send(PlaybackEvent::Ended).ok();
+                    if let Some(slot) = &current {
+                        events.send(PlaybackEvent::Ended { id: Some(slot.id.clone()) }).ok();
+                    }
                     current = queued.take();
                     playing = current.is_some();
                     if let Some(slot) = &current {
                         if let Some(length) = slot.length {
-                            events.send(PlaybackEvent::Length(length)).ok();
+                            events.send(PlaybackEvent::Length {
+                                id: Some(slot.id.clone()),
+                                duration: length,
+                            }).ok();
                         }
-                        events.send(PlaybackEvent::Position(sink.get_pos())).ok();
+                        events.send(PlaybackEvent::Position {
+                            id: Some(slot.id.clone()),
+                            at: sink.get_pos(),
+                        }).ok();
                     }
                 } else if playing && ticks >= report_every {
                     ticks = 0;
-                    events.send(PlaybackEvent::Position(sink.get_pos())).ok();
+                    if let Some(slot) = &current {
+                        events.send(PlaybackEvent::Position {
+                            id: Some(slot.id.clone()),
+                            at: sink.get_pos(),
+                        }).ok();
+                    }
                 }
                 prev_len = len;
             }

--- a/crates/music/src/spotify/playback.rs
+++ b/crates/music/src/spotify/playback.rs
@@ -155,7 +155,7 @@ impl MusicPlayer for Engine {
         self.load_paused_at(track_id, at)
     }
 
-    fn preload(&self, track_id: &str) -> Result<()> {
+    fn preload(&self, track_id: &str, _segue: bool) -> Result<()> {
         self.preload(track_id)
     }
 
@@ -187,22 +187,54 @@ fn track_uri(track_id: &str) -> Result<SpotifyUri> {
 
 fn translate(event: PlayerEvent) -> Option<PlaybackEvent> {
     let millis = |position_ms: u32| Duration::from_millis(position_ms as u64);
+    let track_id = |uri: SpotifyUri| uri.to_id().ok();
 
     match event {
-        PlayerEvent::Loading { position_ms, .. } => {
-            Some(PlaybackEvent::Loading(millis(position_ms)))
+        PlayerEvent::Loading {
+            track_id: uri,
+            position_ms,
+            ..
+        } => Some(PlaybackEvent::Loading {
+            id: track_id(uri),
+            at: millis(position_ms),
+        }),
+        PlayerEvent::Playing {
+            track_id: uri,
+            position_ms,
+            ..
+        } => Some(PlaybackEvent::Playing {
+            id: track_id(uri),
+            at: millis(position_ms),
+        }),
+        PlayerEvent::Paused {
+            track_id: uri,
+            position_ms,
+            ..
+        } => Some(PlaybackEvent::Paused {
+            id: track_id(uri),
+            at: millis(position_ms),
+        }),
+        PlayerEvent::PositionChanged {
+            track_id: uri,
+            position_ms,
+            ..
         }
-        PlayerEvent::Playing { position_ms, .. } => {
-            Some(PlaybackEvent::Playing(millis(position_ms)))
+        | PlayerEvent::PositionCorrection {
+            track_id: uri,
+            position_ms,
+            ..
+        } => Some(PlaybackEvent::Position {
+            id: track_id(uri),
+            at: millis(position_ms),
+        }),
+        PlayerEvent::Stopped { track_id: uri, .. }
+        | PlayerEvent::EndOfTrack { track_id: uri, .. } => {
+            Some(PlaybackEvent::Ended { id: track_id(uri) })
         }
-        PlayerEvent::Paused { position_ms, .. } => Some(PlaybackEvent::Paused(millis(position_ms))),
-        PlayerEvent::PositionChanged { position_ms, .. }
-        | PlayerEvent::PositionCorrection { position_ms, .. } => {
-            Some(PlaybackEvent::Position(millis(position_ms)))
-        }
-        PlayerEvent::Stopped { .. } | PlayerEvent::EndOfTrack { .. } => Some(PlaybackEvent::Ended),
         PlayerEvent::Unavailable { denied: true, .. } => Some(PlaybackEvent::Refused),
-        PlayerEvent::Unavailable { .. } => Some(PlaybackEvent::Unavailable),
+        PlayerEvent::Unavailable { track_id: uri, .. } => {
+            Some(PlaybackEvent::Unavailable { id: track_id(uri) })
+        }
         _ => None,
     }
 }

--- a/crates/music/src/youtube/playback.rs
+++ b/crates/music/src/youtube/playback.rs
@@ -380,25 +380,29 @@ async fn engine_loop(
             }
             arrival = arrivals.recv() => {
                 let Some(Fetched { epoch: at, id, kind, result }) = arrival else { break };
-                if preloading.as_ref().is_some_and(|(p_id, _)| p_id == &id) {
+                let promoted = matches!(&kind, Kind::Ahead { .. })
+                    && pending == Some(epoch)
+                    && current.is_none()
+                    && preloading
+                        .as_ref()
+                        .is_some_and(|(preloaded_id, _)| preloaded_id == &id);
+                if preloading
+                    .as_ref()
+                    .is_some_and(|(preloaded_id, _)| preloaded_id == &id)
+                {
                     preloading = None;
                 }
-                let target = match kind {
-                    Kind::Play if at == epoch && pending == Some(epoch) => true,
-                    _ if pending == Some(epoch) && current.is_none() && ahead.as_ref().is_some_and(|(p_id, _)| p_id == &id) => true,
-                    _ => false,
+                let target = match &kind {
+                    Kind::Play => at == epoch && pending == Some(epoch),
+                    Kind::Ahead { .. } => promoted,
                 };
                 if target {
                     pending = None;
                     inflight = None;
                     let at = hold.take();
-                    let loaded = match kind {
-                        Kind::Play => result,
-                        Kind::Ahead { .. } => ahead.take().map(|(_, l)| l).context("missing preloaded audio"),
-                    };
-                    match loaded
-                        .and_then(|loaded| begin(&sink, &id, &loaded, &config, autostart, at))
-                    {
+                    match result.and_then(|loaded| {
+                        begin(&sink, &id, &loaded, &config, autostart, at)
+                    }) {
                         Ok(slot) => {
                             announce(&events, &slot, autostart, at.unwrap_or_default());
                             prev_len = sink.len();

--- a/crates/music/src/youtube/playback.rs
+++ b/crates/music/src/youtube/playback.rs
@@ -16,8 +16,15 @@ const NORMAL_CAP: f32 = 1.0;
 const POLL: Duration = Duration::from_millis(20);
 
 enum Command {
-    Load { id: String, at: Option<Duration> },
-    Preload { id: String },
+    Load {
+        id: String,
+        at: Option<Duration>,
+        seamless: bool,
+    },
+    Preload {
+        id: String,
+        segue: bool,
+    },
     Play,
     Pause,
     Seek(Duration),
@@ -60,11 +67,12 @@ struct Engine {
 }
 
 impl Player for Engine {
-    fn load(&self, track_id: &str, _seamless: bool) -> Result<()> {
+    fn load(&self, track_id: &str, seamless: bool) -> Result<()> {
         self.commands
             .send(Command::Load {
                 id: track_id.to_string(),
                 at: None,
+                seamless,
             })
             .context("cannot reach playback engine")
     }
@@ -74,14 +82,16 @@ impl Player for Engine {
             .send(Command::Load {
                 id: track_id.to_string(),
                 at: Some(at),
+                seamless: false,
             })
             .context("cannot reach playback engine")
     }
 
-    fn preload(&self, track_id: &str) -> Result<()> {
+    fn preload(&self, track_id: &str, segue: bool) -> Result<()> {
         self.commands
             .send(Command::Preload {
                 id: track_id.to_string(),
+                segue,
             })
             .context("cannot reach playback engine")
     }
@@ -142,7 +152,7 @@ impl Slot {
 
 enum Kind {
     Play,
-    Ahead,
+    Ahead { segue: bool },
 }
 
 struct Fetched {
@@ -202,6 +212,7 @@ async fn engine_loop(
     let mut epoch = 0u64;
     let mut pending: Option<u64> = None;
     let mut inflight: Option<tokio::task::AbortHandle> = None;
+    let mut preloading: Option<(String, tokio::task::AbortHandle)> = None;
     let mut current: Option<Slot> = None;
     let mut queued: Option<Slot> = None;
     let mut ahead: Option<(String, Loaded)> = None;
@@ -212,18 +223,24 @@ async fn engine_loop(
             command = commands.recv() => {
                 let Some(command) = command else { break };
                 match command {
-                    Command::Load { id, at } => {
-                        if at.is_none() && current.as_ref().is_some_and(|slot| slot.id == id) {
+                    Command::Load { id, at, seamless } => {
+                        if seamless && at.is_none() && current.as_ref().is_some_and(|slot| slot.id == id) {
                             playing = true;
                             autostart = true;
                             if let Some(slot) = &current {
                                 slot.unmute();
                                 if let Some(length) = slot.length {
-                                    events.send(PlaybackEvent::Length(length)).ok();
+                                    events.send(PlaybackEvent::Length {
+                                        id: Some(id.clone()),
+                                        duration: length,
+                                    }).ok();
                                 }
                             }
                             sink.play();
-                            events.send(PlaybackEvent::Playing(sink.get_pos())).ok();
+                            events.send(PlaybackEvent::Playing {
+                                id: Some(id),
+                                at: sink.get_pos(),
+                            }).ok();
                             continue;
                         }
                         epoch += 1;
@@ -236,11 +253,21 @@ async fn engine_loop(
                         pending = None;
                         if cached.is_none() {
                             ahead = None;
-                            pending = Some(epoch);
-                            inflight =
-                                Some(spawn(&api, id.clone(), epoch, Kind::Play, &fetched));
+                            if preloading.as_ref().is_some_and(|(p_id, _)| p_id == &id) {
+                                pending = Some(epoch);
+                            } else {
+                                if let Some((_, handle)) = preloading.take() {
+                                    handle.abort();
+                                }
+                                pending = Some(epoch);
+                                inflight =
+                                    Some(spawn(&api, id.clone(), epoch, Kind::Play, &fetched));
+                            }
                         }
-                        events.send(PlaybackEvent::Loading(at.unwrap_or_default())).ok();
+                        events.send(PlaybackEvent::Loading {
+                            id: Some(id.clone()),
+                            at: at.unwrap_or_default(),
+                        }).ok();
                         if output.failed() || output.changed() {
                             events.send(PlaybackEvent::OutputChanged).ok();
                             return;
@@ -262,18 +289,43 @@ async fn engine_loop(
                             }
                             Err(error) => {
                                 log::warn!("playback: cannot decode {id}: {error:#}");
-                                events.send(PlaybackEvent::Unavailable).ok();
+                                events.send(PlaybackEvent::Unavailable { id: Some(id) }).ok();
                             }
                         }
                     }
-                    Command::Preload { id } => {
+                    Command::Preload { id, segue } => {
                         let known = current.as_ref().is_some_and(|slot| slot.id == id)
-                            || queued.as_ref().is_some_and(|slot| slot.id == id)
+                            || (segue && queued.as_ref().is_some_and(|slot| slot.id == id))
                             || ahead.as_ref().is_some_and(|(cached, _)| *cached == id);
-                        if known || current.is_none() {
+                        if known {
                             continue;
                         }
-                        spawn(&api, id, epoch, Kind::Ahead, &fetched);
+                        if segue && current.is_none() {
+                            continue;
+                        }
+                        if let Some((_, loaded)) = ahead.as_ref().filter(|(cached, _)| *cached == id) {
+                            if segue && current.is_some() && queued.is_none() {
+                                match append(&sink, &id, loaded, &config, false) {
+                                    Ok(slot) => {
+                                        log::debug!("playback: {id} is queued for a gapless segue");
+                                        queued = Some(slot);
+                                        prev_len = sink.len();
+                                    }
+                                    Err(error) => {
+                                        log::warn!("playback: cannot decode preload {id}: {error:#}");
+                                    }
+                                }
+                            }
+                            continue;
+                        }
+                        if preloading.as_ref().is_some_and(|(p_id, _)| p_id == &id) {
+                            continue;
+                        }
+                        if let Some((_, handle)) = preloading.take() {
+                            handle.abort();
+                        }
+                        let handle = spawn(&api, id.clone(), epoch, Kind::Ahead { segue }, &fetched);
+                        preloading = Some((id, handle));
                     }
                     Command::Play => {
                         autostart = true;
@@ -285,7 +337,10 @@ async fn engine_loop(
                             sink.play();
                             slot.unmute();
                             playing = true;
-                            events.send(PlaybackEvent::Playing(sink.get_pos())).ok();
+                            events.send(PlaybackEvent::Playing {
+                                id: Some(slot.id.clone()),
+                                at: sink.get_pos(),
+                            }).ok();
                         }
                     }
                     Command::Pause => {
@@ -296,8 +351,11 @@ async fn engine_loop(
                             slot.mute();
                             await_drain(&sink).await;
                             sink.pause();
+                            events.send(PlaybackEvent::Paused {
+                                id: Some(slot.id.clone()),
+                                at: position,
+                            }).ok();
                         }
-                        events.send(PlaybackEvent::Paused(position)).ok();
                     }
                     Command::Seek(position) => match &current {
                         None if hold.is_some() => hold = Some(position),
@@ -311,7 +369,10 @@ async fn engine_loop(
                             if playing {
                                 slot.unmute();
                             }
-                            events.send(PlaybackEvent::Position(sink.get_pos())).ok();
+                            events.send(PlaybackEvent::Position {
+                                id: Some(slot.id.clone()),
+                                at: sink.get_pos(),
+                            }).ok();
                         }
                     },
                     Command::Gain(level) => output.set_volume(level),
@@ -319,50 +380,55 @@ async fn engine_loop(
             }
             arrival = arrivals.recv() => {
                 let Some(Fetched { epoch: at, id, kind, result }) = arrival else { break };
-                if at != epoch {
+                if preloading.as_ref().is_some_and(|(p_id, _)| p_id == &id) {
+                    preloading = None;
+                }
+                let target = match kind {
+                    Kind::Play if at == epoch && pending == Some(epoch) => true,
+                    _ if pending == Some(epoch) && current.is_none() && ahead.as_ref().is_some_and(|(p_id, _)| p_id == &id) => true,
+                    _ => false,
+                };
+                if target {
+                    pending = None;
+                    inflight = None;
+                    let at = hold.take();
+                    let loaded = match kind {
+                        Kind::Play => result,
+                        Kind::Ahead { .. } => ahead.take().map(|(_, l)| l).context("missing preloaded audio"),
+                    };
+                    match loaded
+                        .and_then(|loaded| begin(&sink, &id, &loaded, &config, autostart, at))
+                    {
+                        Ok(slot) => {
+                            announce(&events, &slot, autostart, at.unwrap_or_default());
+                            prev_len = sink.len();
+                            current = Some(slot);
+                            playing = autostart;
+                        }
+                        Err(error) => {
+                            log::warn!("playback: cannot load {id}: {error:#}");
+                            events.send(refusal(id, &error)).ok();
+                        }
+                    }
                     continue;
                 }
-                match kind {
-                    Kind::Play => {
-                        if pending != Some(at) {
-                            continue;
-                        }
-                        pending = None;
-                        inflight = None;
-                        let at = hold.take();
-                        match result
-                            .and_then(|loaded| begin(&sink, &id, &loaded, &config, autostart, at))
-                        {
+                if let Kind::Ahead { segue } = kind {
+                    let Ok(loaded) = result else {
+                        continue;
+                    };
+                    if segue && current.is_some() && queued.is_none() {
+                        match append(&sink, &id, &loaded, &config, false) {
                             Ok(slot) => {
-                                announce(&events, &slot, autostart, at.unwrap_or_default());
+                                log::debug!("playback: {id} is queued for a gapless segue");
+                                queued = Some(slot);
                                 prev_len = sink.len();
-                                current = Some(slot);
-                                playing = autostart;
                             }
                             Err(error) => {
-                                log::warn!("playback: cannot load {id}: {error:#}");
-                                events.send(refusal(&error)).ok();
+                                log::warn!("playback: cannot decode preload {id}: {error:#}")
                             }
                         }
                     }
-                    Kind::Ahead => {
-                        let Ok(loaded) = result else {
-                            continue;
-                        };
-                        if current.is_some() && queued.is_none() {
-                            match append(&sink, &id, &loaded, &config, false) {
-                                Ok(slot) => {
-                                    log::debug!("playback: {id} is queued for a gapless segue");
-                                    queued = Some(slot);
-                                    prev_len = sink.len();
-                                }
-                                Err(error) => {
-                                    log::warn!("playback: cannot decode preload {id}: {error:#}")
-                                }
-                            }
-                        }
-                        ahead = Some((id, loaded));
-                    }
+                    ahead = Some((id, loaded));
                 }
             }
             _ = ticker.tick() => {
@@ -378,22 +444,35 @@ async fn engine_loop(
                 ticks += 1;
                 if current.is_some() && playing && len < prev_len {
                     ticks = 0;
-                    events.send(PlaybackEvent::Ended).ok();
+                    if let Some(slot) = &current {
+                        events.send(PlaybackEvent::Ended { id: Some(slot.id.clone()) }).ok();
+                    }
                     current = queued.take();
                     ahead = None;
                     playing = current.is_some();
                     match &current {
                         Some(slot) => {
                             if let Some(length) = slot.length {
-                                events.send(PlaybackEvent::Length(length)).ok();
+                                events.send(PlaybackEvent::Length {
+                                    id: Some(slot.id.clone()),
+                                    duration: length,
+                                }).ok();
                             }
-                            events.send(PlaybackEvent::Position(sink.get_pos())).ok();
+                            events.send(PlaybackEvent::Position {
+                                id: Some(slot.id.clone()),
+                                at: sink.get_pos(),
+                            }).ok();
                         }
                         None => log::debug!("playback: track ended with nothing queued ahead"),
                     }
                 } else if playing && ticks >= report_every {
                     ticks = 0;
-                    events.send(PlaybackEvent::Position(sink.get_pos())).ok();
+                    if let Some(slot) = &current {
+                        events.send(PlaybackEvent::Position {
+                            id: Some(slot.id.clone()),
+                            at: sink.get_pos(),
+                        }).ok();
+                    }
                 }
                 prev_len = len;
             }
@@ -426,12 +505,11 @@ fn spawn(
 
 async fn silence(sink: &rodio::Player, slot: Option<&Slot>) {
     let Some(slot) = slot else {
-        sink.clear();
         return;
     };
     slot.mute();
     await_drain(sink).await;
-    sink.clear();
+    sink.pause();
 }
 
 async fn await_drain(sink: &rodio::Player) {
@@ -449,7 +527,9 @@ fn begin(
     start: bool,
     at: Option<Duration>,
 ) -> Result<Slot> {
-    sink.clear();
+    if sink.len() > 0 {
+        sink.clear();
+    }
     let slot = append(sink, id, loaded, config, true)?;
     if let Some(at) = at
         && let Err(error) = sink.try_seek(at)
@@ -507,19 +587,30 @@ fn announce(
     position: Duration,
 ) {
     if let Some(length) = slot.length {
-        events.send(PlaybackEvent::Length(length)).ok();
+        events
+            .send(PlaybackEvent::Length {
+                id: Some(slot.id.clone()),
+                duration: length,
+            })
+            .ok();
     }
     let event = match playing {
-        true => PlaybackEvent::Playing(position),
-        false => PlaybackEvent::Paused(position),
+        true => PlaybackEvent::Playing {
+            id: Some(slot.id.clone()),
+            at: position,
+        },
+        false => PlaybackEvent::Paused {
+            id: Some(slot.id.clone()),
+            at: position,
+        },
     };
     events.send(event).ok();
 }
 
-fn refusal(error: &anyhow::Error) -> PlaybackEvent {
+fn refusal(id: String, error: &anyhow::Error) -> PlaybackEvent {
     match error.downcast_ref::<ytmusic::SignInRequired>().is_some() {
         true => PlaybackEvent::Gated,
-        false => PlaybackEvent::Unavailable,
+        false => PlaybackEvent::Unavailable { id: Some(id) },
     }
 }
 

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -389,6 +389,10 @@ impl Playback {
     }
 
     pub fn preload(&mut self, track: &Track) {
+        self.preload_internal(track, false);
+    }
+
+    fn preload_internal(&mut self, track: &Track, segue: bool) {
         let Some(id) = track.id.as_deref() else {
             return;
         };
@@ -406,7 +410,7 @@ impl Playback {
         let Some(engine) = self.engine_for(id) else {
             return;
         };
-        if let Err(error) = engine.preload(id) {
+        if let Err(error) = engine.preload(id, segue) {
             self.preloaded = None;
             log::warn!("playback: cannot preload {}: {error:#}", track.name);
         }
@@ -852,7 +856,7 @@ impl Playback {
             return;
         };
 
-        self.preload(&next);
+        self.preload_internal(&next, true);
     }
 
     pub fn radio(&self) -> bool {
@@ -1474,23 +1478,29 @@ impl Playback {
         if local != self.local_active() {
             return;
         }
+        let current_id = self.track.as_ref().and_then(|track| track.id.as_deref());
+        if let Some(event_id) = event.id()
+            && current_id != Some(event_id)
+        {
+            return;
+        }
         match event {
             BackendEvent::OutputChanged => self.restart_output(cx),
-            BackendEvent::Unavailable | BackendEvent::Refused if self.resume_ready => {
+            BackendEvent::Unavailable { .. } | BackendEvent::Refused if self.resume_ready => {
                 self.resume_ready = false;
                 self.state = PlaybackState::Paused;
                 log::warn!("playback: cannot hold the restored track, waiting for play");
             }
-            BackendEvent::Loading(position) => {
+            BackendEvent::Loading { at, .. } => {
                 self.state = PlaybackState::Loading;
-                self.position = position;
-                self.clock.reset(position, false);
+                self.position = at;
+                self.clock.reset(at, false);
             }
-            BackendEvent::Playing(position) => {
+            BackendEvent::Playing { at, .. } => {
                 let started = self.state != PlaybackState::Playing;
                 self.state = PlaybackState::Playing;
-                self.position = position;
-                self.clock.reset(position, true);
+                self.position = at;
+                self.clock.reset(at, true);
                 if let Some(at) = self.seek_on_play.take() {
                     self.seek(at, cx);
                 }
@@ -1498,22 +1508,22 @@ impl Playback {
                     cx.emit(PlaybackEvent::StartedPlayback);
                 }
             }
-            BackendEvent::Paused(position) => {
+            BackendEvent::Paused { at, .. } => {
                 self.state = PlaybackState::Paused;
-                self.position = position;
-                self.clock.reset(position, false);
+                self.position = at;
+                self.clock.reset(at, false);
                 self.remember(true, cx);
             }
-            BackendEvent::Position(position) => {
-                self.position = position;
+            BackendEvent::Position { at, .. } => {
+                self.position = at;
                 match self.state == PlaybackState::Playing {
-                    true => self.clock.correct(position),
-                    false => self.clock.reset(position, false),
+                    true => self.clock.correct(at),
+                    false => self.clock.reset(at, false),
                 }
                 self.remember(false, cx);
-                self.preload_next(position, cx);
+                self.preload_next(at, cx);
             }
-            BackendEvent::Length(duration) => {
+            BackendEvent::Length { duration, .. } => {
                 if let Some(track) = self.track.as_mut()
                     && !duration.is_zero()
                     && track.duration != duration
@@ -1521,7 +1531,7 @@ impl Playback {
                     track.duration = duration;
                 }
             }
-            BackendEvent::Ended => {
+            BackendEvent::Ended { .. } => {
                 let ended = self.track.take();
                 self.state = PlaybackState::Idle;
                 self.position = Duration::ZERO;
@@ -1529,11 +1539,11 @@ impl Playback {
                 cx.emit(PlaybackEvent::EndedPlayback);
                 self.advance(ended, cx);
             }
-            BackendEvent::Unavailable if self.ask_for_reconnect(cx) => {
+            BackendEvent::Unavailable { .. } if self.ask_for_reconnect(cx) => {
                 self.state = PlaybackState::Loading;
                 log::warn!("playback: the provider went stale, waiting for a reconnect");
             }
-            BackendEvent::Unavailable => {
+            BackendEvent::Unavailable { .. } => {
                 let failed = self.track.take();
                 let target = failed.as_ref().and_then(song_target);
                 let name = failed.map_or_else(|| "?".to_owned(), |track| track.name);


### PR DESCRIPTION
## Summary
- prevent double-clear in rodio sink causing silence after rapid track switches
- filter stale backend playback events by track id in state layer
- prevent infinite audio device restart loops when wasapi reports unknown device
- split hover preloading from queue-end gapless segue preloading