### PR TITLE
fix(local): cache cover thumbnails under xdg cache dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Changing the audio output restarts playback on the selected device.
 - Artwork uses less memory while images load and remain cached.
 
+### Fixed
+
+- Local music cover thumbnails are cached under `$XDG_CACHE_HOME` instead of `$XDG_CONFIG_HOME`.
+
 ## [0.29.0] - 2026-09-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,7 @@ construction, layout and scene assembly, never GPU fill.
 | Settings          | `$XDG_CONFIG_HOME/sonora/settings.json` (durable preferences and local music folder)                                              |
 | App state         | `$XDG_DATA_HOME/sonora/state.sqlite` (window/layout/playback state, pins, history, local playlists, usage flags)                  |
 | Credentials cache | `$XDG_CACHE_HOME/sonora/<provider>/credentials.json`, one per provider slug (`spotify`, `youtube`), owner-only mode                |
+| Local cover cache | `$XDG_CACHE_HOME/sonora/local-covers/`                                                                                             |
 | OAuth redirect    | `http://127.0.0.1:8989/login`, override with `SONORA_REDIRECT_URI`                                                                |
 | Instance socket   | `sonora.sock`, `sonora-dev.sock` in debug builds, so `cargo run` starts beside an installed Sonora rather than handing over to it |
 | Log file          | `$XDG_STATE_HOME/sonora/sonora.log`, rotated to `.1` past 8 MiB                                                                   |

--- a/crates/sonora/src/main.rs
+++ b/crates/sonora/src/main.rs
@@ -68,7 +68,7 @@ fn main() {
         ];
         let local_provider: Arc<dyn music::MusicProvider> =
             Arc::new(music::local::LocalProvider::new(
-                dirs::config_dir()
+                dirs::cache_dir()
                     .unwrap_or_else(std::env::temp_dir)
                     .join("sonora"),
                 database.clone(),


### PR DESCRIPTION
# Summary

- move local cover cache from the XDG config directory to the XDG cache directory