### PR TITLE
feat(music): play free Spotify accounts through YouTube Music

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- A Spotify account without Premium signs in and plays its music anyway: the login is accepted and
+  each track is matched and streamed from YouTube Music instead of Spotify's own audio. The bridge
+  reuses a YouTube Music account already saved on this device, falling back to an anonymous guest
+  when none is stored.
 - On macOS, Sonora follows the platform's shortcuts: `⌘W` closes the window, `⌘M` minimises it,
   `⌃⌘F` toggles native full screen, `⌘H` and `⌥⌘H` hide Sonora or everything else, and `⌘[` / `⌘]`
   step through history. Text fields take the Cocoa conventions too: `⌥` arrows and `⌥⌫` work by

--- a/assets/i18n/de/main.ftl
+++ b/assets/i18n/de/main.ftl
@@ -256,7 +256,6 @@ login-problem-credentials = Deine gespeicherte Spotify-Sitzung ist nicht mehr g�
 login-problem-network = Sonora konnte Spotify nicht erreichen. Prüfe deine Internetverbindung und versuche es erneut.
 login-problem-cancelled = Du hast die Browserseite geschlossen, bevor die Anmeldung bestätigt war. Fang noch einmal an, um sie abzuschließen.
 login-problem-refused = Spotify hat die Anmeldung abgelehnt. Warte einen Moment und versuche es erneut.
-login-problem-premium = Sonora streamt über Spotify Premium, und dieses Konto hat es nicht. Melde dich mit einem Premium-Konto an, um fortzufahren.
 login-sign-in = Mit { $provider } anmelden
 login-connect-cookies = Cookies manuell einfügen
 login-use = { $provider } verwenden

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -256,7 +256,6 @@ login-problem-credentials = Your saved Spotify session is no longer valid. Sign 
 login-problem-network = Sonora could not reach Spotify. Check your internet connection and try again.
 login-problem-cancelled = You closed the browser page before approving the sign-in. Start again to finish.
 login-problem-refused = Spotify turned down the sign-in. Wait a moment and try again.
-login-problem-premium = Sonora streams through Spotify Premium, and this account does not have it. Sign in with a Premium account to continue.
 login-sign-in = Sign in with { $provider }
 login-connect-cookies = Paste cookies manually
 login-use = Use { $provider }

--- a/assets/i18n/es/main.ftl
+++ b/assets/i18n/es/main.ftl
@@ -250,7 +250,6 @@ login-problem-credentials = Tu sesión guardada de Spotify ya no es válida. Ini
 login-problem-network = Sonora no pudo conectarse con Spotify. Revisa tu conexión a internet e inténtalo de nuevo.
 login-problem-cancelled = Cerraste la página del navegador antes de aprobar el inicio de sesión. Empieza de nuevo para terminar.
 login-problem-refused = Spotify rechazó el inicio de sesión. Espera un momento e inténtalo de nuevo.
-login-problem-premium = Sonora reproduce a través de Spotify Premium y esta cuenta no lo tiene. Inicia sesión con una cuenta Premium para continuar.
 login-sign-in = Iniciar sesión con { $provider }
 login-connect-cookies = Pegar las cookies manualmente
 login-use = Usar { $provider }

--- a/assets/i18n/fr/main.ftl
+++ b/assets/i18n/fr/main.ftl
@@ -188,7 +188,6 @@ login-problem-credentials = Votre session Spotify enregistrée n'est plus valide
 login-problem-network = Sonora n'a pas pu joindre Spotify. Vérifiez votre connexion internet et réessayez.
 login-problem-cancelled = Vous avez fermé la page du navigateur avant d'approuver la connexion. Recommencez pour aller au bout.
 login-problem-refused = Spotify a refusé la connexion. Patientez un instant et réessayez.
-login-problem-premium = Sonora diffuse via Spotify Premium, et ce compte ne l'a pas. Connectez-vous avec un compte Premium pour continuer.
 login-sign-in = Se connecter avec { $provider }
 login-connect-cookies = Coller les cookies manuellement
 login-use = Utiliser { $provider }

--- a/assets/i18n/id/main.ftl
+++ b/assets/i18n/id/main.ftl
@@ -256,7 +256,6 @@ login-problem-credentials = Sesi Spotify tersimpan Anda sudah tidak berlaku. Mas
 login-problem-network = Sonora tidak dapat menghubungi Spotify. Periksa koneksi internet Anda dan coba lagi.
 login-problem-cancelled = Anda menutup halaman browser sebelum menyetujui login. Mulai lagi untuk menyelesaikan.
 login-problem-refused = Spotify menolak permintaan login. Tunggu sebentar dan coba lagi.
