### PR TITLE
fix(flatpak): follow the sonorahq move and show the tray inside the sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `sonorahq.github.io/sonora`. A remote added before the move needs
   `flatpak remote-modify --user --url=https://sonorahq.github.io/sonora/repo sonora` once.
 
+- The Flatpak shows its tray icon on KDE Plasma and other StatusNotifier desktops, so Close to
+  tray keeps Sonora playing after the window closes. The sandbox forbids the well-known bus name
+  the tray used to claim, and Sonora now registers under its unique connection name instead.
+
 - On macOS, a socket file left behind by a crash no longer disables single-instance handling: the
   next launch notices nothing is listening, takes the socket over, and later launches and
   `spotify:` links reach that window again instead of opening a second Sonora.

--- a/crates/sonora/src/tray/sni.rs
+++ b/crates/sonora/src/tray/sni.rs
@@ -8,6 +8,8 @@ use super::{Event, Shown};
 const ID: &str = "sonora";
 const ICON_NAME: &str = "sonora";
 const PNG: &[u8] = include_bytes!("../../../../assets/tray/sonora.png");
+/// Flatpak writes this file into every sandbox it starts.
+const FLATPAK_INFO: &str = "/.flatpak-info";
 
 pub struct Icon {
     handle: Handle<Item>,
@@ -39,7 +41,11 @@ impl Icon {
             pixmap,
             shown: None,
         };
-        match item.spawn() {
+        // A sandbox cannot own `org.kde.StatusNotifierItem-<pid>-<n>`, and a manifest cannot
+        // grant it: flatpak's own-name wildcard only matches a `.*` suffix. The watcher
+        // accepts the unique bus name instead.
+        let sandboxed = std::path::Path::new(FLATPAK_INFO).exists();
+        match item.disable_dbus_name(sandboxed).spawn() {
             Ok(handle) => Some(Self { handle }),
             Err(error) => {
                 log::warn!("tray: cannot reach the status notifier host: {error}");


### PR DESCRIPTION
## Summary

- point the flatpak remote and the standalone bundles at sonorahq.github.io
- tell an existing remote how to move to the new address
- register the tray without a well-known bus name inside the flatpak sandbox
- fixes #480