### PR TITLE
feat(input): add macos shortcuts for windows, menus and text fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- On macOS, Sonora follows the platform's shortcuts: `⌘W` closes the window, `⌘M` minimises it,
+  `⌃⌘F` toggles native full screen, `⌘H` and `⌥⌘H` hide Sonora or everything else, and `⌘[` / `⌘]`
+  step through history. Text fields take the Cocoa conventions too: `⌥` arrows and `⌥⌫` work by
+  word, `⌘⌫` and `⌘⌦` clear to either end of the field, `⌘↑`/`⌘↓` jump to the ends, and the Emacs
+  control keys (`⌃A`, `⌃E`, `⌃B`, `⌃F`, `⌃D`, `⌃H`, `⌃K`) do what they do everywhere else on a
+  Mac. The menu bar gains Edit and Window menus and the usual Settings, Hide and Show All items.
+
 ### Fixed
 
 - Local music now carries a date added, taken from when each file was last changed, so the Date

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -691,7 +691,11 @@ field in the title bar. Don't build a second search box.
 **Actions and keys.** Declare actions in `crates/input/src/lib.rs` (`actions!` macro), bind them in
 `bindings()`, handle them with `cx.on_action` (global, in `sonora/src/actions.rs`) or
 `.on_action(cx.listener(…))` (scoped). Key contexts: `Workspace`, `Input`, `Table`. Both `cmd-` and