-login-problem-premium = Sonora memerlukan Spotify Premium untuk streaming. Akun ini tidak memiliki Premium. Masuk dengan akun Premium untuk melanjutkan.
 login-sign-in = Masuk dengan { $provider }
 login-connect-cookies = Tempel cookie manual
 login-use = Gunakan { $provider }

--- a/assets/i18n/it/main.ftl
+++ b/assets/i18n/it/main.ftl
@@ -188,7 +188,6 @@ login-problem-credentials = La tua sessione Spotify salvata non è più valida. 
 login-problem-network = Sonora non è riuscita a raggiungere Spotify. Controlla la connessione internet e riprova.
 login-problem-cancelled = Hai chiuso la pagina del browser prima di approvare l'accesso. Ricomincia per completare.
 login-problem-refused = Spotify ha rifiutato l'accesso. Attendi un momento e riprova.
-login-problem-premium = Sonora trasmette tramite Spotify Premium e questo account non lo possiede. Accedi con un account Premium per continuare.
 login-sign-in = Accedi con { $provider }
 login-connect-cookies = Incolla i cookie manualmente
 login-use = Usa { $provider }

--- a/assets/i18n/ja/main.ftl
+++ b/assets/i18n/ja/main.ftl
@@ -211,7 +211,6 @@ login-problem-credentials = 保存された Spotify のセッションは無効�
 login-problem-network = Spotify に接続できませんでした。インターネット接続を確認してもう一度お試しください。
 login-problem-cancelled = サインインを承認する前にブラウザのページが閉じられました。最初からやり直してください。
 login-problem-refused = Spotify がサインインを拒否しました。しばらく待ってからもう一度お試しください。
-login-problem-premium = Sonora は Spotify Premium でストリーミングしますが、このアカウントは Premium プランに加入していません。続けるには Premium アカウントでサインインしてください。
 login-sign-in = { $provider } でサインイン
 login-connect-cookies = Cookie を手動で貼り付け
 login-use = { $provider } を使う

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -270,7 +270,6 @@ login-problem-credentials = Zapisana sesja Spotify straciła ważność. Zaloguj
 login-problem-network = Sonora nie mogła połączyć się ze Spotify. Sprawdź połączenie internetowe i spróbuj ponownie.
 login-problem-cancelled = Zamknięto stronę przeglądarki przed zatwierdzeniem logowania. Zacznij od nowa.
 login-problem-refused = Spotify odrzucił logowanie. Odczekaj chwilę i spróbuj ponownie.
-login-problem-premium = Sonora odtwarza muzykę przez Spotify Premium, a to konto go nie ma. Zaloguj się na konto z Premium, aby kontynuować.
 login-sign-in = Zaloguj się przez { $provider }
 login-connect-cookies = Wklej pliki cookie ręcznie
 login-use = Otwórz { $provider }

--- a/assets/i18n/pt-BR/main.ftl
+++ b/assets/i18n/pt-BR/main.ftl
@@ -250,7 +250,6 @@ login-problem-credentials = Sua sessão salva do Spotify não é mais válida. F
 login-problem-network = O Sonora não conseguiu acessar o Spotify. Verifique sua conexão com a internet e tente novamente.
 login-problem-cancelled = Você fechou a página do navegador antes de aprovar o login. Recomece para finalizar.
 login-problem-refused = O Spotify recusou o login. Aguarde um momento e tente novamente.
-login-problem-premium = O Sonora usa o Spotify Premium para reproduzir, e esta conta não possui o plano. Faça login com uma conta Premium para continuar.
 login-sign-in = Entrar com { $provider }
 login-connect-cookies = Colar cookies manualmente
 login-use = Usar { $provider }

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -188,7 +188,6 @@ login-problem-credentials = Сохранённая сессия Spotify боль
 login-problem-network = Sonora не смогла связаться со Spotify. Проверьте интернет-соединение и попробуйте снова.
 login-problem-cancelled = Вы закрыли страницу браузера, не подтвердив вход. Начните заново.
 login-problem-refused = Spotify отклонил вход. Подождите немного и попробуйте снова.
