### PR TITLE
fix(playback): move on to the next track when the current one fails to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- A track that fails to load no longer stops playback. Sonora shows a toast, waits out the short
+  back-off and moves on to the next track in the queue, skipping the broken one even in repeat-one.
 - Local track lists keep each row's own embedded cover art when the table is sorted or recycled.
 - The Flatpak remote and the standalone bundles follow the repository to
   `sonorahq.github.io/sonora`. A remote added before the move needs

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -1558,7 +1558,9 @@ impl Playback {
             BackendEvent::Unavailable { .. } => {
                 let failed = self.track.take();
                 let target = failed.as_ref().and_then(song_target);
-                let name = failed.map_or_else(|| "?".to_owned(), |track| track.name);
+                let name = failed
+                    .as_ref()
+                    .map_or_else(|| "?".to_owned(), |track| track.name.clone());
                 log::warn!(
                     "playback: {name} failed to load, backing off {}s",
                     KEY_COOLDOWN.as_secs()
@@ -1569,6 +1571,10 @@ impl Playback {
                 self.clock.reset(Duration::ZERO, false);
                 Toasts::linked(Outcome::Failed, "toast-track-unplayable", name, target, cx);
                 cx.emit(PlaybackEvent::EndedPlayback);
+                match self.repeat {
+                    Repeat::One => self.segue_queue(cx),
+                    _ => self.advance(failed, cx),
+                }
             }
             BackendEvent::Refused => {
                 self.refuse(cx);


### PR DESCRIPTION
## Summary

- move on to the next queue track when the current one fails to load instead of stopping playback
- skip a broken track even in repeat-one rather than reloading it after every back-off
- fix #370

#378 Fixed this by making it skip tracks via a metadata flag, but region-locked songs still seem to pass the metadata check which hits the `Unavailable` event and this one goes idle without advancing.