### PR TITLE
fix(local): date local tracks, albums and artists by their files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Local music now carries a date added, taken from when each file was last changed, so the Date
+  added column fills in and sorting songs, albums and artists by it works.
+
 ## [0.31.0] - 2026-09-05
 
 ### Added

--- a/crates/music/src/local/client.rs
+++ b/crates/music/src/local/client.rs
@@ -290,7 +290,8 @@ impl MusicApi for LocalClient {
         let scanned = self.scanned.read().unwrap();
         let mut artists: Vec<SavedArtist> = Vec::new();
         for track in &scanned.tracks {
-            if artists.iter().any(|known| known.name == track.artists) {
+            if let Some(known) = artists.iter_mut().find(|known| known.name == track.artists) {
+                known.added_at = known.added_at.max(track.added_at);
                 continue;
             }
             artists.push(SavedArtist {
@@ -308,7 +309,7 @@ impl MusicApi for LocalClient {
                             .and_then(|album| album.cover.clone())
                     })
                     .or_else(|| track.cover.clone()),
-                added_at: None,
+                added_at: track.added_at,
             });
         }
         artists.sort_by_key(|artist| artist.name.to_lowercase());

--- a/crates/music/src/local/wire.rs
+++ b/crates/music/src/local/wire.rs
@@ -88,6 +88,18 @@ fn clean(value: Option<std::borrow::Cow<'_, str>>) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
+/// When a file last changed, in whole seconds since the epoch. `None` when the
+/// filesystem does not keep the time or it sits outside what an `i64` of seconds holds.
+pub fn modified_at(path: &Path) -> Option<i64> {
+    let modified = std::fs::metadata(path).ok()?.modified().ok()?;
+    match modified.duration_since(std::time::UNIX_EPOCH) {
+        Ok(since) => i64::try_from(since.as_secs()).ok(),
+        Err(before) => i64::try_from(before.duration().as_secs())
+            .ok()
+            .map(|seconds| -seconds),
+    }
+}
+
 pub fn track_from_file(
     path: &Path,
     artist_hint: Option<&str>,
@@ -125,7 +137,7 @@ pub fn track_from_file(
         album_id: album_dir.map(album_id),
         cover,
         duration,
-        added_at: None,
+        added_at: modified_at(path),
         added_by: None,
         playcount: None,
         popularity: 0,
@@ -167,7 +179,7 @@ pub fn album_from_tracks(
         release_date: String::new(),
         label: String::new(),
         copyrights: Vec::new(),
-        added_at: None,
+        added_at: tracks.iter().filter_map(|track| track.added_at).max(),
     }
 }
 
@@ -236,4 +248,53 @@ fn cache_picture(picture: &Picture, cache_dir: &Path) -> Option<String> {
         std::fs::write(&dest, picture.data()).ok()?;
     }
     Some(format!("file://{}", dest.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(name);
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn a_track_is_dated_by_the_file_it_came_from() {
+        let dir = scratch("sonora-wire-test-dated");
+        let path = dir.join("song.mp3");
+        std::fs::write(&path, []).unwrap();
+
+        let stamped = modified_at(&path).expect("a file just written has a modified time");
+        let track = track_from_file(&path, None, None, &dir).expect("a track");
+
+        assert_eq!(track.added_at, Some(stamped));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn an_album_is_dated_by_its_newest_track() {
+        let dir = scratch("sonora-wire-test-album-dated");
+        let path = dir.join("song.mp3");
+        std::fs::write(&path, []).unwrap();
+
+        let mut older = track_from_file(&path, None, None, &dir).expect("a track");
+        let mut newer = older.clone();
+        older.added_at = Some(1_000);
+        newer.added_at = Some(2_000);
+
+        let album = album_from_tracks("Album", "Artist", &dir, &[older, newer], 2026);
+
+        assert_eq!(album.added_at, Some(2_000));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_missing_file_has_no_date() {
+        let dir = scratch("sonora-wire-test-missing");
+        assert_eq!(modified_at(&dir.join("gone.mp3")), None);
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }


### PR DESCRIPTION
## Summary

- give every local track a date added, taken from when its file was last changed, so the Date added column fills in and sorting songs by it works
- date a local album by its newest track, and a local artist by their newest track, so those two tables sort by it too

Fixes #440.

## Why

`TrackField::AddedAt` sorts on `track.added_at` and `cells::stamp` renders it, but the local scanner
built every track with `added_at: None`. Every row compared equal, so the sort was a no-op, and the
column rendered an empty string. `album_from_tracks` and `saved_artists` set the same field to
`None`, which is the "Sorting artists doesn't work as well" half of the report.

Favourites were the one local list that already carried a date, because `saved_tracks` fills it in
from the favourites table. Everything reached through `all_tracks` did not.

The file's modified time is what the report asks for and the only date a plain audio file carries.

## Tests

`cargo test --workspace`, three new tests in `crates/music/src/local/wire.rs`:

- `a_track_is_dated_by_the_file_it_came_from` — a scanned track's `added_at` is the file's modified
  time. Before this change: `left: None, right: Some(1788617019)`.
- `an_album_is_dated_by_its_newest_track` — the newest of two tracks wins. Before: `left: None,
  right: Some(2000)`.
- `a_missing_file_has_no_date` — a path that is not there yields `None` rather than a panic or a
  zero date.

## How I tested

Windows 11, toolchain 1.97.1 from `rust-toolchain.toml`. `cargo fmt --all --check`,
`cargo check --workspace`, `cargo test --workspace` and `cargo clippy --workspace --all-targets` all
clean. Not run on Linux or macOS; nothing here is platform-specific, `std::fs::metadata` carries the
modified time on all three.

One note in passing, not part of this change: `rust-toolchain.toml` does not list `clippy` in its
components, so a fresh checkout cannot run the clippy command CONTRIBUTING asks for until you add the
component by hand. Happy to send that as its own one-line pull request if it is wanted.