-login-problem-premium = Sonora воспроизводит музыку через Spotify Premium, а у этого аккаунта его нет. Войдите в аккаунт с Premium, чтобы продолжить.
 login-sign-in = Войти через { $provider }
 login-connect-cookies = Вставить cookie вручную
 login-use = Открыть { $provider }

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -188,7 +188,6 @@ login-problem-credentials = Збережена сесія Spotify більше �
 login-problem-network = Sonora не змогла зв'язатися зі Spotify. Перевірте інтернет-з'єднання та спробуйте ще раз.
 login-problem-cancelled = Ви закрили сторінку браузера, не підтвердивши вхід. Почніть знову.
 login-problem-refused = Spotify відхилив вхід. Зачекайте трохи і спробуйте ще раз.
-login-problem-premium = Sonora відтворює музику через Spotify Premium, а цей акаунт його не має. Увійдіть в акаунт з Premium, щоб продовжити.
 login-sign-in = Увійти через { $provider }
 login-connect-cookies = Вставити cookie вручну
 login-use = Відкрити { $provider }

--- a/crates/music/examples/lyrics-prober.rs
+++ b/crates/music/examples/lyrics-prober.rs
@@ -128,7 +128,7 @@ async fn resolve(link: &str) -> Result<(Track, &'static str, Option<Arc<Librespo
         return Ok((track, "youtube", None));
     }
 
-    let session = auth::restore(&AuthConfig::from_env())
+    let auth::Connected { session, .. } = auth::restore(&AuthConfig::from_env())
         .await
         .context("cannot restore the cached session")?
         .context("no cached credentials; sign in with sonora first")?;

