### PR TITLE
fix(views): keep track artwork scoped to its row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Local track lists keep each row's own embedded cover art when the table is sorted or recycled.
 - On macOS, a socket file left behind by a crash no longer disables single-instance handling: the
   next launch notices nothing is listening, takes the socket over, and later launches and
   `spotify:` links reach that window again instead of opening a second Sonora.

--- a/crates/music/src/local/wire.rs
+++ b/crates/music/src/local/wire.rs
@@ -477,14 +477,14 @@ fn cache_image_data(data: &[u8], media_type_or_ext: &str, cache_dir: &Path) -> O
 #[cfg(test)]
 mod tests {
     use super::*;
-  
+
     fn scratch(name: &str) -> std::path::PathBuf {
         let dir = std::env::temp_dir().join(name);
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         dir
     }
-  
+
     #[test]
     fn infer_stem_with_title_and_artist() {
         let (title, artist) = infer_from_stem("Chann Vi Gawah - Madhav Mahajan");

--- a/crates/ui/src/artwork.rs
+++ b/crates/ui/src/artwork.rs
@@ -4,9 +4,9 @@ use crate::theme::ActiveTheme as _;
 use futures::AsyncReadExt as _;
 use gpui::prelude::*;
 use gpui::{
-    App, Asset, AssetLogger, Context, Div, Entity, Global, Hsla, ImageCache, ImageCacheError,
-    ImageSource, Interactivity, ObjectFit, Pixels, RenderImage, Resource, SharedString, SharedUri,
-    StyleRefinement, Styled, Task, Window, div, img, px, svg,
+    App, Asset, AssetLogger, Context, Div, ElementId, Entity, Global, Hsla, ImageCache,
+    ImageCacheError, ImageSource, Interactivity, ObjectFit, Pixels, RenderImage, Resource,
+    SharedString, SharedUri, StyleRefinement, Styled, Task, Window, div, img, px, svg,
 };
 use image::{
     AnimationDecoder, DynamicImage, Frame, ImageDecoder, ImageFormat, RgbaImage,
@@ -605,6 +605,11 @@ impl Artwork {
 
     pub fn size(mut self, size: Pixels) -> Self {
         self.size = size;
+        self
+    }
+
+    pub fn id(mut self, id: impl Into<ElementId>) -> Self {
+        self.interactivity.element_id = Some(id.into());
         self
     }
 

--- a/crates/views/src/shared/cells.rs
+++ b/crates/views/src/shared/cells.rs
@@ -56,6 +56,7 @@ impl RenderOnce for Glyph {
 
 #[derive(IntoElement)]
 struct Thumb {
+    row: usize,
     url: Option<String>,
 }
 
@@ -63,7 +64,9 @@ impl RenderOnce for Thumb {
     fn render(self, _: &mut Window, cx: &mut App) -> impl IntoElement {
         let theme = cx.theme();
 
-        Artwork::new(self.url).size(theme.metrics.thumb)
+        Artwork::new(self.url)
+            .id(("artwork", self.row))
+            .size(theme.metrics.thumb)
     }
 }
 
@@ -377,7 +380,9 @@ pub(crate) fn title<F>(
 }
 
 pub(crate) fn artwork<F>(cell: &Cell<F>, url: Option<String>) -> AnyElement {
-    cell.middle().child(Thumb { url }).into_any_element()
+    cell.middle()
+        .child(Thumb { row: cell.row, url })
+        .into_any_element()
 }
 
 pub(crate) fn avatar<F>(cell: &Cell<F>, url: Option<String>) -> AnyElement {


### PR DESCRIPTION
Fixes #437

## Summary
- give each table artwork node a stable source-row identity
- preserve that identity through the reusable Artwork component

## Validation
- cargo fmt --all -- --check
- cargo check -p views
- cargo test -p views shared::cells::tests --lib
- cargo clippy -p views --all-targets -- -D warnings