-`ctrl-` bindings are registered for every shortcut.
+`ctrl-` bindings are registered for every shortcut in `shared()`; `macos()` is appended only on
+macOS and holds the Cocoa conventions (`cmd-w`, `cmd-m`, `cmd-h`, `alt-` word motions, the Emacs
+control keys). GPUI prefers the binding registered last within one context, which is what lets
+that set override the shared one. Only macOS draws the menu bar, so `actions::menus` adds the
+Edit and Window menus there alone.
 
 **The tray outlives the window.** `sonora/src/tray.rs` owns one `Tray` entity driven by two
 backends: `tray/native.rs` (`tray-icon`, macOS and Windows) and `tray/sni.rs` (`ksni`, Linux over

--- a/README.md
+++ b/README.md
@@ -157,17 +157,17 @@ AI-assisted proofreading and translation of human-written text are permitted.
 
 | Language | Translated | Coverage |
 | --- | --- | --- |
-| English (`en-US`) | 519/519 | 100% |
-| Deutsch (`de`) | 519/519 | 100% |
-| Español (`es`) | 496/519 | 96% |
-| Français (`fr`) | 478/519 | 92% |
-| Italiano (`it`) | 475/519 | 92% |
-| Bahasa Indonesia (`id`) | 513/519 | 99% |
-| 日本語 (`ja`) | 496/519 | 96% |
-| Русский (`ru`) | 486/519 | 94% |
-| Українська (`uk`) | 486/519 | 94% |
-| Polski (`pl`) | 517/519 | 100% |
-| Português (Brasil) (`pt-BR`) | 496/519 | 96% |
+| English (`en-US`) | 532/532 | 100% |
+| Deutsch (`de`) | 532/532 | 100% |
+| Español (`es`) | 509/532 | 96% |
+| Français (`fr`) | 491/532 | 92% |
+| Italiano (`it`) | 488/532 | 92% |
+| Bahasa Indonesia (`id`) | 526/532 | 99% |
+| 日本語 (`ja`) | 509/532 | 96% |
+| Русский (`ru`) | 499/532 | 94% |
+| Українська (`uk`) | 499/532 | 94% |
+| Polski (`pl`) | 530/532 | 100% |
+| Português (Brasil) (`pt-BR`) | 509/532 | 96% |
 
 <!-- i18n:end -->
 

--- a/assets/i18n/de/main.ftl
+++ b/assets/i18n/de/main.ftl
@@ -57,6 +57,19 @@ library-local-unconfigured = Richte deine lokale Bibliothek ein
 app-refresh-library = Bibliothek aktualisieren
 app-sign-out = Abmelden
 app-quit = Beenden
+app-settings = Einstellungen …
+app-hide = Sonora ausblenden
+app-hide-others = Andere ausblenden
+app-show-all = Alle einblenden
+app-edit = Bearbeiten
+app-cut = Ausschneiden
+app-copy = Kopieren
+app-paste = Einsetzen
+app-select-all = Alles auswählen
+app-window = Fenster
+app-close-window = Fenster schließen
+app-minimize = Im Dock ablegen
+app-zoom = Zoomen
 
 # tray menu
 tray-show = Sonora anzeigen

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -57,6 +57,19 @@ library-local-unconfigured = Configure your local library
 app-refresh-library = Refresh Library
 app-sign-out = Sign Out
 app-quit = Quit
+app-settings = Settings…
+app-hide = Hide Sonora
+app-hide-others = Hide Others
+app-show-all = Show All
+app-edit = Edit
+app-cut = Cut
+app-copy = Copy
+app-paste = Paste
+app-select-all = Select All
+app-window = Window
+app-close-window = Close Window
+app-minimize = Minimize
+app-zoom = Zoom
 
 # tray menu
 tray-show = Show Sonora

--- a/assets/i18n/es/main.ftl
+++ b/assets/i18n/es/main.ftl
@@ -57,6 +57,19 @@ library-local-unconfigured = Configura tu biblioteca local
 app-refresh-library = Actualizar biblioteca
 app-sign-out = Cerrar sesión
 app-quit = Salir
+app-settings = Ajustes…
+app-hide = Ocultar Sonora
+app-hide-others = Ocultar otros
+app-show-all = Mostrar todo
+app-edit = Edición
+app-cut = Cortar
+app-copy = Copiar
+app-paste = Pegar
+app-select-all = Seleccionar todo
+app-window = Ventana
+app-close-window = Cerrar ventana
+app-minimize = Minimizar
+app-zoom = Zoom
 
 # table columns
 column-played-at = Reproducido

--- a/assets/i18n/fr/main.ftl
+++ b/assets/i18n/fr/main.ftl
@@ -57,6 +57,19 @@ library-local-unconfigured = Configurez votre bibliothèque locale
 app-refresh-library = Actualiser la bibliothèque
 app-sign-out = Se déconnecter
 app-quit = Quitter
+app-settings = Réglages…
+app-hide = Masquer Sonora
+app-hide-others = Masquer les autres
+app-show-all = Tout afficher
+app-edit = Édition
+app-cut = Couper
+app-copy = Copier
+app-paste = Coller
+app-select-all = Tout sélectionner
+app-window = Fenêtre
+app-close-window = Fermer la fenêtre
+app-minimize = Placer dans le Dock
+app-zoom = Réduire/agrandir
 
 # table columns
 column-played-at = Écouté

--- a/assets/i18n/id/main.ftl
+++ b/assets/i18n/id/main.ftl
@@ -57,6 +57,19 @@ library-local-unconfigured = Konfigurasikan pustaka lokal Anda
 app-refresh-library = Refresh Pustaka
 app-sign-out = Keluar
 app-quit = Keluar
+app-settings = Pengaturan…
+app-hide = Sembunyikan Sonora
+app-hide-others = Sembunyikan Lainnya
+app-show-all = Tampilkan Semua
+app-edit = Edit
+app-cut = Potong
+app-copy = Salin
+app-paste = Tempel
+app-select-all = Pilih Semua
+app-window = Jendela
+app-close-window = Tutup Jendela
+app-minimize = Minimalkan
+app-zoom = Zoom
 
 # tray menu
 tray-show = Tampilkan Sonora

--- a/assets/i18n/it/main.ftl
+++ b/assets/i18n/it/main.ftl
@@ -57,6 +57,19 @@ library-local-unconfigured = Configura la tua libreria locale
 app-refresh-library = Aggiorna libreria
 app-sign-out = Disconnetti
 app-quit = Esci
+app-settings = Impostazioni…
+app-hide = Nascondi Sonora
+app-hide-others = Nascondi altre
+app-show-all = Mostra tutte
+app-edit = Modifica
+app-cut = Taglia
+app-copy = Copia
+app-paste = Incolla
+app-select-all = Seleziona tutto
+app-window = Finestra
+app-close-window = Chiudi finestra
+app-minimize = Contrai
+app-zoom = Zoom
 
 # table columns
 column-played-at = Riprodotto

--- a/assets/i18n/ja/main.ftl
+++ b/assets/i18n/ja/main.ftl
@@ -57,6 +57,19 @@ library-local-unconfigured = ローカルライブラリを設定する
 app-refresh-library = ライブラリを更新
 app-sign-out = サインアウト
 app-quit = 終了
+app-settings = 設定…
+app-hide = Sonoraを隠す
+app-hide-others = ほかを隠す
+app-show-all = すべてを表示
+app-edit = 編集
+app-cut = カット
+app-copy = コピー
+app-paste = ペースト
+app-select-all = すべてを選択
+app-window = ウインドウ
+app-close-window = ウインドウを閉じる
+app-minimize = しまう
+app-zoom = 拡大/縮小
 
 # table columns
 column-played-at = 再生日時

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -57,6 +57,19 @@ library-local-unconfigured = Skonfiguruj lokalną bibliotekę
 app-refresh-library = Odśwież bibliotekę
 app-sign-out = Wyloguj się
 app-quit = Zakończ
+app-settings = Ustawienia…
+app-hide = Ukryj Sonora
+app-hide-others = Ukryj pozostałe
+app-show-all = Pokaż wszystkie
+app-edit = Edycja
+app-cut = Wytnij
+app-copy = Kopiuj
+app-paste = Wklej
+app-select-all = Zaznacz wszystko
+app-window = Okno
+app-close-window = Zamknij okno
+app-minimize = Minimalizuj
+app-zoom = Powiększ
 
 # tray menu
 tray-show = Pokaż Sonorę

--- a/assets/i18n/pt-BR/main.ftl
+++ b/assets/i18n/pt-BR/main.ftl
@@ -57,6 +57,19 @@ library-local-unconfigured = Configure sua biblioteca local
 app-refresh-library = Atualizar Biblioteca
 app-sign-out = Sair
 app-quit = Sair do aplicativo
+app-settings = Ajustes…
+app-hide = Ocultar Sonora
+app-hide-others = Ocultar outros
+app-show-all = Mostrar tudo
+app-edit = Editar
+app-cut = Recortar
+app-copy = Copiar
+app-paste = Colar
+app-select-all = Selecionar tudo
+app-window = Janela
+app-close-window = Fechar janela
+app-minimize = Minimizar
+app-zoom = Zoom
 
 # table columns
 column-played-at = Tocada em

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -57,6 +57,19 @@ library-local-unconfigured = Настройте локальную библио�
 app-refresh-library = Обновить медиатеку
 app-sign-out = Выйти
 app-quit = Выход
+app-settings = Настройки…
+app-hide = Скрыть Sonora
+app-hide-others = Скрыть остальные
+app-show-all = Показать все
+app-edit = Правка
+app-cut = Вырезать
+app-copy = Копировать
+app-paste = Вставить
+app-select-all = Выбрать все
+app-window = Окно
+app-close-window = Закрыть окно
+app-minimize = Свернуть
+app-zoom = Изменить масштаб
 
 # table columns
 column-played-at = Прослушано

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -57,6 +57,19 @@ library-local-unconfigured = Налаштуйте локальну бібліо�
 app-refresh-library = Оновити медіатеку
 app-sign-out = Вийти
 app-quit = Вихід
+app-settings = Налаштування…
+app-hide = Сховати Sonora
+app-hide-others = Сховати інші
+app-show-all = Показати все
+app-edit = Правка
+app-cut = Вирізати
+app-copy = Скопіювати
+app-paste = Вставити
+app-select-all = Вибрати все
+app-window = Вікно
+app-close-window = Закрити вікно
+app-minimize = Згорнути
+app-zoom = Змінити масштаб
 
 # table columns
 column-played-at = Прослухано

--- a/crates/input/src/lib.rs
+++ b/crates/input/src/lib.rs
@@ -1,9 +1,10 @@
 use gpui::{KeyBinding, actions};
 use ui::{
-    Activate, Backspace, BackspaceWord, Copy, Cut, Delete, DeleteWord, Deselect, Dismiss, End,
-    FORM_CONTEXT, Home, INPUT_CONTEXT, Left, MENU_CONTEXT, Paste, Remove, Right, SelectAll,
-    SelectEnd, SelectHome, SelectLeft, SelectNext, SelectPrevious, SelectRight, SelectWordLeft,
-    SelectWordRight, ShowCharacterPalette, Space, Submit, TABLE_CONTEXT, WordLeft, WordRight,
+    Activate, Backspace, BackspaceToStart, BackspaceWord, Copy, Cut, Delete, DeleteToEnd,
+    DeleteWord, Deselect, Dismiss, End, FORM_CONTEXT, Home, INPUT_CONTEXT, Left, MENU_CONTEXT,
+    Paste, Remove, Right, SelectAll, SelectEnd, SelectHome, SelectLeft, SelectNext, SelectPrevious,
+    SelectRight, SelectWordLeft, SelectWordRight, ShowCharacterPalette, Space, Submit,
+    TABLE_CONTEXT, WordLeft, WordRight,
 };
 
 actions!(
@@ -22,14 +23,32 @@ actions!(
         OpenSettings,
         ToggleFullscreen,
         ToggleQueue,
-        ToggleLyrics
+        ToggleLyrics,
+        CloseWindow,
+        MinimizeWindow,
+        ZoomWindow,
+        ToggleWindowFullscreen,
+        Hide,
+        HideOthers,
+        ShowAll
     ]
 );
 
 pub const WORKSPACE_CONTEXT: &str = "Workspace";
 pub const SEARCH_CONTEXT: &str = "Search";
 
+/// Every key binding, in precedence order: GPUI prefers the deepest matching context and,
+/// within one, the binding registered last, so the macOS set at the end overrides the shared one.
 pub fn bindings() -> Vec<KeyBinding> {
+    let mut bindings = shared();
+    if cfg!(target_os = "macos") {
+        bindings.extend(macos());
+    }
+    bindings
+}
+
+/// The bindings every platform gets; both `cmd-` and `ctrl-` are registered for each shortcut.
+fn shared() -> Vec<KeyBinding> {
     let editing = Some(INPUT_CONTEXT);
     let away_from_text = format!("{WORKSPACE_CONTEXT} && !{INPUT_CONTEXT}");
     let table = Some(TABLE_CONTEXT);
@@ -117,5 +136,41 @@ pub fn bindings() -> Vec<KeyBinding> {
         KeyBinding::new("escape", Dismiss, editing),
         KeyBinding::new("enter", Submit, form),
         KeyBinding::new("escape", Dismiss, form),
+    ]
+}
+
+/// What a Mac user expects on top of the shared set: the standard window and application
+/// shortcuts, `cmd-[`/`cmd-]` history, and the Cocoa text-field conventions, `alt` for words,
+/// `cmd` for the line and the Emacs control keys.
+fn macos() -> Vec<KeyBinding> {
+    let editing = Some(INPUT_CONTEXT);
+
+    vec![
+        KeyBinding::new("cmd-w", CloseWindow, None),
+        KeyBinding::new("cmd-m", MinimizeWindow, None),
+        KeyBinding::new("ctrl-cmd-f", ToggleWindowFullscreen, None),
+        KeyBinding::new("cmd-h", Hide, None),
+        KeyBinding::new("alt-cmd-h", HideOthers, None),
+        KeyBinding::new("cmd-[", NavigateBack, None),
+        KeyBinding::new("cmd-]", NavigateForward, None),
+        KeyBinding::new("alt-left", WordLeft, editing),
+        KeyBinding::new("alt-right", WordRight, editing),
+        KeyBinding::new("shift-alt-left", SelectWordLeft, editing),
+        KeyBinding::new("shift-alt-right", SelectWordRight, editing),
+        KeyBinding::new("alt-backspace", BackspaceWord, editing),
+        KeyBinding::new("alt-delete", DeleteWord, editing),
+        KeyBinding::new("cmd-backspace", BackspaceToStart, editing),
+        KeyBinding::new("cmd-delete", DeleteToEnd, editing),
+        KeyBinding::new("cmd-up", Home, editing),
+        KeyBinding::new("cmd-down", End, editing),
+        KeyBinding::new("shift-cmd-up", SelectHome, editing),
+        KeyBinding::new("shift-cmd-down", SelectEnd, editing),
+        KeyBinding::new("ctrl-a", Home, editing),
+        KeyBinding::new("ctrl-e", End, editing),
+        KeyBinding::new("ctrl-b", Left, editing),
+        KeyBinding::new("ctrl-f", Right, editing),
+        KeyBinding::new("ctrl-h", Backspace, editing),
+        KeyBinding::new("ctrl-d", Delete, editing),
+        KeyBinding::new("ctrl-k", DeleteToEnd, editing),
     ]
 }

--- a/crates/sonora/src/actions.rs
+++ b/crates/sonora/src/actions.rs
@@ -1,13 +1,20 @@
-use gpui::{App, Menu, MenuItem};
+use gpui::{App, Menu, MenuItem, OsAction};
 use i18n::t;
-use input::{Quit, RefreshLibrary, SignOut, SongNext, SongPrevious, TogglePlayback};
+use input::{
+    CloseWindow, Hide, HideOthers, MinimizeWindow, OpenSettings, Quit, RefreshLibrary, ShowAll,
+    SignOut, SongNext, SongPrevious, TogglePlayback, ZoomWindow,
+};
 use router::Destination;
 use state::Sonora;
+use ui::{Copy, Cut, Paste, SelectAll};
 
 pub fn register(lingers: bool, cx: &mut App) {
     cx.bind_keys(input::bindings());
 
     cx.on_action(|_: &Quit, cx: &mut App| cx.quit());
+    cx.on_action(|_: &Hide, cx: &mut App| cx.hide());
+    cx.on_action(|_: &HideOthers, cx: &mut App| cx.hide_other_apps());
+    cx.on_action(|_: &ShowAll, cx: &mut App| cx.unhide_other_apps());
 
     cx.on_window_closed(move |cx, _| {
         if !cx.windows().is_empty() {
@@ -54,14 +61,57 @@ pub fn register(lingers: bool, cx: &mut App) {
         playback.update(cx, |playback, cx| playback.next(cx));
     });
 
-    cx.set_menus(vec![Menu {
-        name: "Sonora".into(),
-        disabled: false,
-        items: vec![
+    cx.set_menus(menus());
+}
+
+/// The menu bar. Only macOS draws one, so only macOS gets the Edit and Window menus and the
+/// application-menu items Cocoa users expect; the other platforms keep the one Sonora menu.
+fn menus() -> Vec<Menu> {
+    let app = match cfg!(target_os = "macos") {
+        true => vec![
+            MenuItem::action(t!("app-settings"), OpenSettings),
+            MenuItem::separator(),
+            MenuItem::action(t!("app-refresh-library"), RefreshLibrary),
+            MenuItem::action(t!("app-sign-out"), SignOut),
+            MenuItem::separator(),
+            MenuItem::action(t!("app-hide"), Hide),
+            MenuItem::action(t!("app-hide-others"), HideOthers),
+            MenuItem::action(t!("app-show-all"), ShowAll),
+            MenuItem::separator(),
+            MenuItem::action(t!("app-quit"), Quit),
+        ],
+        false => vec![
             MenuItem::action(t!("app-refresh-library"), RefreshLibrary),
             MenuItem::action(t!("app-sign-out"), SignOut),
             MenuItem::separator(),
             MenuItem::action(t!("app-quit"), Quit),
         ],
-    }]);
+    };
+    let mut menus = vec![Menu {
+        name: "Sonora".into(),
+        disabled: false,
+        items: app,
+    }];
+    if cfg!(target_os = "macos") {
+        menus.push(Menu {
+            name: t!("app-edit"),
+            disabled: false,
+            items: vec![
+                MenuItem::os_action(t!("app-cut"), Cut, OsAction::Cut),
+                MenuItem::os_action(t!("app-copy"), Copy, OsAction::Copy),
+                MenuItem::os_action(t!("app-paste"), Paste, OsAction::Paste),
+                MenuItem::os_action(t!("app-select-all"), SelectAll, OsAction::SelectAll),
+            ],
+        });
+        menus.push(Menu {
+            name: t!("app-window"),
+            disabled: false,
+            items: vec![
+                MenuItem::action(t!("app-close-window"), CloseWindow),
+                MenuItem::action(t!("app-minimize"), MinimizeWindow),
+                MenuItem::action(t!("app-zoom"), ZoomWindow),
+            ],
+        });
+    }
+    menus
 }

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -308,6 +308,8 @@ impl Render for Input {
             .on_action(cx.listener(Self::backspace_word))
             .on_action(cx.listener(Self::delete))
             .on_action(cx.listener(Self::delete_word))
+            .on_action(cx.listener(Self::backspace_to_start))
+            .on_action(cx.listener(Self::delete_to_end))
             .on_action(cx.listener(Self::left))
             .on_action(cx.listener(Self::right))
             .on_action(cx.listener(Self::word_left))

--- a/crates/ui/src/input/mod.rs
+++ b/crates/ui/src/input/mod.rs
@@ -15,8 +15,10 @@ actions!(
     [
         Backspace,
         BackspaceWord,
+        BackspaceToStart,
         Delete,
         DeleteWord,
+        DeleteToEnd,
         Left,
         Right,
         WordLeft,
@@ -373,6 +375,21 @@ impl Input {
 
     fn delete_word(&mut self, _: &DeleteWord, window: &mut Window, cx: &mut Context<Self>) {
         self.erase(next_word, window, cx);
+    }
+
+    /// Erases from the caret back to the start of the field (`cmd-backspace` on macOS).
+    fn backspace_to_start(
+        &mut self,
+        _: &BackspaceToStart,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.erase(|_, _| 0, window, cx);
+    }
+
+    /// Erases from the caret to the end of the field (`cmd-delete` and `ctrl-k` on macOS).
+    fn delete_to_end(&mut self, _: &DeleteToEnd, window: &mut Window, cx: &mut Context<Self>) {
+        self.erase(|text, _| text.len(), window, cx);
     }
 
     fn write_selection(&self, cx: &mut Context<Self>) -> bool {

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -61,9 +61,10 @@ pub use glide::Glide;
 pub use info_card::{Fact, InfoCard};
 pub use inline_links::{InlineLink, InlineLinks};
 pub use input::{
-    Backspace, BackspaceWord, Copy, Cut, Delete, DeleteWord, Dismiss, End, Home, INPUT_CONTEXT,
-    Input, Left, Paste, Right, SelectAll, SelectEnd, SelectHome, SelectLeft, SelectRight,
-    SelectWordLeft, SelectWordRight, ShowCharacterPalette, Space, WordLeft, WordRight,
+    Backspace, BackspaceToStart, BackspaceWord, Copy, Cut, Delete, DeleteToEnd, DeleteWord,
+    Dismiss, End, Home, INPUT_CONTEXT, Input, Left, Paste, Right, SelectAll, SelectEnd, SelectHome,
+    SelectLeft, SelectRight, SelectWordLeft, SelectWordRight, ShowCharacterPalette, Space,
+    WordLeft, WordRight,
 };
 pub use label::{eyebrow, faint, heading, upper, vacant};
 pub use layout::{ALWAYS, MIN_CONTENT, ROOMY, Room, SNUG, VAST, WIDE};

--- a/crates/views/src/root.rs
+++ b/crates/views/src/root.rs
@@ -2,8 +2,8 @@ use gpui::{AnyView, Context, Entity, MouseButton, NavigationDirection, Render, T
 use gpui::{App, Font, FontFallbacks, SharedString, font, prelude::*};
 use gpui::{Window, div};
 use input::{
-    NavigateBack, NavigateForward, OpenFilter, OpenSearch, OpenSettings, ToggleFullscreen,
-    ToggleLyrics, ToggleQueue,
+    CloseWindow, MinimizeWindow, NavigateBack, NavigateForward, OpenFilter, OpenSearch,
+    OpenSettings, ToggleFullscreen, ToggleLyrics, ToggleQueue, ToggleWindowFullscreen, ZoomWindow,
 };
 use router::{Destination, NavigationEvent, SettingsTab, back, forward, navigate};
 use state::{
@@ -607,6 +607,10 @@ impl Render for Root {
             .on_action(cx.listener(|this, _: &OpenSearch, _, cx| this.open_search(cx)))
             .on_action(cx.listener(|this, _: &OpenSettings, _, cx| this.open_settings(cx)))
             .on_action(cx.listener(|this, _: &ToggleFullscreen, _, cx| this.toggle_fullscreen(cx)))
+            .on_action(|_: &CloseWindow, window, _| window.remove_window())
+            .on_action(|_: &MinimizeWindow, window, _| window.minimize_window())
+            .on_action(|_: &ZoomWindow, window, _| window.zoom_window())
+            .on_action(|_: &ToggleWindowFullscreen, window, _| window.toggle_fullscreen())
             .on_action(cx.listener(|this, _: &Dismiss, _, cx| this.dismiss(cx)))
             .on_action(
                 cx.listener(|this, _: &ToggleQueue, _, cx| this.show_side(SideTab::Queue, cx)),


### PR DESCRIPTION
## Summary

- close, minimise, zoom and toggle native full screen with cmd-w, cmd-m and ctrl-cmd-f on macos
- hide sonora or other apps with cmd-h and alt-cmd-h, and step through history with cmd-[ and cmd-]
- give text fields the cocoa conventions: alt word motions and deletes, cmd to clear or jump to either end, and the emacs control keys
- add edit and window menus plus settings, hide and show all items to the macos menu bar