--- a/crates/music/examples/lyrics_bench.rs
+++ b/crates/music/examples/lyrics_bench.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<()> {
         .and_then(|value| value.parse().ok())
         .unwrap_or(2000);
 
-    let session = auth::restore(&AuthConfig::from_env())
+    let auth::Connected { session, .. } = auth::restore(&AuthConfig::from_env())
         .await
         .context("cannot restore the cached session")?
         .context("no cached credentials; sign in with sonora first")?;

--- a/crates/music/src/hybrid.rs
+++ b/crates/music/src/hybrid.rs
@@ -1,0 +1,399 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context as _, Result};
+use async_trait::async_trait;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+use ytmusic::YtMusic;
+
+use crate::youtube::{self, playback::refusal};
+use crate::{
+    MusicApi, PlaybackConfig, PlaybackEvent, PlaybackEvents, PlaybackFactory, Player, Spectrum,
+};
+
+enum Command {
+    Load {
+        id: String,
+        at: Option<Duration>,
+        seamless: bool,
+    },
+    Preload {
+        id: String,
+        segue: bool,
+    },
+    Play,
+    Pause,
+    Seek(Duration),
+    Gain(f32),
+}
+
+struct Resolve {
+    epoch: u64,
+    kind: Kind,
+    id: String,
+    at: Option<Duration>,
+    seamless: bool,
+    segue: bool,
+}
+
+pub struct HybridFactory {
+    spotify: Arc<dyn MusicApi>,
+    youtube: Arc<YtMusic>,
+}
+
+impl HybridFactory {
+    pub fn new(spotify: Arc<dyn MusicApi>, youtube: Arc<YtMusic>) -> Self {
+        Self { spotify, youtube }
+    }
+}
+
+impl PlaybackFactory for HybridFactory {
+    fn start(&self, config: PlaybackConfig) -> (Box<dyn Player>, Box<dyn PlaybackEvents>) {
+        let (inner, inner_events) =
+            youtube::playback::Factory::new(self.youtube.clone()).start(config);
+        let spectrum = inner.spectrum();
+
+        let (commands, command_rx) = unbounded_channel();
+        let (events, event_rx) = unbounded_channel();
+        let spotify = self.spotify.clone();
+        let youtube = self.youtube.clone();
+        let failure = events.clone();
+
+        let spawned = std::thread::Builder::new()
+            .name("hybrid-playback".to_string())
+            .spawn(move || run(spotify, youtube, inner, inner_events, command_rx, events));
+        if let Err(error) = spawned {
+            log::error!("hybrid: cannot spawn bridge thread: {error}");
+            failure.send(PlaybackEvent::Unavailable { id: None }).ok();
+        }
+
+        (
+            Box::new(Engine { commands, spectrum }),
+            Box::new(Events(event_rx)),
+        )
+    }
+}
+
+struct Engine {
+    commands: UnboundedSender<Command>,
+    spectrum: Option<Spectrum>,
+}
+
+impl Player for Engine {
+    fn load(&self, track_id: &str, seamless: bool) -> Result<()> {
+        self.commands
+            .send(Command::Load {
+                id: track_id.to_string(),
+                at: None,
+                seamless,
+            })
+            .context("cannot reach the hybrid playback engine")
+    }
+
+    fn load_paused_at(&self, track_id: &str, at: Duration) -> Result<()> {
+        self.commands
+            .send(Command::Load {
+                id: track_id.to_string(),
+                at: Some(at),
+                seamless: false,
+            })
+            .context("cannot reach the hybrid playback engine")
+    }
+
+    fn preload(&self, track_id: &str, segue: bool) -> Result<()> {
+        self.commands
+            .send(Command::Preload {
+                id: track_id.to_string(),
+                segue,
+            })
+            .context("cannot reach the hybrid playback engine")
+    }
+
+    fn play(&self) {
+        self.commands.send(Command::Play).ok();
+    }
+
+    fn pause(&self) {
+        self.commands.send(Command::Pause).ok();
+    }
+
+    fn seek(&self, position: Duration) {
+        self.commands.send(Command::Seek(position)).ok();
+    }
+
+    fn set_gain(&self, gain: f32) {
+        self.commands.send(Command::Gain(gain)).ok();
+    }
+
+    fn spectrum(&self) -> Option<Spectrum> {
+        self.spectrum.clone()
+    }
+}
+
+struct Events(UnboundedReceiver<PlaybackEvent>);
+
+#[async_trait]
+impl PlaybackEvents for Events {
+    async fn next(&mut self) -> Option<PlaybackEvent> {
+        self.0.recv().await
+    }
+}
+
+fn run(
+    spotify: Arc<dyn MusicApi>,
+    youtube: Arc<YtMusic>,
+    inner: Box<dyn Player>,
+    inner_events: Box<dyn PlaybackEvents>,
+    commands: UnboundedReceiver<Command>,
+    events: UnboundedSender<PlaybackEvent>,
+) {
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            log::error!("hybrid: cannot build bridge runtime: {error}");
+            return;
+        }
+    };
+    runtime.block_on(engine_loop(
+        spotify,
+        youtube,
+        inner,
+        inner_events,
+        commands,
+        events,
+    ));
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Kind {
+    Play,
+    Ahead,
+}
+
+struct Resolved {
+    epoch: u64,
+    id: String,
+    kind: Kind,
+    at: Option<Duration>,
+    seamless: bool,
+    segue: bool,
+    video: Result<String>,
+}
+
+async fn engine_loop(
+    spotify: Arc<dyn MusicApi>,
+    youtube: Arc<YtMusic>,
+    inner: Box<dyn Player>,
+    mut inner_events: Box<dyn PlaybackEvents>,
+    mut commands: UnboundedReceiver<Command>,
+    events: UnboundedSender<PlaybackEvent>,
+) {
+    let mut cache: Option<(String, String)> = None;
+    let (resolved, mut arrivals) = unbounded_channel::<Resolved>();
+
+    let mut epoch = 0u64;
+    let mut current_id: Option<String> = None;
+    let mut pending: Option<u64> = None;
+    let mut inflight: Option<tokio::task::AbortHandle> = None;
+
+    loop {
+        tokio::select! {
+            command = commands.recv() => {
+                let Some(command) = command else { break };
+                match command {
+                    Command::Load { id, at, seamless } => {
+                        epoch += 1;
+                        current_id = Some(id.clone());
+                        if let Some(handle) = inflight.take() {
+                            handle.abort();
+                        }
+                        pending = None;
+                        let cached = cache.as_ref().filter(|(s, _)| *s == id).map(|(_, v)| v.clone());
+                        if cached.is_none() {
+                            pending = Some(epoch);
+                            inflight = Some(spawn_resolve(
+                                &spotify,
+                                &youtube,
+                                Resolve { epoch, kind: Kind::Play, id: id.clone(), at, seamless, segue: false },
+                                &resolved,
+                            ));
+                        }
+                        cache = None;
+                        let Some(video_id) = cached else { continue };
+                        cache = Some((id.clone(), video_id.clone()));
+                        load(&*inner, &video_id, at, seamless);
+                    }
+                    Command::Preload { id, segue } => {
+                        if cache.as_ref().is_some_and(|(s, _)| *s == id) {
+                            continue;
+                        }
+                        spawn_resolve(
+                            &spotify,
+                            &youtube,
+                            Resolve { epoch, kind: Kind::Ahead, id, at: None, seamless: false, segue },
+                            &resolved,
+                        );
+                    }
+                    Command::Play => inner.play(),
+                    Command::Pause => inner.pause(),
+                    Command::Seek(position) => inner.seek(position),
+                    Command::Gain(gain) => inner.set_gain(gain),
+                }
+            }
+            arrival = arrivals.recv() => {
+                let Some(Resolved { epoch: arrived, id, kind, at, seamless, segue, video }) = arrival
+                else {
+                    break;
+                };
+                if arrived != epoch {
+                    continue;
+                }
+                match kind {
+                    Kind::Play => {
+                        if pending != Some(arrived) {
+                            continue;
+                        }
+                        pending = None;
+                        inflight = None;
+                        match video {
+                            Ok(video_id) => {
+                                cache = Some((id.clone(), video_id.clone()));
+                                load(&*inner, &video_id, at, seamless);
+                            }
+                            Err(error) => {
+                                log::warn!("hybrid: no YouTube Music match for {id}: {error:#}");
+                                events.send(refusal(id, &error)).ok();
+                            }
+                        }
+                    }
+                    Kind::Ahead => {
+                        let Ok(video_id) = video else { continue };
+                        cache = Some((id.clone(), video_id.clone()));
+                        if let Err(error) = inner.preload(&video_id, segue) {
+                            log::warn!("hybrid: cannot preload {id}: {error:#}");
+                        }
+                    }
+                }
+            }
+            event = inner_events.next() => {
+                let Some(event) = event else { break };
+                events.send(embed_id(event, current_id.as_deref())).ok();
+            }
+        }
+    }
+}
+
+async fn resolve(
+    spotify: &Arc<dyn MusicApi>,
+    youtube: &Arc<YtMusic>,
+    spotify_track_id: &str,
+) -> Result<String> {
+    let track = spotify
+        .track(spotify_track_id)
+        .await
+        .context("cannot read the track's metadata from Spotify")?;
+
+    let artists = match track.artist_refs.is_empty() {
+        true => track.artists.clone(),
+        false => track
+            .artist_refs
+            .iter()
+            .map(|a| a.name.as_str())
+            .collect::<Vec<_>>()
+            .join(" "),
+    };
+    let query = if track.album.is_empty() {
+        format!("{} {artists}", track.name)
+    } else {
+        format!("{} {artists} {}", track.name, track.album)
+    };
+    let candidates = youtube
+        .search_songs(&query)
+        .await
+        .context("cannot search YouTube Music")?;
+
+    candidates
+        .into_iter()
+        .find(|c| c.available && c.video_id.is_some())
+        .and_then(|c| c.video_id)
+        .context("no match on YouTube Music")
+}
+
+fn spawn_resolve(
+    spotify: &Arc<dyn MusicApi>,
+    youtube: &Arc<YtMusic>,
+    req: Resolve,
+    resolved: &UnboundedSender<Resolved>,
+) -> tokio::task::AbortHandle {
+    let spotify = spotify.clone();
+    let youtube = youtube.clone();
+    let resolved = resolved.clone();
+    let Resolve {
+        epoch,
+        kind,
+        id,
+        at,
+        seamless,
+        segue,
+    } = req;
+    tokio::spawn(async move {
+        let video = resolve(&spotify, &youtube, &id).await;
+        resolved
+            .send(Resolved {
+                epoch,
+                id,
+                kind,
+                at,
+                seamless,
+                segue,
+                video,
+            })
+            .ok();
+    })
+    .abort_handle()
+}
+
+fn load(inner: &dyn Player, video_id: &str, at: Option<Duration>, seamless: bool) {
+    let result = match at {
+        Some(at) => inner.load_paused_at(video_id, at),
+        None => inner.load(video_id, seamless),
+    };
+    if let Err(error) = result {
+        log::error!("hybrid: cannot hand a track to the YouTube Music engine: {error:#}");
+    }
+}
+
+fn embed_id(event: PlaybackEvent, id: Option<&str>) -> PlaybackEvent {
+    match event {
+        PlaybackEvent::Loading { at, .. } => PlaybackEvent::Loading {
+            id: id.map(str::to_owned),
+            at,
+        },
+        PlaybackEvent::Playing { at, .. } => PlaybackEvent::Playing {
+            id: id.map(str::to_owned),
+            at,
+        },
+        PlaybackEvent::Paused { at, .. } => PlaybackEvent::Paused {
+            id: id.map(str::to_owned),
+            at,
+        },
+        PlaybackEvent::Position { at, .. } => PlaybackEvent::Position {
+            id: id.map(str::to_owned),
+            at,
+        },
+        PlaybackEvent::Length { duration, .. } => PlaybackEvent::Length {
+            id: id.map(str::to_owned),
+            duration,
+        },
+        PlaybackEvent::Ended { .. } => PlaybackEvent::Ended {
+            id: id.map(str::to_owned),
+        },
+        PlaybackEvent::Unavailable { .. } => PlaybackEvent::Unavailable {
+            id: id.map(str::to_owned),
+        },
+        other => other,
+    }
+}

