### PR TITLE
Add system reduce motion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The Motion setting's System option now follows the operating system: Reduce Motion on macOS,
+  Animation effects on Windows, and GNOME's Reduce Animation on Linux through the desktop portal.
+  Sonora re-reads it whenever its window comes to the front, so flipping the switch takes effect
+  without a restart.
 - Local music now carries a date added, taken from when each file was last changed, so the Date
   added column fills in and sorting songs, albums and artists by it works.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,9 @@ sonora → views → state → music
   and the models in its root; each provider lives in a submodule (`music::spotify`,
   `music::youtube`, `music::local`). `state` and `views` see only the root traits and models — never
   a provider module. Only `sonora/src/main.rs` names a concrete provider.
-- `ui` depends only on `gpui`, `serde` and `i18n`. It must never know about `music`, `state`, or
-  playback.
+- `ui` depends only on `gpui`, `serde` and `i18n`, plus the per-platform crates `ui::motion` needs
+  to read the system reduce-motion preference (`objc2-app-kit`, `windows-sys`, `ashpd`). It must
+  never know about `music`, `state`, or playback.
 - `music` must never depend on `gpui`. It is plain async Rust.
 - `storage` is a leaf shared by `state` and `music`; it owns the only state database path, schema,
   connection setup and legacy database migration.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8236,6 +8236,7 @@ dependencies = [
 name = "ui"
 version = "0.31.0"
 dependencies = [
+ "ashpd",
  "futures",
  "gpui",
  "gpui_platform",
@@ -8243,8 +8244,10 @@ dependencies = [
  "icons",
  "image",
  "log",
+ "objc2-app-kit 0.3.2",
  "serde",
  "unicode-segmentation",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ gpui_platform = { git = "https://github.com/nolight132/gpui", rev = "96ffcd35c2d
 ] }
 http = "1.3"
 winresource = "0.1"
-windows-sys = { version = "0.61", features = ["Win32_Graphics_Dwm"] }
+windows-sys = { version = "0.61", features = ["Win32_Graphics_Dwm", "Win32_UI_WindowsAndMessaging"] }
 interprocess = "2.4"
 image = { version = "0.25", default-features = false, features = [
   "jpeg",
@@ -57,7 +57,8 @@ moka = { version = "0.12.15", features = ["future", "sync"] }
 oauth2 = "5.0"
 open = "5.4"
 objc2 = "0.6"
-objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSApplication", "NSResponder", "NSRunningApplication"] }
+objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSApplication", "NSResponder", "NSRunningApplication", "NSWorkspace", "NSAccessibility"] }
+ashpd = { version = "0.13", default-features = false, features = ["async-io", "settings"] }
 reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "rustls-tls-native-roots",

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -14,5 +14,14 @@ log.workspace = true
 serde.workspace = true
 unicode-segmentation.workspace = true
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-app-kit.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows-sys.workspace = true
+
+[target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
+ashpd.workspace = true
+
 [dev-dependencies]
 gpui_platform.workspace = true

--- a/crates/ui/src/motion.rs
+++ b/crates/ui/src/motion.rs
@@ -291,11 +291,12 @@ impl Stillness {
         }
     }
 
-    pub fn still(self) -> bool {
+    /// Whether motion is reduced: `Some` for a hard choice, `None` when the system decides.
+    pub fn still(self) -> Option<bool> {
         match self {
-            Self::System => system_still(),
-            Self::Always => true,
-            Self::Never => false,
+            Self::System => None,
+            Self::Always => Some(true),
+            Self::Never => Some(false),
         }
     }
 }
@@ -329,7 +330,10 @@ pub fn apply(stillness: Stillness, pace: Pace, cx: &mut App) {
         },
         Ordering::Relaxed,
     );
-    cx.set_reduce_motion(stillness.still());
+    match stillness.still() {
+        Some(still) => cx.set_reduce_motion(still),
+        None => system::settle(cx),
+    }
 }
 
 pub fn animates(cx: &App) -> bool {
@@ -360,8 +364,67 @@ impl Movement {
     }
 }
 
-fn system_still() -> bool {
-    false
+/// The operating system's reduce-motion preference. Every probe answers
+/// through `App::set_reduce_motion`, which repaints on a change, late answer is harmless.
+mod system {
+    use gpui::App;
+
+    /// Reduce Motion under System Settings > Accessibility > Display.
+    #[cfg(target_os = "macos")]
+    pub(super) fn settle(cx: &mut App) {
+        use objc2_app_kit::NSWorkspace;
+
+        let still = NSWorkspace::sharedWorkspace().accessibilityDisplayShouldReduceMotion();
+        cx.set_reduce_motion(still);
+    }
+
+    /// "Animation effects" under Settings > Accessibility > Visual effects
+    #[cfg(windows)]
+    pub(super) fn settle(cx: &mut App) {
+        use windows_sys::Win32::UI::WindowsAndMessaging::{
+            SPI_GETCLIENTAREAANIMATION, SystemParametersInfoW,
+        };
+
+        let mut animated: windows_sys::core::BOOL = 1;
+        // SAFETY: SPI_GETCLIENTAREAANIMATION writes one BOOL through pvparam, which is what
+        // `animated` is, and asks nothing else of the caller.
+        let answered = unsafe {
+            SystemParametersInfoW(SPI_GETCLIENTAREAANIMATION, 0, (&raw mut animated).cast(), 0)
+        };
+        cx.set_reduce_motion(answered != 0 && animated == 0);
+    }
+
+    /// GNOME's Reduce Animation toggle
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    pub(super) fn settle(cx: &mut App) {
+        use ashpd::desktop::settings::Settings;
+        use gpui::AppContext as _;
+
+        cx.spawn(async move |cx| {
+            let still = cx
+                .background_spawn(async {
+                    let settings = Settings::new().await.ok()?;
+                    let animated = settings
+                        .read::<bool>("org.gnome.desktop.interface", "enable-animations")
+                        .await
+                        .ok()?;
+                    Some(!animated)
+                })
+                .await;
+            cx.update(|cx| cx.set_reduce_motion(still.unwrap_or(false)));
+        })
+        .detach();
+    }
+
+    #[cfg(not(any(
+        target_os = "macos",
+        windows,
+        target_os = "linux",
+        target_os = "freebsd"
+    )))]
+    pub(super) fn settle(cx: &mut App) {
+        cx.set_reduce_motion(false);
+    }
 }
 
 #[cfg(test)]

