### PR TITLE
fix(youtube): keep the cookies google refreshes after a sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `spotify:` links reach that window again instead of opening a second Sonora.
 - Local music now carries a date added, taken from when each file was last changed, so the Date
   added column fills in and sorting songs, albums and artists by it works.
+- A YouTube Music sign-in now keeps the cookies Google refreshes during a session, and writes them
+  to `cookies.json` beside the credential file. The pasted cookies no longer stop working when
+  Google rotates them.
 
 ## [0.31.0] - 2026-09-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,6 +1172,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5639,6 +5668,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
 name = "psm"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5646,6 +5681,16 @@ checksum = "4dcd034599e63b970727f70d79e02d62390a4a84f7c6b827c27c46d5ac3fa622"
 dependencies = [
  "ar_archive_writer",
  "cc",
+]
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
 ]
 
 [[package]]
@@ -6141,6 +6186,8 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -6172,6 +6219,18 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest_cookie_store"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e75bc88d954b228850d19e3685cedb38c030a17da34aa01c307f95d6e33de34"
+dependencies = [
+ "bytes",
+ "cookie_store",
+ "reqwest",
+ "url",
 ]
 
 [[package]]
@@ -9733,20 +9792,18 @@ dependencies = [
 [[package]]
 name = "ytmusic"
 version = "0.1.0"
-source = "git+https://github.com/nolight132/ytmusic-rs?rev=0b2b13a32c16e4245b6c9001f8088a75c83a638c#0b2b13a32c16e4245b6c9001f8088a75c83a638c"
+source = "git+https://github.com/nolight132/ytmusic-rs?rev=736995285a283a7c1d8e158ac1361c30bcea2913#736995285a283a7c1d8e158ac1361c30bcea2913"
 dependencies = [
- "aes",
  "anyhow",
  "async-trait",
  "base64",
- "cbc",
+ "cookie_store",
  "log",
- "pbkdf2",
  "rand 0.9.5",
  "regex-lite",
  "reqwest",
+ "reqwest_cookie_store",
  "rquickjs",
- "rusqlite",
  "serde",
  "serde_json",
  "sha1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ symphonia = { version = "0.5.5", default-features = false, features = ["mkv", "o
 tray-icon = { version = "0.24", default-features = false }
 unic-langid = { version = "0.9", features = ["macros"] }
 unicode-segmentation = "1.12"
-ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "0b2b13a32c16e4245b6c9001f8088a75c83a638c" }
+ytmusic = { git = "https://github.com/nolight132/ytmusic-rs", rev = "736995285a283a7c1d8e158ac1361c30bcea2913" }
 
 librespot-core = { version = "0.8.0", default-features = false, features = [
   "rustls-tls-native-roots",

--- a/crates/music/Cargo.toml
+++ b/crates/music/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [features]
-bundled-sqlite = ["rusqlite/bundled", "storage/bundled-sqlite", "ytmusic/bundled-sqlite"]
+bundled-sqlite = ["rusqlite/bundled", "storage/bundled-sqlite"]
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/music/src/youtube/mod.rs
+++ b/crates/music/src/youtube/mod.rs
@@ -36,6 +36,9 @@ enum Saved {
 
 pub struct YouTubeProvider {
     credentials: PathBuf,
+    /// The cookie store ytmusic writes back to as Google rotates the session. The pasted
+    /// header in the credential file seeds it when it is missing.
+    cookies: PathBuf,
     resolved: PathBuf,
     player: PathBuf,
 }
@@ -45,6 +48,7 @@ impl YouTubeProvider {
         let cache = credentials::dir("youtube");
         Self {
             credentials: cache.join(credentials::FILE),
+            cookies: cache.join("cookies.json"),
             resolved: cache.join("resolved.json"),
             player: cache.join("player.json"),
         }
@@ -69,6 +73,7 @@ impl YouTubeProvider {
         Arc::new(
             YtMusic::with_cookies(cookies)
                 .as_user(authuser)
+                .persist_cookies(self.cookies.clone())
                 .cache_resolutions(self.resolved.clone())
                 .cache_player(self.player.clone()),
         )
@@ -118,6 +123,7 @@ impl YouTubeProvider {
         };
 
         let profile = wire::profile(account.profile.clone());
+        credentials::remove(&self.cookies);
         let api = self.cookie_client(&cookies, account.index);
         self.store_cookies(&cookies, account.index)?;
         log::debug!(
@@ -269,5 +275,6 @@ impl MusicProvider for YouTubeProvider {
 
     fn sign_out(&self) {
         credentials::remove(&self.credentials);
+        credentials::remove(&self.cookies);
     }
 }


### PR DESCRIPTION
## Summary

- keep the youtube session cookies google refreshes and write them to cookies.json beside the credential file
- seed the store from the pasted cookie header and replace it on a fresh sign-in
- delete the cookie store on sign-out
- point ytmusic at the rev that carries the cookie store and drop its removed bundled-sqlite feature