### PR TITLE
chore: add clippy to the pinned toolchain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,10 +55,11 @@ Three things that bite people:
   proprietary driver (`nvidia-utils` on Arch).
 - **mold must be on `PATH`** — `.cargo/config.toml` passes `-fuse-ld=mold` for
   `x86_64-unknown-linux-gnu`. Build with `RUSTFLAGS="" cargo build …` to drop it.
-- **Rust must be 1.85 or newer** — the workspace is edition 2024 with resolver 3, and there is no
-  `rust-toolchain.toml`, so whatever is on `PATH` builds it. Arch and Fedora ship current toolchains;
-  Debian 13 sits exactly on 1.85.0, and Debian 12 (1.63) and Ubuntu 24.04 are too old — use
-  [rustup](https://rustup.rs) there.
+- **The toolchain is pinned** — `rust-toolchain.toml` names the version and the components, so
+  [rustup](https://rustup.rs) fetches them on the first `cargo` command and every checkout builds
+  and lints with the same compiler. A distribution's own `cargo` ignores the file and needs at least
+  1.85, since the workspace is edition 2024 with resolver 3; Debian 12 (1.63) and Ubuntu 24.04 are
+  too old for that.
 
 The first build compiles GPUI from source, so expect several minutes.
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,6 +4,7 @@ components = [
   "cargo",
   "rustc",
   "rustfmt",
+  "clippy",
   "rust-analyzer",
   "rust-src",
 ]


### PR DESCRIPTION
## Summary

- add `clippy` to the components in `rust-toolchain.toml`, so the clippy command in the Checks
  section runs on a fresh checkout
- rewrite the setup note that still says there is no pinned toolchain

## Why

`de8fdb0` pinned the toolchain to 1.97.1 two days ago. Its component list carries `rustfmt` but not
`clippy`, so `cargo clippy --workspace --all-targets` — one of the four commands CONTRIBUTING asks
you to run before opening a pull request — fails on a fresh checkout:

```
error: 'cargo-clippy.exe' is not installed for the toolchain '1.97.1-x86_64-pc-windows-msvc'.
```

The contributor then either installs the component by hand or skips the lint, and the guide says
clippy is clean, so anything it reports is theirs to fix.

The same commit also made the Setup note wrong. It still reads "there is no `rust-toolchain.toml`,
so whatever is on `PATH` builds it", which is now the opposite of what happens: rustup reads the
file and fetches 1.97.1 regardless of what is on `PATH`. The 1.85 floor still matters for a
distribution's own cargo, which ignores the file, so that part is kept and attributed to that case.

## How I tested

Windows 11. Removed the pinned toolchain entirely (`rustup toolchain uninstall
1.97.1-x86_64-pc-windows-msvc`), then ran `cargo clippy --version` in the workspace: rustup
reinstalled 1.97.1 from the file and clippy came with it.

```
clippy 0.1.97 (8bab26f4f6 2026-07-14)
```

`cargo fmt --all --check` and `cargo clippy --workspace --all-targets` are both clean afterwards.

No changelog entry: nothing about running Sonora changes.
