### PR TITLE
feat(ui): enable windows 11 rounded corners and dynamic opacity

### DIFF
--- a/crates/sonora/src/main.rs
+++ b/crates/sonora/src/main.rs
@@ -184,11 +184,18 @@ fn open_window(cx: &mut App) {
     let saver = settings.saver();
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     let decorations = settings.window_decorations();
+    let background = match cfg!(target_os = "windows") {
+        true => match settings.transparent() {
+            true => WindowBackgroundAppearance::Transparent,
+            false => WindowBackgroundAppearance::Opaque,
+        },
+        false => WindowBackgroundAppearance::Transparent,
+    };
 
     cx.open_window(
         WindowOptions {
             window_bounds: Some(placement),
-            window_background: WindowBackgroundAppearance::Transparent,
+            window_background: background,
             titlebar: Some(TitlebarOptions {
                 title: Some("Sonora".into()),
                 appears_transparent: true,
@@ -217,7 +224,7 @@ fn open_window(cx: &mut App) {
 fn platform_handle(window: &gpui::Window) -> Option<*mut std::ffi::c_void> {
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
     use windows_sys::Win32::Graphics::Dwm::{
-        DWMNCRP_DISABLED, DWMWA_NCRENDERING_POLICY, DwmSetWindowAttribute,
+        DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_ROUND, DwmSetWindowAttribute,
     };
 
     let RawWindowHandle::Win32(handle) = HasWindowHandle::window_handle(window).ok()?.as_raw()
@@ -226,11 +233,12 @@ fn platform_handle(window: &gpui::Window) -> Option<*mut std::ffi::c_void> {
     };
     let handle = handle.hwnd.get() as *mut std::ffi::c_void;
     unsafe {
+        let preference = DWMWCP_ROUND;
         DwmSetWindowAttribute(
             handle,
-            DWMWA_NCRENDERING_POLICY as u32,
-            &DWMNCRP_DISABLED as *const _ as *const std::ffi::c_void,
-            size_of_val(&DWMNCRP_DISABLED) as u32,
+            DWMWA_WINDOW_CORNER_PREFERENCE as u32,
+            &preference as *const _ as *const std::ffi::c_void,
+            size_of_val(&preference) as u32,
         );
     }
     Some(handle)

--- a/crates/views/src/root.rs
+++ b/crates/views/src/root.rs
@@ -76,6 +76,8 @@ pub struct Root {
     navigation_transition: Option<Task<()>>,
     screens: Screens,
     _adaptive: Entity<Adaptive>,
+    #[cfg(target_os = "windows")]
+    background: Option<gpui::WindowBackgroundAppearance>,
 }
 
 impl Root {
@@ -226,6 +228,8 @@ impl Root {
                 settings,
             },
             _adaptive: adaptive,
+            #[cfg(target_os = "windows")]
+            background: None,
         };
         root.show(start, cx);
         root
@@ -569,6 +573,17 @@ impl Render for Root {
 
         let theme = *cx.theme();
         window.set_rem_size(theme.font_size);
+        #[cfg(target_os = "windows")]
+        {
+            let appearance = match theme.transparent {
+                true => gpui::WindowBackgroundAppearance::Transparent,
+                false => gpui::WindowBackgroundAppearance::Opaque,
+            };
+            if self.background != Some(appearance) {
+                self.background = Some(appearance);
+                window.set_background_appearance(appearance);
+            }
+        }
 
         let root = div()
             .relative()


### PR DESCRIPTION
## Summary

Enables native windows 11 rounded window corners, system drop shadows, 

## Changes

- request native windows 11 rounded corners through DWMWA_WINDOW_CORNER_PREFERENCE and DWMWCP_ROUND
- remove DWMNCRP_DISABLED so DWM manages the non-client frame and drop shadow
- set window background to opaque at 100 opacity on Windows, enabling native framing, rounded corners, and subpixel text antialiasing
- dynamically toggle the window background to transparent on windows when opacity is lowered below 100, allowing desktop transparency
- Unchanged on linux and mac

## Testing

Tested on Windows 11:

- default 100 opacity displays native rounded corners, outer drop shadow, and ClearType text
- on lower than 100, shows appropriate transperency
- hovering the maximize button triggers windows 11 Snap Layouts
- titlebar dragging, double-click maximize and restore, and window controls work as expected

| Before | After |
|:----:|:----:|
| <img width="202" height="127" alt="image" src="https://github.com/user-attachments/assets/cf49fd2c-a3ea-4f7b-b310-a715d991bd0e" /> | <img width="202" height="166" alt="image" src="https://github.com/user-attachments/assets/bc05b202-2ef9-45b6-a102-746d8bd91cf8" /> |