### PR TITLE
feat(views): put a shuffle button beside play on collection pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- A Shuffle button sits beside Play on every album, playlist, artist and library page. It turns
+  shuffle on and starts the collection from a random track.
+
 - On macOS, Sonora follows the platform's shortcuts: `⌘W` closes the window, `⌘M` minimises it,
   `⌃⌘F` toggles native full screen, `⌘H` and `⌥⌘H` hide Sonora or everything else, and `⌘[` / `⌘]`
   step through history. Text fields take the Cocoa conventions too: `⌥` arrows and `⌥⌫` work by

--- a/README.md
+++ b/README.md
@@ -164,17 +164,17 @@ AI-assisted proofreading and translation of human-written text are permitted.
 
 | Language | Translated | Coverage |
 | --- | --- | --- |
-| English (`en-US`) | 532/532 | 100% |
-| Deutsch (`de`) | 532/532 | 100% |
-| Español (`es`) | 509/532 | 96% |
-| Français (`fr`) | 491/532 | 92% |
-| Italiano (`it`) | 488/532 | 92% |
-| Bahasa Indonesia (`id`) | 526/532 | 99% |
-| 日本語 (`ja`) | 509/532 | 96% |
-| Русский (`ru`) | 499/532 | 94% |
-| Українська (`uk`) | 499/532 | 94% |
-| Polski (`pl`) | 530/532 | 100% |
-| Português (Brasil) (`pt-BR`) | 509/532 | 96% |
+| English (`en-US`) | 533/533 | 100% |
+| Deutsch (`de`) | 533/533 | 100% |
+| Español (`es`) | 510/533 | 96% |
+| Français (`fr`) | 492/533 | 92% |
+| Italiano (`it`) | 489/533 | 92% |
+| Bahasa Indonesia (`id`) | 527/533 | 99% |
+| 日本語 (`ja`) | 510/533 | 96% |
+| Русский (`ru`) | 500/533 | 94% |
+| Українська (`uk`) | 500/533 | 94% |
+| Polski (`pl`) | 531/533 | 100% |
+| Português (Brasil) (`pt-BR`) | 510/533 | 96% |
 
 <!-- i18n:end -->
 

--- a/assets/i18n/de/main.ftl
+++ b/assets/i18n/de/main.ftl
@@ -287,6 +287,7 @@ detail-play-playlist = Playlist abspielen
 play-pause = Pause
 play-resume = Fortsetzen
 play-loading = Wird geladen…
+play-shuffle = Zufallswiedergabe
 
 # artist page
 artist-eyebrow = Künstler

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -287,6 +287,7 @@ detail-play-playlist = Play playlist
 play-pause = Pause
 play-resume = Resume
 play-loading = Loading…
+play-shuffle = Shuffle
 
 # artist page
 artist-eyebrow = Artist

--- a/assets/i18n/es/main.ftl
+++ b/assets/i18n/es/main.ftl
@@ -280,6 +280,7 @@ detail-play-playlist = Reproducir lista
 play-pause = Pausar
 play-resume = Reanudar
 play-loading = Cargando…
+play-shuffle = Aleatorio
 
 # artist page
 artist-eyebrow = Artista

--- a/assets/i18n/fr/main.ftl
+++ b/assets/i18n/fr/main.ftl
@@ -218,6 +218,7 @@ detail-play-playlist = Lire la playlist
 play-pause = Pause
 play-resume = Reprendre
 play-loading = Chargement…
+play-shuffle = Lecture aléatoire
 
 # artist page
 artist-eyebrow = Artiste

--- a/assets/i18n/id/main.ftl
+++ b/assets/i18n/id/main.ftl
@@ -286,6 +286,7 @@ detail-play-playlist = Putar playlist
 play-pause = Jeda
 play-resume = Lanjutkan
 play-loading = Memuat…
+play-shuffle = Acak
 
 # artist page
 artist-eyebrow = Artis

--- a/assets/i18n/it/main.ftl
+++ b/assets/i18n/it/main.ftl
@@ -218,6 +218,7 @@ detail-play-playlist = Riproduci playlist
 play-pause = Pausa
 play-resume = Riprendi
 play-loading = Caricamento…
+play-shuffle = Casuale
 
 # artist page
 artist-eyebrow = Artista

--- a/assets/i18n/ja/main.ftl
+++ b/assets/i18n/ja/main.ftl
@@ -241,6 +241,7 @@ detail-play-playlist = プレイリストを再生
 play-pause = 一時停止
 play-resume = 再開
 play-loading = 読み込み中…
+play-shuffle = シャッフル
 
 # artist page
 artist-eyebrow = アーティスト

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -301,6 +301,7 @@ detail-play-playlist = Odtwórz playlistę
 play-pause = Wstrzymaj
 play-resume = Wznów
 play-loading = Ładowanie…
+play-shuffle = Losowo
 
 # artist page
 artist-eyebrow = Wykonawca

--- a/assets/i18n/pt-BR/main.ftl
+++ b/assets/i18n/pt-BR/main.ftl
@@ -280,6 +280,7 @@ detail-play-playlist = Tocar playlist
 play-pause = Pausar
 play-resume = Retomar
 play-loading = Carregando…
+play-shuffle = Aleatório
 
 # artist page
 artist-eyebrow = Artista

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -219,6 +219,7 @@ detail-play-playlist = Слушать плейлист
 play-pause = Пауза
 play-resume = Продолжить
 play-loading = Загрузка…
+play-shuffle = Перемешать
 
 # artist page
 artist-eyebrow = Исполнитель

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -219,6 +219,7 @@ detail-play-playlist = Слухати плейлист
 play-pause = Пауза
 play-resume = Продовжити
 play-loading = Завантаження…