--- a/crates/ui/src/motion.rs
+++ b/crates/ui/src/motion.rs
@@ -394,7 +394,10 @@ mod system {
         cx.set_reduce_motion(answered != 0 && animated == 0);
     }
 
-    /// GNOME's Reduce Animation toggle
+    /// Reads the standardized XDG reduced-motion preference.
+    ///
+    /// Requires a backend that supports `org.freedesktop.appearance.reduced-motion`;
+    /// older versions may not expose it.
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     pub(super) fn settle(cx: &mut App) {
         use ashpd::desktop::settings::Settings;
@@ -404,11 +407,9 @@ mod system {
             let still = cx
                 .background_spawn(async {
                     let settings = Settings::new().await.ok()?;
-                    let animated = settings
-                        .read::<bool>("org.gnome.desktop.interface", "enable-animations")
-                        .await
-                        .ok()?;
-                    Some(!animated)
+                    let reduced = settings.reduced_motion().await.ok()?;
+
+                    Some(reduced == ReducedMotion::ReducedMotion)
                 })
                 .await;
             cx.update(|cx| cx.set_reduce_motion(still.unwrap_or(false)));

--- a/crates/views/src/root.rs
+++ b/crates/views/src/root.rs
@@ -12,7 +12,7 @@ use state::{
 };
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use ui::WindowFrame;
-use ui::{ActiveTheme as _, Dismiss, Look, Theme, ThemeKind, clear_listing};
+use ui::{ActiveTheme as _, Dismiss, Look, Stillness, Theme, ThemeKind, clear_listing};
 
 use crate::chrome::{TitleBar, TitleBarEvent, TitleBarOptions, Toolbar, Tooled};
 use crate::screens::search::SearchView;
@@ -164,6 +164,24 @@ impl Root {
                 .shells
                 .workspace
                 .update(cx, |workspace, cx| workspace.toggle_sidebar_right(cx)),
+        })
+        .detach();
+
+        // the system reduce-motion preference has no change event here, so it is re-read each
+        // time the user comes back to the window, which is when they could have flipped it
+        cx.observe_window_activation(window, |_, window, cx| {
+            if !window.is_window_active() {
+                return;
+            }
+            let settings = Sonora::global(cx).settings.clone();
+            let (stillness, pace) = {
+                let settings = settings.read(cx);
+                (settings.stillness(), settings.pace())
+            };
+            if stillness != Stillness::System {
+                return;
+            }
+            ui::motion::apply(stillness, pace, cx);
         })
         .detach();
 


### PR DESCRIPTION
Replaces the placeholder stub with actual logic for reducing motion based on the system setting.
Verified on macOS, will need triage on Windows and all the Linux environments.