### PR TITLE
fix(views): align fullscreen lyrics controls

### DIFF
--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -1723,7 +1723,9 @@ impl Render for Aside {
                     cx.notify();
                 }
             }))
-            .child(self.header(sections, window, cx))
+            .when(self.titled || self.tab == SideTab::Queue, |this| {
+                this.child(self.header(sections, window, cx))
+            })
             .child(
                 div()
                     .id("queue-drop")

--- a/crates/views/src/shells/fullscreen.rs
+++ b/crates/views/src/shells/fullscreen.rs
@@ -19,7 +19,7 @@ use ui::{
     clock, snapped,
 };
 
-use crate::chrome::{Aside, TitleBarOptions};
+use crate::chrome::{Aside, PlayerBar, TitleBarOptions};
 use crate::shared::menus::ItemMenu;
 use crate::shared::transport::{NOTCH, like, moved, percent, transport, volume_icon};
 use crate::shared::visualizer::VisualizerDrive;
@@ -854,8 +854,9 @@ impl FullscreenView {
     fn leave(&self) -> Button {
         Button::new("leave-fullscreen")
             .ghost()
+            .small()
             .icon("icons/chevron-down.svg")
-            .tooltip("player-fullscreen-leave")
+            .tooltip_above("player-fullscreen-leave")
             .on_click(|_, window, cx| window.dispatch_action(Box::new(ToggleFullscreen), cx))
     }
 }
@@ -1023,8 +1024,18 @@ impl Render for FullscreenView {
                 this.child(
                     div()
                         .absolute()
-                        .top(px(SINK) * -hide)
-                        .right_3()
+                        .bottom(px(SINK) * -hide)
+                        .right_5()
+                        .h(PlayerBar::height(window, cx))
+                        .flex()
+                        .flex_col()
+                        .justify_center()
+                        .when(!room.fits(Room::Roomy), |this| {
+                            // Match the second row of the compact player bar.
+                            this.py_2()
+                                .gap_2()
+                                .child(div().h(snapped(theme.metrics.row, window)).flex_none())
+                        })
                         .opacity(1. - hide)
                         .child(self.leave()),
                 )


### PR DESCRIPTION
Move the fullscreen exit button from the top right to the player bar's fullscreen entry position at the bottom right, matching its small size and compact two-row layout. Show the exit tooltip above the button.

Remove the empty header from fullscreen lyrics so the lyrics area extends upward. Keep headers for the regular sidebar and queue controls.

Validation: `cargo check --locked --offline -p views`, rustfmt checks for both changed files, and `git diff --check` passed. The user visually verified both changes in the app.