--- a/crates/music/src/lib.rs
+++ b/crates/music/src/lib.rs
@@ -1,6 +1,7 @@
 mod audio;
 pub mod binimum;
 pub mod credentials;
+mod hybrid;
 pub mod kugou;
 #[cfg(test)]
 mod live_tests;
@@ -257,7 +258,6 @@ pub enum SignIn {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SignInProblem {
-    Premium,
     Region,
     Credentials,
     Network,
@@ -271,7 +271,6 @@ pub struct SignInFailure(pub SignInProblem);
 impl std::fmt::Display for SignInFailure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let reason = match self.0 {
-            SignInProblem::Premium => "the account has no Spotify Premium",
             SignInProblem::Region => "the account is out of its home region",
             SignInProblem::Credentials => "the stored credentials are no longer valid",
             SignInProblem::Network => "Spotify could not be reached",

--- a/crates/music/src/live_tests/add_album.rs
+++ b/crates/music/src/live_tests/add_album.rs
@@ -14,7 +14,7 @@ const VERIFY_ATTEMPTS: usize = 30;
 #[tokio::test]
 #[ignore = "changes the saved albums of the connected Spotify account"]
 async fn spotify_can_add_and_remove_an_album_for_the_connected_account() -> Result<()> {
-    let provider = SpotifyProvider::from_env();
+    let provider = SpotifyProvider::from_env(ytmusic::YtMusic::anonymous().into());
     let session = connected(&provider).await?;
 
     exercise_album_cycles("Spotify", session.api.as_ref(), SPOTIFY_ALBUMS).await

--- a/crates/music/src/live_tests/follow_artist.rs
+++ b/crates/music/src/live_tests/follow_artist.rs
@@ -14,7 +14,7 @@ const VERIFY_ATTEMPTS: usize = 30;
 #[tokio::test]
 #[ignore = "changes the followed artists of the connected Spotify account"]
 async fn spotify_can_follow_and_unfollow_an_artist_for_the_connected_account() -> Result<()> {
-    let provider = SpotifyProvider::from_env();
+    let provider = SpotifyProvider::from_env(ytmusic::YtMusic::anonymous().into());
     let session = connected(&provider).await?;
 
     exercise_artist_cycles(session.api.as_ref(), SPOTIFY_ARTISTS).await

--- a/crates/music/src/live_tests/playlist_privacy.rs
+++ b/crates/music/src/live_tests/playlist_privacy.rs
@@ -13,7 +13,7 @@ const LIBRARY_LIMIT: u32 = 10_000;
 #[tokio::test]
 #[ignore = "creates, changes, and deletes a playlist on the connected Spotify account"]
 async fn spotify_can_make_a_playlist_public_and_private() -> Result<()> {
-    let provider = SpotifyProvider::from_env();
+    let provider = SpotifyProvider::from_env(ytmusic::YtMusic::anonymous().into());
     let session = connected(&provider).await?;
 
     exercise_playlist_privacy(session.api.as_ref()).await

--- a/crates/music/src/spotify/auth.rs
+++ b/crates/music/src/spotify/auth.rs
@@ -98,7 +98,12 @@ fn socket_address(uri: &str) -> Option<String> {
     }
 }
 
-pub async fn restore(config: &AuthConfig) -> Result<Option<Session>> {
+pub struct Connected {
+    pub session: Session,
+    pub premium: bool,
+}
+
+pub async fn restore(config: &AuthConfig) -> Result<Option<Connected>> {
     let session = session(config)?;
     let Some(credentials) = session.cache().and_then(|cache| cache.credentials()) else {
         return Ok(None);
@@ -106,11 +111,11 @@ pub async fn restore(config: &AuthConfig) -> Result<Option<Session>> {
 
     session.connect(credentials, true).await.map_err(denied)?;
     credentials::secure(&config.file());
-    premium(&session).await?;
-    Ok(Some(session))
+    let premium = is_premium(&session).await;
+    Ok(Some(Connected { session, premium }))
 }
 
-pub async fn login(config: &AuthConfig, prompt: PromptSink) -> Result<Session> {
+pub async fn login(config: &AuthConfig, prompt: PromptSink) -> Result<Connected> {
     let client_id = config.client_id.clone();
     let redirect_uri = config.redirect_uri.clone();
 
@@ -123,8 +128,8 @@ pub async fn login(config: &AuthConfig, prompt: PromptSink) -> Result<Session> {
         .await
         .map_err(denied)?;
     credentials::secure(&config.file());
-    premium(&session).await?;
-    Ok(session)
+    let premium = is_premium(&session).await;
+    Ok(Connected { session, premium })
 }
 
 fn authorize(client_id: &str, redirect_uri: &str, prompt: PromptSink) -> Result<String> {
@@ -188,20 +193,15 @@ fn authorize(client_id: &str, redirect_uri: &str, prompt: PromptSink) -> Result<
     Ok(response.access_token().secret().to_owned())
 }
 
-async fn premium(session: &Session) -> Result<()> {
+async fn is_premium(session: &Session) -> bool {
     let deadline = tokio::time::Instant::now() + PRODUCT_WAIT;
     loop {
         if let Some(account) = session.user_data().attributes.get("type") {
-            match account.as_str() {
-                "premium" => return Ok(()),
-                _ => {
-                    session.shutdown();
-                    return Err(anyhow::Error::new(SignInFailure(SignInProblem::Premium)));
-                }
-            }
+            return account.as_str() == "premium";
         }
         if tokio::time::Instant::now() >= deadline {
-            return Ok(());
+            log::warn!("auth: account type did not arrive in time; assuming Premium");
+            return true;
         }
         tokio::time::sleep(PRODUCT_POLL).await;
     }

--- a/crates/music/src/spotify/mod.rs
+++ b/crates/music/src/spotify/mod.rs
@@ -21,41 +21,44 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_trait::async_trait;
 
+use crate::hybrid::HybridFactory;
 use crate::spotify::playback::Factory;
-use crate::{MusicApi as _, MusicProvider, ProviderSession, SignInFailure, SignInProblem};
+use crate::{MusicApi, MusicProvider, PlaybackFactory, ProviderSession};
 
 pub use auth::AuthConfig;
 pub use client::LibrespotClient;
 
 pub struct SpotifyProvider {
     config: AuthConfig,
+    youtube: Arc<ytmusic::YtMusic>,
 }
 
 impl SpotifyProvider {
-    pub fn new(config: AuthConfig) -> Self {
-        Self { config }
+    pub fn new(config: AuthConfig, youtube: Arc<ytmusic::YtMusic>) -> Self {
+        Self { config, youtube }
     }
 
-    pub fn from_env() -> Self {
-        Self::new(AuthConfig::from_env())
+    pub fn from_env(youtube: Arc<ytmusic::YtMusic>) -> Self {
+        Self::new(AuthConfig::from_env(), youtube)
     }
 
-    fn drop_free(&self, error: anyhow::Error) -> anyhow::Error {
-        if matches!(
-            error.downcast_ref::<SignInFailure>(),
-            Some(SignInFailure(SignInProblem::Premium))
-        ) {
-            auth::forget(&self.config);
-        }
-        error
-    }
-
-    async fn session(&self, client: LibrespotClient) -> Result<ProviderSession> {
+    async fn session(&self, client: LibrespotClient, premium: bool) -> Result<ProviderSession> {
         let profile = client.profile().await?;
-        let playback = Arc::new(Factory::new(client.session().clone()));
+        let session = client.session().clone();
+        let api: Arc<dyn MusicApi> = Arc::new(client);
+
+        let playback: Arc<dyn PlaybackFactory> = if premium {
+            Arc::new(Factory::new(session))
+        } else {
+            log::info!(
+                "spotify: this account has no Premium; playing its tracks through YouTube Music"
+            );
+            Arc::new(HybridFactory::new(api.clone(), self.youtube.clone()))
+        };
+
         Ok(ProviderSession {
             profile,
-            api: Arc::new(client),
+            api,
             playback,
             authenticated: true,
             playcounts: true,
@@ -86,13 +89,12 @@ impl MusicProvider for SpotifyProvider {
     }
 
     async fn restore(&self) -> Result<Option<ProviderSession>> {
-        let Some(session) = auth::restore(&self.config)
-            .await
-            .map_err(|error| self.drop_free(error))?
-        else {
+        let Some(auth::Connected { session, premium }) = auth::restore(&self.config).await? else {
             return Ok(None);
         };
-        self.session(LibrespotClient::new(session)).await.map(Some)
+        self.session(LibrespotClient::new(session), premium)
+            .await
+            .map(Some)
     }
 
     async fn sign_in(
@@ -101,10 +103,8 @@ impl MusicProvider for SpotifyProvider {
         prompt: crate::PromptSink,
         _input: crate::InputSource,
     ) -> Result<ProviderSession> {
-        let session = auth::login(&self.config, prompt)
-            .await
-            .map_err(|error| self.drop_free(error))?;
-        self.session(LibrespotClient::new(session)).await
+        let auth::Connected { session, premium } = auth::login(&self.config, prompt).await?;
+        self.session(LibrespotClient::new(session), premium).await
     }
 
     fn sign_out(&self) {

--- a/crates/music/src/youtube/mod.rs
+++ b/crates/music/src/youtube/mod.rs
@@ -2,7 +2,7 @@ mod accounts;
 mod auth;
 mod client;
 mod genres;
-mod playback;
+pub(crate) mod playback;
 mod subscriptions;
 mod trim;
 mod wire;
@@ -81,6 +81,16 @@ impl YouTubeProvider {
 
     fn guest_client(&self) -> Arc<YtMusic> {
         Arc::new(YtMusic::anonymous().cache_player(self.player.clone()))
+    }
+
+    pub fn playback_client(&self) -> Arc<YtMusic> {
+        match self.saved() {
+            Some(Saved::Cookies { cookies, authuser }) => {
+                log::info!("youtube: reusing the signed-in account for hybrid playback");
+                self.cookie_client(&cookies, authuser)
+            }
+            _ => self.guest_client(),
+        }
     }
 
     fn authenticated_session(&self, api: Arc<YtMusic>, profile: UserProfile) -> ProviderSession {

--- a/crates/music/src/youtube/playback.rs
+++ b/crates/music/src/youtube/playback.rs
@@ -611,7 +611,7 @@ fn announce(
     events.send(event).ok();
 }
 
-fn refusal(id: String, error: &anyhow::Error) -> PlaybackEvent {
+pub(crate) fn refusal(id: String, error: &anyhow::Error) -> PlaybackEvent {
     match error.downcast_ref::<ytmusic::SignInRequired>().is_some() {
         true => PlaybackEvent::Gated,
         false => PlaybackEvent::Unavailable { id: Some(id) },

--- a/crates/sonora/src/main.rs
+++ b/crates/sonora/src/main.rs
@@ -62,10 +62,9 @@ fn main() {
         }
 
         let database = storage::Database::standard();
-        let providers: Vec<Arc<dyn music::MusicProvider>> = vec![
-            Arc::new(music::spotify::SpotifyProvider::from_env()),
-            Arc::new(music::youtube::YouTubeProvider::new()),
-        ];
+        let youtube = Arc::new(music::youtube::YouTubeProvider::new());
+        let spotify = music::spotify::SpotifyProvider::from_env(youtube.playback_client());
+        let providers: Vec<Arc<dyn music::MusicProvider>> = vec![Arc::new(spotify), youtube];
         let local_provider: Arc<dyn music::MusicProvider> =
             Arc::new(music::local::LocalProvider::new(
                 dirs::cache_dir()

--- a/crates/views/src/shared/trouble.rs
+++ b/crates/views/src/shared/trouble.rs
@@ -53,7 +53,6 @@ fn unwrapped_reason(text: &str) -> String {
 
 fn reason(problem: SignInProblem) -> &'static str {
     match problem {
-        SignInProblem::Premium => "login-problem-premium",
         SignInProblem::Region => "login-problem-region",
         SignInProblem::Credentials => "login-problem-credentials",
         SignInProblem::Network => "login-problem-network",


### PR DESCRIPTION
## Summary

- free Spotify accounts now sign in and play instead of hitting a paywall screen
- each track is looked up on YouTube Music using name, artist and album as the query
- reuses a signed-in YouTube Music account if one exists, otherwise goes anonymous
- drops `SignInProblem::Premium` since free accounts are no longer an error case
