### PR TITLE
fix(sonora): recover a stale instance socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- On macOS, a socket file left behind by a crash no longer disables single-instance handling: the
+  next launch notices nothing is listening, takes the socket over, and later launches and
+  `spotify:` links reach that window again instead of opening a second Sonora.
 - Local music now carries a date added, taken from when each file was last changed, so the Date
   added column fills in and sorting songs, albums and artists by it works.
 

--- a/crates/sonora/src/main.rs
+++ b/crates/sonora/src/main.rs
@@ -9,6 +9,7 @@ mod memory;
 mod single;
 mod tray;
 
+use std::process::exit;
 use std::sync::Arc;
 
 use gpui::{
@@ -30,8 +31,10 @@ fn main() {
 
     let opened = std::env::args().skip(1).find(|arg| !arg.starts_with('-'));
     let (sender, mut links) = tokio::sync::mpsc::unbounded_channel();
-    if let single::Instance::Running = single::claim(opened.as_deref(), sender.clone()) {
-        return;
+    match single::claim(opened.as_deref(), sender.clone()) {
+        single::Instance::First => {}
+        single::Instance::Running => return,
+        single::Instance::Failed => exit(1),
     }
     let opened_start = opened.as_deref().and_then(router::destination);
 

--- a/crates/sonora/src/single.rs
+++ b/crates/sonora/src/single.rs
@@ -1,5 +1,6 @@
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, ErrorKind, Write};
 use std::thread;
+use std::time::Duration;
 
 use interprocess::local_socket::traits::{ListenerExt as _, Stream as _};
 use interprocess::local_socket::{GenericNamespaced, ListenerOptions, Stream, ToNsName};
@@ -13,6 +14,7 @@ const SOCKET: &str = match cfg!(debug_assertions) {
 pub enum Instance {
     First,
     Running,
+    Failed,
 }
 
 pub fn claim(link: Option<&str>, sender: UnboundedSender<String>) -> Instance {
@@ -20,16 +22,40 @@ pub fn claim(link: Option<&str>, sender: UnboundedSender<String>) -> Instance {
         Ok(name) => name,
         Err(error) => {
             log::warn!("single: cannot name the instance socket: {error:#}");
-            return Instance::First;
+            return Instance::Failed;
         }
     };
 
     let listener = match ListenerOptions::new().name(name.clone()).create_sync() {
         Ok(listener) => listener,
-        Err(_) if hand_over(name, link) => return Instance::Running,
+
+        Err(error) if error.kind() == ErrorKind::AddrInUse => {
+            // There's probably a running instance.
+            if hand_over(name.clone(), link) {
+                return Instance::Running;
+            }
+
+            // Nothing answered. On filesystem-backed Unix sockets this may
+            // be a stale socket left behind by an unclean shutdown.
+            log::warn!("single: socket is occupied but unreachable; attempting recovery");
+
+            match ListenerOptions::new()
+                .name(name.clone())
+                .try_overwrite(true)
+                .max_spin_time(Duration::ZERO)
+                .create_sync()
+            {
+                Ok(listener) => listener,
+                Err(error) => {
+                    log::warn!("single: cannot recover instance socket: {error:#}");
+                    return Instance::First;
+                }
+            }
+        }
+
         Err(error) => {
-            log::warn!("single: cannot own the instance socket: {error:#}");
-            return Instance::First;
+            log::error!("single: cannot own the instance socket: {error:#}");
+            return Instance::Failed;
         }
     };
 


### PR DESCRIPTION
## Summary

- take over an instance socket nothing answers on, so a crash on macos no longer leaves single-instance handling disabled
- exit with an error instead of running unguarded when the instance socket cannot be created at all