+play-shuffle = Перемішати
 
 # artist page
 artist-eyebrow = Виконавець

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -484,6 +484,18 @@ impl Playback {
         self.start(tracks, index, origin, cx);
     }
 
+    /// Turn shuffle on and start the tracks from a random playable one.
+    pub fn shuffle_any(
+        &mut self,
+        tracks: Vec<Track>,
+        origin: Option<Origin>,
+        cx: &mut Context<Self>,
+    ) {
+        self.queue
+            .update(cx, |queue, cx| queue.set_shuffle(true, cx));
+        self.start_any(tracks, origin, cx);
+    }
+
     fn opener(&self, tracks: &[Track], cx: &Context<Self>) -> Option<usize> {
         let playable = tracks
             .iter()

--- a/crates/views/src/screens/artist.rs
+++ b/crates/views/src/screens/artist.rs
@@ -310,6 +310,14 @@ impl ArtistView {
                 )
                 .from(self.playing_from(cx)),
             )
+            .child(
+                HeroPlayButton::shuffle(
+                    "shuffle-artist",
+                    self.popular.as_ref().clone(),
+                    self.playback.clone(),
+                )
+                .from(self.playing_from(cx)),
+            )
             .children(self.follow_button(cx))
             .children(overflow);
 

--- a/crates/views/src/screens/detail.rs
+++ b/crates/views/src/screens/detail.rs
@@ -336,6 +336,11 @@ impl DetailView {
                 &self.table,
                 self.playback.clone(),
             ))
+            .child(HeroPlayButton::shuffle_listed(
+                "shuffle-detail",
+                &self.table,
+                self.playback.clone(),
+            ))
             .children(self.library_button(cx))
             .children(overflow);
 

--- a/crates/views/src/screens/library/mod.rs
+++ b/crates/views/src/screens/library/mod.rs
@@ -630,12 +630,23 @@ impl LibraryView {
             .accent()
             .eyebrow(eyebrow)
             .meta(strip)
-            .actions(HeroPlayButton::listed(
-                "play-library",
-                t!("library-play-liked-songs"),
-                self.tracks(),
-                self.playback.clone(),
-            ))
+            .actions(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap_2()
+                    .child(HeroPlayButton::listed(
+                        "play-library",
+                        t!("library-play-liked-songs"),
+                        self.tracks(),
+                        self.playback.clone(),
+                    ))
+                    .child(HeroPlayButton::shuffle_listed(
+                        "shuffle-library",
+                        self.tracks(),
+                        self.playback.clone(),
+                    )),
+            )
             .into_any_element()
     }
 

--- a/crates/views/src/shared/hero.rs
+++ b/crates/views/src/shared/hero.rs
@@ -131,6 +131,7 @@ pub(crate) struct HeroPlayButton {
     label: SharedString,
     listing: Listing,
     from: Option<Origin>,
+    shuffled: bool,
     playback: Entity<Playback>,
 }
 
@@ -146,6 +147,7 @@ impl HeroPlayButton {
             label: label.into(),
             listing: Listing::Owned(tracks),
             from: None,
+            shuffled: false,
             playback,
         }
     }
@@ -153,6 +155,31 @@ impl HeroPlayButton {
     pub(crate) fn from(mut self, origin: Option<Origin>) -> Self {
         self.from = origin;
         self
+    }
+
+    /// The Shuffle button beside Play: an icon-only outline button that turns shuffle on and
+    /// starts the tracks from a random one, never mirroring the transport state.
+    pub(crate) fn shuffle(
+        id: impl Into<ElementId>,
+        tracks: Vec<Track>,
+        playback: Entity<Playback>,
+    ) -> Self {
+        Self {
+            shuffled: true,
+            ..Self::new(id, SharedString::default(), tracks, playback)
+        }
+    }
+
+    /// `shuffle` over a table's rows, in their displayed order.
+    pub(crate) fn shuffle_listed(
+        id: impl Into<ElementId>,
+        table: &Entity<TableState<TrackSource>>,
+        playback: Entity<Playback>,
+    ) -> Self {
+        Self {
+            shuffled: true,
+            ..Self::listed(id, SharedString::default(), table, playback)
+        }
     }
 
     pub(crate) fn listed(
@@ -166,13 +193,35 @@ impl HeroPlayButton {
             label: label.into(),
             listing: Listing::Listed(table.clone()),
             from: None,
+            shuffled: false,
             playback,
         }
+    }
+
+    fn shuffle_button(self, cx: &App) -> Button {
+        let disabled = self.listing.first(cx).is_none();
+        let listing = self.listing;
+        let from = self.from;
+        let playback = self.playback;
+
+        Button::new(self.id)
+            .icon("icons/shuffle.svg")
+            .tooltip("play-shuffle")
+            .outline()
+            .disabled(disabled)
+            .on_click(move |_, _, cx| {
+                let queued = listing.queue(cx);
+                let from = from.clone().or_else(|| listing.whence(cx));
+                playback.update(cx, |playback, cx| playback.shuffle_any(queued, from, cx));
+            })
     }
 }
 
 impl RenderOnce for HeroPlayButton {
     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        if self.shuffled {
+            return div().flex().child(self.shuffle_button(cx));
+        }
         let state = {
             let playback = self.playback.read(cx);
             let current = playback.track().and_then(|track| track.id.as_deref());


### PR DESCRIPTION
## Summary

- add an icon-only shuffle button beside play on album, playlist, artist and library pages
- turn shuffle on and start the collection from a random track when it is pressed
- add the shuffle tooltip to every locale

fixes #491