### PR TITLE
fix(sonora): hand over to a running instance before reading the socket error

### DIFF
--- a/crates/sonora/src/single.rs
+++ b/crates/sonora/src/single.rs
@@ -29,14 +29,19 @@ pub fn claim(link: Option<&str>, sender: UnboundedSender<String>) -> Instance {
     let listener = match ListenerOptions::new().name(name.clone()).create_sync() {
         Ok(listener) => listener,
 
-        Err(error) if error.kind() == ErrorKind::AddrInUse => {
-            // There's probably a running instance.
+        Err(error) => {
+            // Windows reports an occupied pipe with an error other than
+            // AddrInUse, so any failure may mean another Sonora owns the socket.
             if hand_over(name.clone(), link) {
                 return Instance::Running;
             }
 
-            // Nothing answered. On filesystem-backed Unix sockets this may
-            // be a stale socket left behind by an unclean shutdown.
+            // Only a filesystem socket can leave a stale AddrInUse behind.
+            if error.kind() != ErrorKind::AddrInUse {
+                log::error!("single: cannot own the instance socket: {error:#}");
+                return Instance::Failed;
+            }
+
             log::warn!("single: socket is occupied but unreachable; attempting recovery");
 
             match ListenerOptions::new()
@@ -47,15 +52,10 @@ pub fn claim(link: Option<&str>, sender: UnboundedSender<String>) -> Instance {
             {
                 Ok(listener) => listener,
                 Err(error) => {
-                    log::warn!("single: cannot recover instance socket: {error:#}");
-                    return Instance::First;
+                    log::error!("single: cannot recover instance socket: {error:#}");
+                    return Instance::Failed;
                 }
             }
-        }
-
-        Err(error) => {
-            log::error!("single: cannot own the instance socket: {error:#}");
-            return Instance::Failed;
         }
     };
 


### PR DESCRIPTION
## Summary

- try to hand a link to a running instance on any socket error, not only AddrInUse, so a second sonora on windows reaches the first one
- exit instead of starting without a socket when a stale one cannot be recovered