### PR TITLE
fix(playback): count a seek or a start as playing only when the audio comes out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - A track that fails to load no longer stops playback. Sonora shows a toast, waits out the short
   back-off and moves on to the next track in the queue, skipping the broken one even in repeat-one.
 - Local track lists keep each row's own embedded cover art when the table is sorted or recycled.
+- Seeking, and starting a track, count as playing only once the audio actually comes out. The
+  lyrics and the progress bar wait at the target until then instead of running ahead while the
+  track buffers, and the old audio stops the moment you seek or pick another track. Seeking
+  repeatedly, as when clicking through the lyrics, no longer queues every position behind the
+  last. The play button follows what you asked for and flips the moment you press it.
 - The Flatpak remote and the standalone bundles follow the repository to
   `sonorahq.github.io/sonora`. A remote added before the move needs
   `flatpak remote-modify --user --url=https://sonorahq.github.io/sonora/repo sonora` once.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -561,10 +561,12 @@ Working notes:
 
 ### Audio
 
-`music::spotify::playback` owns `librespot_playback::Player` plus `BlazingSink` (`sink.rs`), a
-custom rodio sink with smooth gain ramping and flush-on-seek. `Factory` implements
+`music::spotify::playback` owns `librespot_playback::Player` plus `OutputSink` (`sink.rs`), a
+rodio sink that paces the decoder and drops what a seek or a new track made stale. librespot
+announces `Playing` and `Seeked` before it has written a byte, so `Events` holds those two until
+the sink writes the first packet of the new audio. `Factory` implements
 `music::PlaybackFactory`; `Engine` implements `music::Player`; events arrive as
-`music::PlaybackEvent` (`Loading/Playing/Paused/Position/Ended/Unavailable`).
+`music::PlaybackEvent` (`Loading/Playing/Paused/Position/Seeked/Length/Ended/Unavailable`).
 
 Never drive a player from a view. Go through `state::Playback`, which owns the engine, pumps
 events into `PlaybackState`, and handles shuffle, repeat, skip debouncing, and the cooldown after

--- a/crates/music/src/lib.rs
+++ b/crates/music/src/lib.rs
@@ -161,6 +161,8 @@ pub struct PlaybackConfig {
     pub gain: f32,
 }
 
+/// What an engine reports back. `Playing` and `Seeked` mean audio from `at` is reaching the
+/// output, not that a decoder is ready, so whatever follows the sound can start on them.
 #[derive(Clone, Debug, PartialEq)]
 pub enum PlaybackEvent {
     Loading {
@@ -175,7 +177,14 @@ pub enum PlaybackEvent {
         id: Option<String>,
         at: Duration,
     },
+    /// A progress report from the decoder. It runs ahead of what is audible by whatever the
+    /// output has queued, and none arrive while the engine is busy with a seek.
     Position {
+        id: Option<String>,
+        at: Duration,
+    },
+    /// Audio from the new position has reached the output after a seek.
+    Seeked {
         id: Option<String>,
         at: Duration,
     },
@@ -201,6 +210,7 @@ impl PlaybackEvent {
             | Self::Playing { id, .. }
             | Self::Paused { id, .. }
             | Self::Position { id, .. }
+            | Self::Seeked { id, .. }
             | Self::Length { id, .. }
             | Self::Ended { id, .. }
             | Self::Unavailable { id, .. } => id.as_deref(),
@@ -209,19 +219,24 @@ impl PlaybackEvent {
     }
 }
 
+/// Transport control of one engine. Every call is fire-and-forget: the outcome arrives as a
+/// `PlaybackEvent`, never as a return value.
 pub trait Player: Send + Sync {
-    fn load(&self, track_id: &str, seamless: bool) -> Result<()>;
+    /// Fetches a track and plays it from `at`. A `seamless` load is a queue segue: a gapless
+    /// engine keeps what it has queued so the join has no gap, any other load drops it.
+    fn load(&self, track_id: &str, at: Duration, seamless: bool) -> Result<()>;
 
-    fn load_paused_at(&self, track_id: &str, at: Duration) -> Result<()> {
-        self.load(track_id, false)?;
-        self.pause();
-        self.seek(at);
-        Ok(())
-    }
+    /// Fetches a track and leaves it paused at `at`, ready for `play`.
+    fn load_paused_at(&self, track_id: &str, at: Duration) -> Result<()>;
 
+    /// Fetches a track ahead of time so a later `load` starts at once. `segue` marks the next
+    /// queue item, which a gapless engine may already line up behind the current one.
     fn preload(&self, track_id: &str, segue: bool) -> Result<()>;
     fn play(&self);
     fn pause(&self);
+
+    /// Moves to `position`. While loading, the track starts there instead; while playing, a
+    /// `Seeked` event follows once audio from there reaches the output.
     fn seek(&self, position: Duration);
     fn set_gain(&self, gain: f32);
 

--- a/crates/music/src/local/playback.rs
+++ b/crates/music/src/local/playback.rs
@@ -16,6 +16,7 @@ enum Command {
     Load {
         id: String,
         at: Option<Duration>,
+        play: bool,
         seamless: bool,
     },
     Preload {
@@ -56,11 +57,12 @@ struct Engine {
 }
 
 impl Player for Engine {
-    fn load(&self, track_id: &str, seamless: bool) -> Result<()> {
+    fn load(&self, track_id: &str, at: Duration, seamless: bool) -> Result<()> {
         self.commands
             .send(Command::Load {
                 id: track_id.to_owned(),
-                at: None,
+                at: (!at.is_zero()).then_some(at),
+                play: true,
                 seamless,
             })
             .context("cannot reach local playback engine")
@@ -71,6 +73,7 @@ impl Player for Engine {
             .send(Command::Load {
                 id: track_id.to_owned(),
                 at: Some(at),
+                play: false,
                 seamless: false,
             })
             .context("cannot reach local playback engine")
@@ -171,7 +174,7 @@ async fn engine_loop(
             command = commands.recv() => {
                 let Some(command) = command else { break };
                 match command {
-                    Command::Load { id, at, seamless } => {
+                    Command::Load { id, at, play, seamless } => {
                         let segued = seamless
                             && at.is_none()
                             && current.as_ref().is_some_and(|slot| slot.id == id);
@@ -201,9 +204,9 @@ async fn engine_loop(
                         match load(&sink, &id) {
                             Ok(slot) => {
                                 place(&sink, &id, at);
-                                match at {
-                                    Some(_) => sink.pause(),
-                                    None => sink.play(),
+                                match play {
+                                    true => sink.play(),
+                                    false => sink.pause(),
                                 }
                                 if let Some(length) = slot.length {
                                     events.send(PlaybackEvent::Length {
@@ -213,7 +216,7 @@ async fn engine_loop(
                                 }
                                 prev_len = sink.len();
                                 current = Some(slot);
-                                playing = at.is_none();
+                                playing = play;
                                 let position = at.unwrap_or_default();
                                 events
                                     .send(match playing {
@@ -280,7 +283,7 @@ async fn engine_loop(
                             if let Err(error) = sink.try_seek(position) {
                                 log::warn!("playback: cannot seek: {error}");
                             }
-                            events.send(PlaybackEvent::Position {
+                            events.send(PlaybackEvent::Seeked {
                                 id: Some(slot.id.clone()),
                                 at: sink.get_pos(),
                             }).ok();

--- a/crates/music/src/spotify/playback.rs
+++ b/crates/music/src/spotify/playback.rs
@@ -11,25 +11,69 @@ use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
 
 use crate::audio::Volume;
 use crate::spectrum::Spectrum;
-use crate::spotify::sink::{BlazingSink, Flush};
+use crate::spotify::sink::{Cue, OutputSink};
 use crate::{
     PlaybackConfig, PlaybackEvent, PlaybackEvents, PlaybackFactory, Player as MusicPlayer,
 };
 
 const TRACK_PREFIX: &str = "spotify:track:";
+/// Position reports that can still come from before a seek or load: one already in the channel
+/// and one for a packet decoded before the player read the command.
+const STALE_POSITIONS: u8 = 2;
 
+/// The engine's events, with one correction: librespot says `Playing` when the decoder is
+/// ready and `Seeked` when it has moved, both before it has buffered or written anything. Each
+/// waits here for the sink's next write, which the same player thread makes strictly after it.
 pub struct Events {
     player: UnboundedReceiver<PlayerEvent>,
     output: UnboundedReceiver<()>,
+    cue: Cue,
+    written: UnboundedReceiver<()>,
+    /// The `Playing` or `Seeked` waiting for the sink; a newer one replaces an older one.
+    held: Option<PlaybackEvent>,
+    /// Position reports seen while the cue refuses writes. A seek or load that took keeps the
+    /// player thread busy, so a run of them means it never left the old position.
+    stale: u8,
 }
 
 #[async_trait]
 impl PlaybackEvents for Events {
     async fn next(&mut self) -> Option<PlaybackEvent> {
         loop {
+            // librespot's event always precedes the write it led to, so it is taken first when
+            // both are ready at once.
             tokio::select! {
+                biased;
                 event = self.player.recv() => {
-                    if let Some(event) = translate(event?) {
+                    let Some(event) = translate(event?) else { continue };
+                    match event {
+                        PlaybackEvent::Playing { .. } | PlaybackEvent::Seeked { .. } => {
+                            self.cue.arm();
+                            self.stale = 0;
+                            self.held = Some(event);
+                        }
+                        PlaybackEvent::Position { .. } if self.cue.cleared() => {
+                            self.stale += 1;
+                            if self.stale > STALE_POSITIONS {
+                                log::warn!("playback: the engine kept its old position, letting audio through");
+                                self.cue.arm();
+                                self.stale = 0;
+                            }
+                            return Some(event);
+                        }
+                        PlaybackEvent::Position { .. } | PlaybackEvent::Length { .. } => {
+                            return Some(event);
+                        }
+                        event => {
+                            self.held = None;
+                            self.stale = 0;
+                            return Some(event);
+                        }
+                    }
+                }
+                written = self.written.recv() => {
+                    written?;
+                    if let Some(event) = self.held.take() {
                         return Some(event);
                     }
                 }
@@ -42,6 +86,7 @@ impl PlaybackEvents for Events {
     }
 }
 
+/// Builds a Spotify engine on a connected session.
 pub struct Factory(Session);
 
 impl Factory {
@@ -57,10 +102,12 @@ impl PlaybackFactory for Factory {
     }
 }
 
+/// The librespot player with our sink behind it. Every method queues a command to librespot's
+/// own thread, which answers through `Events`.
 pub struct Engine {
     player: Arc<Player>,
     volume: Volume,
-    flush: Flush,
+    cue: Cue,
     spectrum: Spectrum,
     gapless: bool,
 }
@@ -68,7 +115,7 @@ pub struct Engine {
 impl Engine {
     fn start(session: Session, config: PlaybackConfig) -> (Self, Events) {
         let volume = Volume::new(config.gain);
-        let flush = Flush::default();
+        let (cue, written) = Cue::new();
         let spectrum = Spectrum::new();
 
         let player_config = PlayerConfig {
@@ -80,41 +127,45 @@ impl Engine {
         };
 
         let sink_volume = volume.clone();
-        let sink_flush = flush.clone();
+        let sink_cue = cue.clone();
         let sink_spectrum = spectrum.clone();
         let (output_tx, output_rx) = unbounded_channel();
         let player = Player::new(player_config, session, Box::new(NoOpVolume), move || {
-            BlazingSink::boxed(sink_flush, sink_volume, sink_spectrum, output_tx.clone())
+            OutputSink::boxed(sink_cue, sink_volume, sink_spectrum, output_tx.clone())
         });
 
         let events = Events {
             player: player.get_player_event_channel(),
             output: output_rx,
+            cue: cue.clone(),
+            written,
+            held: None,
+            stale: 0,
         };
         let engine = Self {
             player,
             volume,
-            flush,
+            cue,
             spectrum,
             gapless: config.gapless,
         };
         (engine, events)
     }
 
-    fn load(&self, track_id: &str, seamless: bool) -> Result<()> {
+    fn load(&self, track_id: &str, at: Duration, seamless: bool) -> Result<()> {
         let uri = track_uri(track_id)?;
 
         if !seamless || !self.gapless {
-            self.flush.request();
+            self.cue.clear();
         }
-        self.player.load(uri, true, 0);
+        self.player.load(uri, true, at.as_millis() as u32);
         Ok(())
     }
 
     fn load_paused_at(&self, track_id: &str, at: Duration) -> Result<()> {
         let uri = track_uri(track_id)?;
 
-        self.flush.request();
+        self.cue.clear();
         self.player.load(uri, false, at.as_millis() as u32);
         Ok(())
     }
@@ -133,8 +184,8 @@ impl Engine {
     }
 
     fn seek(&self, position: Duration) {
-        self.flush.request();
         self.player.seek(position.as_millis() as u32);
+        self.cue.clear();
     }
 
     fn set_gain(&self, gain: f32) {
@@ -147,8 +198,8 @@ impl Engine {
 }
 
 impl MusicPlayer for Engine {
-    fn load(&self, track_id: &str, seamless: bool) -> Result<()> {
-        self.load(track_id, seamless)
+    fn load(&self, track_id: &str, at: Duration, seamless: bool) -> Result<()> {
+        self.load(track_id, at, seamless)
     }
 
     fn load_paused_at(&self, track_id: &str, at: Duration) -> Result<()> {
@@ -185,6 +236,8 @@ fn track_uri(track_id: &str) -> Result<SpotifyUri> {
         .with_context(|| format!("{track_id} is not a track id"))
 }
 
+/// librespot's event as ours, or `None` for the ones the state has no use for. A denied audio
+/// key is `Refused`; any other unavailability names the track.
 fn translate(event: PlayerEvent) -> Option<PlaybackEvent> {
     let millis = |position_ms: u32| Duration::from_millis(position_ms as u64);
     let track_id = |uri: SpotifyUri| uri.to_id().ok();
@@ -224,6 +277,14 @@ fn translate(event: PlayerEvent) -> Option<PlaybackEvent> {
             position_ms,
             ..
         } => Some(PlaybackEvent::Position {
+            id: track_id(uri),
+            at: millis(position_ms),
+        }),
+        PlayerEvent::Seeked {
+            track_id: uri,
+            position_ms,
+            ..
+        } => Some(PlaybackEvent::Seeked {
             id: track_id(uri),
             at: millis(position_ms),
         }),

--- a/crates/music/src/spotify/sink.rs
+++ b/crates/music/src/spotify/sink.rs
@@ -1,44 +1,170 @@
 use std::num::NonZero;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicU32, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use librespot_playback::audio_backend::{Sink, SinkError, SinkResult};
 use librespot_playback::convert::Converter;
 use librespot_playback::decoder::AudioPacket;
 use librespot_playback::{NUM_CHANNELS, SAMPLE_RATE};
-use tokio::sync::mpsc::UnboundedSender;
+use rodio::buffer::SamplesBuffer;
+use rodio::{ChannelCount, SampleRate, Source};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
 use crate::audio::{Output, Volume};
 use crate::spectrum::Spectrum;
 
+/// How many packets stay queued before a write blocks. This is what paces the decoder to real
+/// time; deeper rides out network hiccups, but the decoder's position runs this far ahead of
+/// what is heard.
 const QUEUED_CHUNKS: usize = 26;
+/// How long a blocked write sleeps between looks at the queue.
 const DRAIN_POLL: Duration = Duration::from_millis(10);
+/// How often a write asks the system whether the default device changed.
 const DEVICE_POLL: Duration = Duration::from_millis(500);
 
-#[derive(Clone, Default)]
-pub struct Flush(Arc<AtomicBool>);
+/// Writes pass through and nothing is reported.
+const OPEN: u8 = 0;
+/// A clear was asked for and the engine has not announced the new track or position yet, so
+/// every write is still the old one and is dropped.
+const CLEARED: u8 = 1;
+/// The engine announced the new track or position; the next write is its first audio.
+const ARMED: u8 = 2;
 
-impl Flush {
-    pub fn request(&self) {
-        self.0.store(true, Ordering::Relaxed);
+/// The sink's link to the event stream. `clear` retires every packet queued so far and refuses
+/// the ones the engine still writes from the old position, so the old audio stops when the user
+/// acts. `arm` lets writes through again and has the first one reported; the stream arms it on
+/// librespot's own `Playing` and `Seeked`, which come from the player thread strictly before the
+/// write that follows, so the report can only mark audio from the new track or position. A
+/// gapless segue and a resume from pause ask for no clear, so nothing of theirs is dropped.
+#[derive(Clone)]
+pub struct Cue {
+    state: Arc<AtomicU8>,
+    generation: Arc<AtomicU32>,
+    written: UnboundedSender<()>,
+}
+
+impl Cue {
+    pub fn new() -> (Self, UnboundedReceiver<()>) {
+        let (written, receiver) = unbounded_channel();
+        let cue = Self {
+            state: Arc::default(),
+            generation: Arc::default(),
+            written,
+        };
+        (cue, receiver)
     }
 
-    fn take(&self) -> bool {
-        self.0.swap(false, Ordering::Relaxed)
+    /// Moves the queue on a generation. Every chunk from before ends at its next sample, and
+    /// nothing here touches rodio's own bookkeeping, which does not survive a clear that races
+    /// a chunk ending on its own.
+    pub fn clear(&self) {
+        self.generation.fetch_add(1, Ordering::Relaxed);
+        self.state.store(CLEARED, Ordering::Relaxed);
+    }
+
+    /// Lets writes through again and has the next one reported.
+    pub fn arm(&self) {
+        self.state.store(ARMED, Ordering::Relaxed);
+    }
+
+    /// Whether a clear is still waiting for the engine to announce where it went.
+    pub fn cleared(&self) -> bool {
+        self.state.load(Ordering::Relaxed) == CLEARED
+    }
+
+    /// Decides a write: refused after a clear, reported when armed, plain otherwise. A clear
+    /// that lands during the armed write wins, since that packet predates the seek behind it.
+    fn admit(&self) -> bool {
+        match self.state.load(Ordering::Relaxed) {
+            CLEARED => false,
+            ARMED => {
+                let armed = self
+                    .state
+                    .compare_exchange(ARMED, OPEN, Ordering::Relaxed, Ordering::Relaxed)
+                    .is_ok();
+                if armed {
+                    self.written.send(()).ok();
+                }
+                armed
+            }
+            _ => true,
+        }
     }
 }
 
-pub struct BlazingSink {
+/// One packet in the output queue. It ends as soon as the cue moves on a generation and counts
+/// itself out when dropped, whichever way it went, so `live` is the number still queued.
+struct Chunk {
+    samples: SamplesBuffer,
+    born: u32,
+    generation: Arc<AtomicU32>,
+    live: Arc<AtomicUsize>,
+}
+
+impl Chunk {
+    fn new(samples: SamplesBuffer, cue: &Cue, live: &Arc<AtomicUsize>) -> Self {
+        live.fetch_add(1, Ordering::Relaxed);
+        Self {
+            samples,
+            born: cue.generation.load(Ordering::Relaxed),
+            generation: cue.generation.clone(),
+            live: live.clone(),
+        }
+    }
+}
+
+impl Iterator for Chunk {
+    type Item = f32;
+
+    fn next(&mut self) -> Option<f32> {
+        if self.generation.load(Ordering::Relaxed) != self.born {
+            return None;
+        }
+        self.samples.next()
+    }
+}
+
+impl Source for Chunk {
+    fn current_span_len(&self) -> Option<usize> {
+        self.samples.current_span_len()
+    }
+
+    fn channels(&self) -> ChannelCount {
+        self.samples.channels()
+    }
+
+    fn sample_rate(&self) -> SampleRate {
+        self.samples.sample_rate()
+    }
+
+    fn total_duration(&self) -> Option<Duration> {
+        self.samples.total_duration()
+    }
+}
+
+impl Drop for Chunk {
+    fn drop(&mut self) {
+        self.live.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+/// librespot's `Sink` over the shared rodio output. A write blocks once enough is queued, which
+/// keeps the decoder in step with playback, and every write checks that the default device is
+/// still the one the output was opened on.
+pub struct OutputSink {
     output: Output,
-    flush: Flush,
+    cue: Cue,
+    /// Chunks appended and not yet played out or retired.
+    live: Arc<AtomicUsize>,
     changed: UnboundedSender<()>,
     checked_at: Instant,
 }
 
-impl BlazingSink {
+impl OutputSink {
+    /// Claims the default output device, paused until librespot starts the sink.
     pub fn open(
-        flush: Flush,
+        cue: Cue,
         volume: Volume,
         spectrum: Spectrum,
         changed: UnboundedSender<()>,
@@ -49,27 +175,32 @@ impl BlazingSink {
 
         Ok(Self {
             output,
-            flush,
+            cue,
+            live: Arc::default(),
             changed,
             checked_at: Instant::now(),
         })
     }
 
+    /// The sink librespot's player builder asks for. Without an output device it gets a silent
+    /// one, so playback state still moves.
     pub fn boxed(
-        flush: Flush,
+        cue: Cue,
         volume: Volume,
         spectrum: Spectrum,
         changed: UnboundedSender<()>,
     ) -> Box<dyn Sink> {
-        match Self::open(flush, volume, spectrum, changed) {
+        match Self::open(cue.clone(), volume, spectrum, changed) {
             Ok(sink) => Box::new(sink),
             Err(error) => {
                 log::error!("sink: cannot open an output device: {error}");
-                Box::new(Silence)
+                Box::new(Silence(cue))
             }
         }
     }
 
+    /// Whether the output failed or the default device is no longer the one it was opened on,
+    /// asking the system at most every `DEVICE_POLL`.
     fn output_changed(&mut self) -> bool {
         let now = Instant::now();
         let changed = self.output.failed()
@@ -80,13 +211,14 @@ impl BlazingSink {
         changed
     }
 
+    /// Tells the engine the output is gone and hands librespot the error that pauses it.
     fn disconnected(&self) -> SinkError {
         self.changed.send(()).ok();
         SinkError::OnWrite("audio output changed".to_owned())
     }
 }
 
-impl Sink for BlazingSink {
+impl Sink for OutputSink {
     fn start(&mut self) -> SinkResult<()> {
         if self.output.failed() || self.output.changed() {
             return Err(self.disconnected());
@@ -105,23 +237,24 @@ impl Sink for BlazingSink {
             return Err(self.disconnected());
         }
 
-        if self.flush.take() {
-            self.output.sink().clear();
-            self.output.sink().play();
+        if !self.cue.admit() {
+            return Ok(());
         }
 
         let samples = packet
             .samples()
             .map_err(|error| SinkError::OnWrite(error.to_string()))?;
         let samples = converter.f64_to_f32(samples);
-
-        self.output.sink().append(rodio::buffer::SamplesBuffer::new(
+        let samples = SamplesBuffer::new(
             const { NonZero::new(NUM_CHANNELS as cpal::ChannelCount).unwrap() },
             const { NonZero::new(SAMPLE_RATE).unwrap() },
             &*samples,
-        ));
+        );
+        self.output
+            .sink()
+            .append(Chunk::new(samples, &self.cue, &self.live));
 
-        while self.output.sink().len() > QUEUED_CHUNKS {
+        while self.live.load(Ordering::Relaxed) > QUEUED_CHUNKS {
             if self.output_changed() {
                 return Err(self.disconnected());
             }
@@ -131,10 +264,13 @@ impl Sink for BlazingSink {
     }
 }
 
-struct Silence;
+/// Swallows the audio when no output device opens. It still answers the cue, so playback state
+/// moves on rather than waiting for sound that cannot come.
+struct Silence(Cue);
 
 impl Sink for Silence {
     fn write(&mut self, _packet: AudioPacket, _converter: &mut Converter) -> SinkResult<()> {
+        self.0.admit();
         Ok(())
     }
 }

--- a/crates/music/src/youtube/playback.rs
+++ b/crates/music/src/youtube/playback.rs
@@ -19,6 +19,7 @@ enum Command {
     Load {
         id: String,
         at: Option<Duration>,
+        play: bool,
         seamless: bool,
     },
     Preload {
@@ -67,11 +68,12 @@ struct Engine {
 }
 
 impl Player for Engine {
-    fn load(&self, track_id: &str, seamless: bool) -> Result<()> {
+    fn load(&self, track_id: &str, at: Duration, seamless: bool) -> Result<()> {
         self.commands
             .send(Command::Load {
                 id: track_id.to_string(),
-                at: None,
+                at: (!at.is_zero()).then_some(at),
+                play: true,
                 seamless,
             })
             .context("cannot reach playback engine")
@@ -82,6 +84,7 @@ impl Player for Engine {
             .send(Command::Load {
                 id: track_id.to_string(),
                 at: Some(at),
+                play: false,
                 seamless: false,
             })
             .context("cannot reach playback engine")
@@ -223,7 +226,7 @@ async fn engine_loop(
             command = commands.recv() => {
                 let Some(command) = command else { break };
                 match command {
-                    Command::Load { id, at, seamless } => {
+                    Command::Load { id, at, play, seamless } => {
                         if seamless && at.is_none() && current.as_ref().is_some_and(|slot| slot.id == id) {
                             playing = true;
                             autostart = true;
@@ -276,7 +279,7 @@ async fn engine_loop(
                         current = None;
                         queued = None;
                         playing = false;
-                        autostart = at.is_none();
+                        autostart = play;
                         hold = at;
                         prev_len = 0;
                         let Some(loaded) = cached else { continue };
@@ -358,8 +361,8 @@ async fn engine_loop(
                         }
                     }
                     Command::Seek(position) => match &current {
-                        None if hold.is_some() => hold = Some(position),
-                        None => {}
+                        // Still loading: start there once the track arrives.
+                        None => hold = Some(position),
                         Some(slot) => {
                             slot.mute();
                             await_drain(&sink).await;
@@ -369,7 +372,7 @@ async fn engine_loop(
                             if playing {
                                 slot.unmute();
                             }
-                            events.send(PlaybackEvent::Position {
+                            events.send(PlaybackEvent::Seeked {
                                 id: Some(slot.id.clone()),
                                 at: sink.get_pos(),
                             }).ok();

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -12,17 +12,26 @@ use ui::{Pin, PinKind};
 
 type Fetch = std::pin::Pin<Box<dyn Future<Output = Result<Vec<Track>>> + Send>>;
 
+/// Why the provider will play nothing more this session. Every later load fails the same way
+/// without asking the engine again.
 #[derive(Clone, Copy, PartialEq)]
 enum Refusal {
+    /// Spotify denied an audio key for the account.
     Keys,
+    /// The provider streams only to a signed-in listener.
     SignIn,
 }
 
+/// How a load came about, which decides its debounce and whether the engine may keep its queue.
 #[derive(Clone, Copy, PartialEq)]
 enum Start {
+    /// The user chose a track.
     Pick,
+    /// The user skipped once.
     Skip,
+    /// The user is skipping repeatedly; the load waits for the skipping to stop.
     Burst,
+    /// The queue moved on by itself, so a gapless engine keeps the tail of the last track.
     Segue,
 }
 
@@ -35,14 +44,25 @@ impl Start {
     }
 }
 
+/// What the user asked for last. It moves the moment they act, while `PlaybackState` waits for
+/// the engine to confirm, so a control can follow the intent without waiting on the network.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Intent {
+    Play,
+    Pause,
+}
+
+/// Where fetched tracks go in the queue.
 #[derive(Clone, Copy)]
 enum QueuePlacement {
     Next,
     End,
+    /// After this many upcoming tracks; a gap past the end appends.
     Gap(usize),
 }
 
 impl QueuePlacement {
+    /// The toast key for a placement worth announcing.
     fn toast(self, source: &str) -> Option<String> {
         match self {
             Self::Next => Some(format!("toast-next-{source}")),
@@ -59,6 +79,14 @@ use crate::{AppSettings, Io, Outcome, Session, SessionEvent, Target, Toasts, joi
 
 const POSITION_INTERVAL: Duration = Duration::from_millis(500);
 const CLOCK_SETTLE: Duration = Duration::from_secs(1);
+/// Position reports that can still arrive from before a seek: one already in the channel and
+/// one for a packet decoded before the engine read the command. A successful seek keeps the
+/// engine busy, so more than this while one is in flight means it never left the old position.
+const STALE_POSITIONS: u8 = 2;
+/// How far before a seek target the engine may land and still be shown at the target. A decoder
+/// settles on the packet holding the target, a few tens of milliseconds early at most; showing
+/// the target keeps a lyric clicked at its first word on that line, not the one before.
+const SEEK_SNAP: Duration = Duration::from_millis(100);
 const PRELOAD_BEFORE_END: Duration = Duration::from_secs(10);
 const SKIP_DEBOUNCE: Duration = Duration::from_millis(250);
 const RESTART_WINDOW: Duration = Duration::from_secs(3);
@@ -68,10 +96,15 @@ const TAPER_DB: f32 = 50.;
 const LOCAL_FAVORITES: &str = "favorites";
 const SIMILAR_LIMIT: usize = 20;
 
+/// The position shown between the engine's reports. It runs on wall time from `reset` and is
+/// nudged toward each report by `correct`, spread over a moment so the progress bar and the
+/// lyrics glide instead of stepping. Parked, it holds `base`.
 struct LiveClock {
     base: Duration,
     since: Option<Instant>,
+    /// Seconds still to fold in from the last report, negative when the clock was ahead.
     correction: f64,
+    /// Seconds over which the correction is folded in.
     settle: f64,
 }
 
@@ -85,6 +118,7 @@ impl LiveClock {
         }
     }
 
+    /// Puts the clock at `at`, running from now or parked there.
     fn reset(&mut self, at: Duration, running: bool) {
         self.base = at;
         self.since = running.then(Instant::now);
@@ -92,6 +126,7 @@ impl LiveClock {
         self.settle = CLOCK_SETTLE.as_secs_f64();
     }
 
+    /// Folds a reported position in without a jump.
     fn correct(&mut self, toward: Duration) {
         self.correct_at(toward, Instant::now());
     }
@@ -120,6 +155,7 @@ impl LiveClock {
     }
 }
 
+/// Seconds from `from` to `to`, negative when `to` is earlier.
 fn signed_gap(to: Duration, from: Duration) -> f64 {
     match to >= from {
         true => (to - from).as_secs_f64(),
@@ -127,6 +163,7 @@ fn signed_gap(to: Duration, from: Duration) -> f64 {
     }
 }
 
+/// `base` moved by `seconds`, never below zero.
 fn shifted(base: Duration, seconds: f64) -> Duration {
     match seconds >= 0. {
         true => base.saturating_add(Duration::from_secs_f64(seconds)),
@@ -134,6 +171,8 @@ fn shifted(base: Duration, seconds: f64) -> Duration {
     }
 }
 
+/// The linear gain for a volume level, on a decibel taper that spans `TAPER_DB` and is silent
+/// at zero.
 fn gain(level: f32) -> f32 {
     match level.clamp(0., 1.) {
         level if level <= 0. => 0.,
@@ -141,15 +180,21 @@ fn gain(level: f32) -> f32 {
     }
 }
 
+/// What the engine has confirmed. `Playing` means audio is reaching the output; a track being
+/// fetched, or a seek still buffering, reads `Loading`. What the user asked for lives in
+/// `Intent` and can run ahead of this.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PlaybackState {
     Idle,
     Playing,
     Paused,
     Loading,
+    /// Nothing plays and this is why, in developer English.
     Failed(String),
 }
 
+/// What other entities hear from `Playback`: history records a start, the sheet closes on an
+/// end.
 pub enum PlaybackEvent {
     StartedPlayback,
     EndedPlayback,
@@ -171,6 +216,7 @@ pub enum Repeat {
     One,
 }
 
+/// What kind of collection the queue was started from.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Whence {
@@ -182,7 +228,9 @@ pub enum Whence {
     Local,
 }
 
-// same thing, same origin
+/// The collection the queue was started from, so its page can show a pause button and a
+/// restart resumes it. Two origins are the same collection when kind and id match; the name is
+/// only for display.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Origin {
     pub whence: Whence,
@@ -254,9 +302,14 @@ impl From<&Pin> for Origin {
     }
 }
 
+/// Everything the UI knows about what is playing, and the only thing that drives an engine.
+/// Holds one engine for the streaming provider and one for local files, a `Queue` for what
+/// comes next, and a clock for the position between the engine's reports. Views act through
+/// its methods; the engine answers through `on_backend_event`; nothing else touches a `Player`.
 pub struct Playback {
     state: PlaybackState,
     origin: Option<Origin>,
+    /// The last position the engine reported, or the one asked of it.
     position: Duration,
     clock: LiveClock,
     track: Option<Track>,
@@ -270,21 +323,43 @@ pub struct Playback {
     gapless: bool,
     repeat: Repeat,
     radio: bool,
+    /// The track the current similar-tracks suggestions were drawn from.
     seeded: Option<String>,
+    /// The streaming engine's event pump; dropping it stops listening.
     task: Option<Task<()>>,
     local_task: Option<Task<()>>,
+    /// The pending load, held through its debounce; a newer load cancels it.
     load: Option<Task<()>>,
+    /// The collection being fetched to start or extend the queue.
     fetch: Option<Task<()>>,
     enqueue: Option<Task<()>>,
     suggest: Option<Task<()>>,
+    /// The track the engine was asked to fetch ahead, so it is asked once.
     preloaded: Option<String>,
+    /// When the user last skipped, for telling a burst of skips from one.
     skipped: Option<Instant>,
+    /// No load goes out before this after a track failed, so a bad key cannot be hammered.
     blocked_until: Option<Instant>,
     refused: Option<Refusal>,
+    /// Where the restored track resumes. Set until the engine has it ready or the user plays.
     resume_at: Option<Duration>,
-    seek_on_play: Option<Duration>,
+    /// The seek the engine is carrying out while playing. One is in flight at a time: the clock
+    /// waits at its target until the engine reports audio from there, and position reports
+    /// from before it are ignored.
+    seek_in_flight: Option<Duration>,
+    /// The latest seek asked for while one was in flight. It goes out when that one lands, so
+    /// a burst of seeks costs the engine two rather than one per click.
+    seek_next: Option<Duration>,
+    /// Position reports seen while a seek is in flight.
+    stale_positions: u8,
+    /// Where the last seek asked to go, until the engine reports where it landed.
+    seek_target: Option<Duration>,
+    intent: Intent,
+    /// Whether the engine holds the restored track paused at `resume_at`, so play is instant.
     resume_ready: bool,
+    /// Whether playback stopped on a stale session and continues once it reconnects.
     awaiting_reconnect: bool,
+    /// The position last written to settings for resuming.
     stored: Duration,
     sleep: Option<Sleep>,
     sleep_task: Option<Task<()>>,
@@ -360,7 +435,11 @@ impl Playback {
             blocked_until: None,
             refused: None,
             resume_at: None,
-            seek_on_play: None,
+            seek_in_flight: None,
+            seek_next: None,
+            stale_positions: 0,
+            seek_target: None,
+            intent: Intent::Pause,
             resume_ready: false,
             awaiting_reconnect: false,
             stored: Duration::ZERO,
@@ -369,10 +448,12 @@ impl Playback {
         }
     }
 
+    /// Plays a track the user picked, from its start.
     pub fn play(&mut self, track: &Track, cx: &mut Context<Self>) {
         self.load_after(track, Start::Pick, cx);
     }
 
+    /// The engine a track id belongs to: local files have their own.
     fn engine_for(&self, id: &str) -> Option<&dyn Player> {
         match music::is_local_id(id) {
             true => self.local_engine.as_deref(),
@@ -389,6 +470,7 @@ impl Playback {
         self.active_engine()?.spectrum()
     }
 
+    /// Pauses the engine the new track does not belong to, so the two never sound at once.
     fn silence_other(&self, id: &str) {
         let other = match music::is_local_id(id) {
             true => self.engine.as_deref(),
@@ -399,6 +481,8 @@ impl Playback {
         }
     }
 
+    /// Fetches a track ahead, as when the pointer rests on its row, so playing it starts at
+    /// once. Asked once per track; the current track is never preloaded.
     pub fn preload(&mut self, track: &Track) {
         self.preload_internal(track, false);
     }
@@ -428,6 +512,13 @@ impl Playback {
     }
 
     fn load_after(&mut self, track: &Track, start: Start, cx: &mut Context<Self>) {
+        self.load_from(track, Duration::ZERO, start, cx);
+    }
+
+    /// Loads a track to play from `at`, after the debounce `start` asks for. The state reads
+    /// Loading from here until the engine reports audio; a refusal or an unplayable track fails
+    /// without reaching the engine.
+    fn load_from(&mut self, track: &Track, at: Duration, start: Start, cx: &mut Context<Self>) {
         match self.refused {
             Some(Refusal::Keys) => return self.refuse(cx),
             Some(Refusal::SignIn) => return self.gate(cx),
@@ -446,11 +537,14 @@ impl Playback {
 
         self.track = Some(track.clone());
         self.state = PlaybackState::Loading;
-        self.position = Duration::ZERO;
-        self.clock.reset(Duration::ZERO, false);
+        self.position = at;
+        self.clock.reset(at, false);
         self.preloaded = None;
         self.resume_at = None;
-        self.seek_on_play = None;
+        self.seek_in_flight = None;
+        self.seek_next = None;
+        self.seek_target = None;
+        self.intent = Intent::Play;
         self.resume_ready = false;
         cx.notify();
 
@@ -466,7 +560,7 @@ impl Playback {
                 let Some(engine) = this.engine_for(&id) else {
                     return;
                 };
-                if let Err(error) = engine.load(&id, start == Start::Segue) {
+                if let Err(error) = engine.load(&id, at, start == Start::Segue) {
                     this.failed(format!("{error:#}"), cx);
                 }
             })
@@ -474,6 +568,7 @@ impl Playback {
         }));
     }
 
+    /// Replaces the queue with `tracks` and plays the one at `index`.
     pub fn start(
         &mut self,
         tracks: Vec<Track>,
@@ -485,6 +580,8 @@ impl Playback {
         self.begin(tracks, index, origin, cx);
     }
 
+    /// Replaces the queue with `tracks` and plays the first playable one, or a random one when
+    /// shuffle is on.
     pub fn start_any(
         &mut self,
         tracks: Vec<Track>,
@@ -507,6 +604,7 @@ impl Playback {
         self.start_any(tracks, origin, cx);
     }
 
+    /// Which of `tracks` a collection opens with.
     fn opener(&self, tracks: &[Track], cx: &Context<Self>) -> Option<usize> {
         let playable = tracks
             .iter()
@@ -520,6 +618,7 @@ impl Playback {
         }
     }
 
+    /// Plays `seed` now and fills the queue behind it with its radio once that arrives.
     pub fn play_radio(&mut self, seed: &Track, cx: &mut Context<Self>) {
         let Some(id) = seed.id.clone() else {
             return self.failed(format!("{} has no track id", seed.name), cx);
@@ -570,6 +669,7 @@ impl Playback {
         });
     }
 
+    /// Appends a track, or starts playing it when nothing is queued.
     pub fn enqueue(&mut self, track: Track, cx: &mut Context<Self>) {
         if self.queue.read(cx).current().is_none() {
             self.begin(vec![track], 0, None, cx);
@@ -628,6 +728,7 @@ impl Playback {
             .update(cx, |queue, cx| queue.insert_upcoming(gap, tracks, cx));
     }
 
+    /// Fetches a pinned collection and inserts it `gap` tracks ahead, or at the end.
     pub fn enqueue_pin(&mut self, pin: &Pin, gap: Option<usize>, cx: &mut Context<Self>) {
         let placement = QueuePlacement::Gap(gap.unwrap_or(usize::MAX));
         let id = pin.id.clone();
@@ -739,6 +840,8 @@ impl Playback {
         }
     }
 
+    /// Fetches tracks for the queue on the tokio runtime and places them on arrival. One fetch
+    /// at a time; a second request while one runs is dropped.
     fn enqueue_from<F>(
         &mut self,
         source: &'static str,
@@ -786,10 +889,13 @@ impl Playback {
         self.origin.as_ref()
     }
 
+    /// The playback state when the queue was started from `origin`, so its page can show it.
     pub fn playing_from(&self, origin: &Origin) -> Option<PlaybackState> {
         (self.origin.as_ref() == Some(origin)).then(|| self.state.clone())
     }
 
+    /// Hands a fetched collection to the queue, remembers where it came from for resuming, and
+    /// plays the chosen track.
     fn begin(
         &mut self,
         tracks: Vec<Track>,
@@ -810,6 +916,8 @@ impl Playback {
         self.play(&track, cx);
     }
 
+    /// Fetches a collection and starts the queue from it. Shows Loading only when nothing
+    /// plays yet, so a failure mid-playback is logged rather than shown.
     fn gather<F>(&mut self, origin: Origin, cx: &mut Context<Self>, tracks: F)
     where
         F: FnOnce(Arc<dyn MusicApi>) -> Fetch + Send + 'static,
@@ -841,12 +949,15 @@ impl Playback {
         }));
     }
 
+    /// Skips to the next playable track.
     pub fn next(&mut self, cx: &mut Context<Self>) {
         self.fetch = None;
         let start = self.burst();
         self.follow_queue(start, cx);
     }
 
+    /// Notes a skip and says whether it is part of a burst, which loads only once the skipping
+    /// stops.
     fn burst(&mut self) -> Start {
         let now = Instant::now();
         let rapid = self
@@ -859,6 +970,8 @@ impl Playback {
         }
     }
 
+    /// Asks the engine to fetch the next track once the current one is near its end, so a
+    /// gapless engine can line it up.
     fn preload_next(&mut self, position: Duration, cx: &Context<Self>) {
         let Some(duration) = self.track.as_ref().map(|track| track.duration) else {
             return;
@@ -897,6 +1010,7 @@ impl Playback {
         }
     }
 
+    /// Plays one of the suggested similar tracks, making the suggestions the queue.
     pub fn play_similar(&mut self, index: usize, cx: &mut Context<Self>) {
         self.fetch = None;
         let Some(track) = self
@@ -915,11 +1029,14 @@ impl Playback {
         cx.notify();
     }
 
+    /// The track suggestions are drawn from: the last queued, else the current.
     fn seed(&self, cx: &Context<Self>) -> Option<Track> {
         let queue = self.queue.read(cx);
         queue.upcoming().last().or_else(|| queue.current()).cloned()
     }
 
+    /// Fills the suggestions from the seed's radio when radio is on and they are empty,
+    /// leaving out what is already queued.
     fn suggest_similar(&mut self, cx: &mut Context<Self>) {
         if !self.radio || self.queue.read(cx).similar().len() > 0 {
             return;
@@ -978,6 +1095,8 @@ impl Playback {
         cx.notify();
     }
 
+    /// Decides what follows a track that ended: the same one on repeat-one, the queue's start
+    /// on repeat-all, more radio when it is on and the queue ran out, else the next in line.
     fn advance(&mut self, ended: Option<Track>, cx: &mut Context<Self>) {
         match self.repeat {
             Repeat::One => match ended {
@@ -1005,6 +1124,7 @@ impl Playback {
         self.follow_queue(Start::Segue, cx);
     }
 
+    /// Appends the seed's radio to the queue and moves on, or just moves on if it fails.
     fn extend_radio(&mut self, seed: &Track, cx: &mut Context<Self>) {
         let Some(id) = seed.id.clone() else {
             return self.next(cx);
@@ -1047,6 +1167,7 @@ impl Playback {
         self.load_after(&track, start, cx);
     }
 
+    /// The next playable track the queue has, dropping the ones that are not.
     fn playable_next(&mut self, cx: &mut Context<Self>) -> Option<Track> {
         loop {
             let track = self.queue.update(cx, |queue, cx| queue.next(cx))?;
@@ -1071,6 +1192,8 @@ impl Playback {
         self.track.is_some() || self.queue.read(cx).has_previous()
     }
 
+    /// Whether the previous button restarts the track rather than going back: a few seconds
+    /// in, or nothing to go back to.
     fn restarts(&self, cx: &App) -> bool {
         self.track.is_some()
             && (self.live_position() > RESTART_WINDOW || !self.queue.read(cx).has_previous())
@@ -1110,7 +1233,9 @@ impl Playback {
         self.load_after(&track, Start::Pick, cx);
     }
 
+    /// Plays on. A restored track the engine does not hold yet is loaded at its position.
     pub fn resume(&mut self, cx: &mut Context<Self>) {
+        self.intent = Intent::Play;
         if let Some(at) = self.resume_at {
             if !self.resume_ready {
                 return self.reload_and_seek(at, cx);
@@ -1131,10 +1256,11 @@ impl Playback {
         if self.active_engine().is_none() {
             return;
         }
-        self.load_after(&track, Start::Pick, cx);
-        self.seek_on_play = Some(at);
+        self.load_from(&track, at, Start::Pick, cx);
     }
 
+    /// Has the engine fetch the restored track and hold it paused at `resume_at`, so the first
+    /// play is instant. Until it says so, play loads the track instead.
     fn prepare_resume(&mut self, cx: &mut Context<Self>) {
         self.resume_ready = false;
         let Some(at) = self.resume_at else {
@@ -1164,6 +1290,8 @@ impl Playback {
         cx.notify();
     }
 
+    /// Restores the last session's track and queue from settings, paused where it stopped.
+    /// Only when nothing is playing or queued, and only for the provider that saved it.
     fn adopt(&mut self, cx: &mut Context<Self>) {
         if self.track.is_some() || !self.queue.read(cx).is_empty() {
             return;
@@ -1196,6 +1324,7 @@ impl Playback {
         self.prepare_resume(cx);
     }
 
+    /// Writes the position to settings for resuming, every few seconds or when `force`d.
     fn remember(&mut self, force: bool, cx: &mut Context<Self>) {
         let position = self.position;
         if !force && position.abs_diff(self.stored) < RESUME_STEP {
@@ -1208,6 +1337,7 @@ impl Playback {
     }
 
     pub fn pause(&mut self, cx: &mut Context<Self>) {
+        self.intent = Intent::Pause;
         if let Some(engine) = self.active_engine() {
             engine.pause();
             cx.notify();
@@ -1215,10 +1345,9 @@ impl Playback {
     }
 
     pub fn toggle_play(&mut self, cx: &mut Context<Self>) {
-        if self.state == PlaybackState::Playing {
-            self.pause(cx);
-        } else {
-            self.resume(cx);
+        match self.wants_playing() {
+            true => self.pause(cx),
+            false => self.resume(cx),
         }
     }
 
@@ -1257,6 +1386,12 @@ impl Playback {
         self.prepare_resume(cx);
     }
 
+    /// Whether the user wants the current track playing, whatever the engine has managed so
+    /// far. A transport control reads this; anything that follows the sound reads `state`.
+    pub fn wants_playing(&self) -> bool {
+        self.intent == Intent::Play && self.track.is_some()
+    }
+
     pub fn play_origin(&mut self, origin: Origin, cx: &mut Context<Self>) {
         match origin.whence {
             Whence::Album => self.play_album_of(origin, cx),
@@ -1268,6 +1403,8 @@ impl Playback {
         }
     }
 
+    /// The play button of a collection page: pauses or resumes when the queue came from it,
+    /// starts it otherwise.
     pub fn toggle_origin(&mut self, origin: &Origin, cx: &mut Context<Self>) {
         match self.playing_from(origin) {
             Some(PlaybackState::Playing) => self.pause(cx),
@@ -1276,10 +1413,10 @@ impl Playback {
         }
     }
 
+    /// Moves to `position`. While playing, the clock parks there until the engine reports
+    /// audio from it, and a second seek meanwhile waits for the first to land. A restored track
+    /// not yet held by the engine only moves its resume point.
     pub fn seek(&mut self, position: Duration, cx: &mut Context<Self>) {
-        if self.state != PlaybackState::Playing {
-            self.seek_on_play = Some(position);
-        }
         if self.resume_at.is_some() {
             self.resume_at = Some(position);
             if self.resume_ready
@@ -1293,15 +1430,50 @@ impl Playback {
             cx.notify();
             return;
         }
+        if self.active_engine().is_none() {
+            return;
+        }
+        // The clock parks at the target; the engine's Seeked starts it again once audio from
+        // there is playing. A loading or paused engine takes the seek at once and reports the
+        // position with its Playing, so only a playing one needs the seek tracked.
+        self.position = position;
+        self.clock.reset(position, false);
+        self.seek_target = Some(position);
+        match (self.state == PlaybackState::Playing, self.seek_in_flight) {
+            (true, Some(_)) => self.seek_next = Some(position),
+            (true, None) => {
+                self.seek_in_flight = Some(position);
+                self.stale_positions = 0;
+                self.send_seek(position);
+            }
+            (false, _) => self.send_seek(position),
+        }
+        cx.notify();
+    }
+
+    fn send_seek(&self, position: Duration) {
         if let Some(engine) = self.active_engine() {
             engine.seek(position);
-            self.position = position;
-            self.clock
-                .reset(position, self.state == PlaybackState::Playing);
-            cx.notify();
         }
     }
 
+    /// The position to show for where the engine reports it landed: the seek target itself
+    /// when the engine stopped just short of it on a packet boundary.
+    fn landed(&mut self, at: Duration) -> Duration {
+        match self.seek_target.take() {
+            Some(target) if at < target && target - at < SEEK_SNAP => target,
+            _ => at,
+        }
+    }
+
+    /// Sends the seek that queued up behind the one that just landed.
+    fn follow_up_seek(&mut self, cx: &mut Context<Self>) {
+        if let Some(next) = self.seek_next.take() {
+            self.seek(next, cx);
+        }
+    }
+
+    /// Seeks to a share of the track, as the progress bar asks.
     pub fn seek_fraction(&mut self, fraction: f32, cx: &mut Context<Self>) {
         let Some(total) = self
             .track
@@ -1320,10 +1492,12 @@ impl Playback {
         &self.state
     }
 
+    /// The position as last reported or asked for. It only moves on events.
     pub fn position(&self) -> Duration {
         self.position
     }
 
+    /// The position right now: the clock while playing, else `position`. Never past the end.
     pub fn live_position(&self) -> Duration {
         let live = match self.state == PlaybackState::Playing {
             true => self.clock.now(),
@@ -1339,6 +1513,7 @@ impl Playback {
         self.track.as_ref()
     }
 
+    /// How far through the track `position` is, from 0 to 1.
     pub fn progress(&self) -> f32 {
         let Some(total) = self.track.as_ref().map(|track| track.duration) else {
             return 0.;
@@ -1353,6 +1528,7 @@ impl Playback {
         matches!(self.state, PlaybackState::Loading)
     }
 
+    /// Whether a track is loaded, whatever it is doing.
     fn has_active_playback(&self) -> bool {
         self.track.is_some()
             && matches!(
@@ -1407,6 +1583,7 @@ impl Playback {
         self.restart_engine(cx);
     }
 
+    /// Whether the current track plays through the local engine.
     fn local_active(&self) -> bool {
         self.track
             .as_ref()
@@ -1414,6 +1591,8 @@ impl Playback {
             .is_some_and(music::is_local_id)
     }
 
+    /// Rebuilds the streaming engine after a setting it was configured with changed, resuming
+    /// where it was unless a local track is playing.
     fn restart_engine(&mut self, cx: &mut Context<Self>) {
         let playback = match self.engine.is_some() {
             true => self.session.read(cx).playback(),
@@ -1429,6 +1608,8 @@ impl Playback {
         }
     }
 
+    /// Rebuilds the engine of the current track on the new default audio device and reloads
+    /// the track where the clock stood.
     fn restart_output(&mut self, cx: &mut Context<Self>) {
         let Some(track) = self.track.clone() else {
             return;
@@ -1459,10 +1640,11 @@ impl Playback {
                 self.start_engine(playback, cx);
             }
         }
-        self.load_after(&track, Start::Pick, cx);
-        self.seek_on_play = Some(at);
+        self.load_from(&track, at, Start::Pick, cx);
     }
 
+    /// Whether a track's failure is the session having gone stale, in which case the session
+    /// reconnects and playback continues from `rebind`.
     fn ask_for_reconnect(&mut self, cx: &mut Context<Self>) -> bool {
         if self.track.is_none() {
             return false;
@@ -1473,6 +1655,8 @@ impl Playback {
         self.awaiting_reconnect
     }
 
+    /// Moves playback onto a fresh engine, as after a reconnect, and resumes where it was if it
+    /// was playing or waiting to.
     fn rebind(&mut self, playback: Arc<dyn PlaybackFactory>, cx: &mut Context<Self>) {
         let resume = self.state == PlaybackState::Playing || self.awaiting_reconnect;
         self.awaiting_reconnect = false;
@@ -1490,6 +1674,7 @@ impl Playback {
         }
     }
 
+    /// Builds the streaming engine and starts pumping its events.
     fn start_engine(&mut self, playback: Arc<dyn PlaybackFactory>, cx: &mut Context<Self>) {
         let config = PlaybackConfig {
             normalisation: self.normalisation,
@@ -1525,6 +1710,7 @@ impl Playback {
         self.prepare_resume(cx);
     }
 
+    /// Pumps an engine's events into `on_backend_event` until the engine is dropped.
     fn listen(&mut self, mut events: Box<dyn PlaybackEvents>, local: bool, cx: &mut Context<Self>) {
         let task = Some(cx.spawn(async move |this, cx| {
             while let Some(event) = events.next().await {
@@ -1542,6 +1728,9 @@ impl Playback {
         }
     }
 
+    /// Applies what an engine reports. Events from the engine not playing the current track,
+    /// or about another track, are dropped, so a late event from a previous load cannot move
+    /// the clock.
     fn on_backend_event(&mut self, event: BackendEvent, local: bool, cx: &mut Context<Self>) {
         if local != self.local_active() {
             return;
@@ -1551,6 +1740,23 @@ impl Playback {
             && current_id != Some(event_id)
         {
             return;
+        }
+        match event {
+            // A Loading with the current id is the engine restarting the load at a seek
+            // target, so a seek queued behind it must survive.
+            BackendEvent::Position { .. }
+            | BackendEvent::Length { .. }
+            | BackendEvent::Loading { .. }
+            | BackendEvent::OutputChanged => {}
+            BackendEvent::Playing { .. }
+            | BackendEvent::Paused { .. }
+            | BackendEvent::Seeked { .. } => {
+                self.seek_in_flight = None;
+            }
+            _ => {
+                self.seek_in_flight = None;
+                self.seek_next = None;
+            }
         }
         match event {
             BackendEvent::OutputChanged => self.restart_output(cx),
@@ -1565,31 +1771,54 @@ impl Playback {
                 self.clock.reset(at, false);
             }
             BackendEvent::Playing { at, .. } => {
+                let at = self.landed(at);
                 let started = self.state != PlaybackState::Playing;
+                self.intent = Intent::Play;
                 self.state = PlaybackState::Playing;
                 self.position = at;
                 self.clock.reset(at, true);
-                if let Some(at) = self.seek_on_play.take() {
-                    self.seek(at, cx);
-                }
                 if started {
                     cx.emit(PlaybackEvent::StartedPlayback);
                 }
+                self.follow_up_seek(cx);
             }
             BackendEvent::Paused { at, .. } => {
+                self.intent = Intent::Pause;
                 self.state = PlaybackState::Paused;
                 self.position = at;
                 self.clock.reset(at, false);
                 self.remember(true, cx);
+                self.follow_up_seek(cx);
+            }
+            BackendEvent::Seeked { at, .. } => {
+                let at = self.landed(at);
+                self.position = at;
+                self.clock.reset(at, self.state == PlaybackState::Playing);
+                self.remember(true, cx);
+                self.follow_up_seek(cx);
             }
             BackendEvent::Position { at, .. } => {
+                let mut failed = false;
+                if self.seek_in_flight.is_some() {
+                    self.stale_positions += 1;
+                    if self.stale_positions <= STALE_POSITIONS {
+                        return;
+                    }
+                    log::warn!("playback: the seek did not land, carrying on from {at:?}");
+                    self.seek_in_flight = None;
+                    failed = true;
+                }
                 self.position = at;
-                match self.state == PlaybackState::Playing {
-                    true => self.clock.correct(at),
-                    false => self.clock.reset(at, false),
+                match (self.state == PlaybackState::Playing, failed) {
+                    (true, true) => self.clock.reset(at, true),
+                    (true, false) => self.clock.correct(at),
+                    (false, _) => self.clock.reset(at, false),
                 }
                 self.remember(false, cx);
                 self.preload_next(at, cx);
+                if failed {
+                    self.follow_up_seek(cx);
+                }
             }
             BackendEvent::Length { duration, .. } => {
                 if let Some(track) = self.track.as_mut()
@@ -1647,6 +1876,8 @@ impl Playback {
         cx.notify();
     }
 
+    /// Drops the streaming engine and everything derived from its session on sign-out. A local
+    /// track keeps playing.
     fn teardown(&mut self, cx: &mut Context<Self>) {
         self.task = None;
         self.engine = None;
@@ -1667,7 +1898,9 @@ impl Playback {
             self.position = Duration::ZERO;
             self.clock.reset(Duration::ZERO, false);
             self.resume_at = None;
-            self.seek_on_play = None;
+            self.seek_in_flight = None;
+            self.seek_next = None;
+            self.seek_target = None;
             self.resume_ready = false;
             self.awaiting_reconnect = false;
             self.stored = Duration::ZERO;
@@ -1677,12 +1910,14 @@ impl Playback {
         cx.notify();
     }
 
+    /// Stops with a reason the UI can show.
     fn failed(&mut self, problem: String, cx: &mut Context<Self>) {
         log::error!("playback: {problem}");
         self.state = PlaybackState::Failed(problem);
         cx.notify();
     }
 
+    /// Records that the provider wants a signed-in listener and stops until sign-in.
     fn gate(&mut self, cx: &mut Context<Self>) {
         let first = self.refused.is_none();
         self.refused = Some(Refusal::SignIn);
@@ -1711,6 +1946,7 @@ impl Playback {
         cx.notify();
     }
 
+    /// Records that Spotify denied an audio key and stops for the rest of the session.
     fn refuse(&mut self, cx: &mut Context<Self>) {
         let first = self.refused.is_none();
         self.refused = Some(Refusal::Keys);

--- a/crates/views/src/shared/transport.rs
+++ b/crates/views/src/shared/transport.rs
@@ -1,7 +1,7 @@
 use gpui::prelude::*;
 use gpui::{App, Entity, SharedString, div};
 use i18n::t;
-use state::{Playback, PlaybackState, Queue, Repeat, Sonora};
+use state::{Playback, Queue, Repeat, Sonora};
 use ui::{ActiveTheme as _, Button};
 
 pub(crate) const NOTCH: f32 = 0.05;
@@ -69,7 +69,7 @@ pub(crate) fn transport(
 
 pub(crate) fn toggle(playback: &Entity<Playback>, big: bool, cx: &App) -> Button {
     let held = playback.read(cx);
-    let playing = matches!(held.state(), PlaybackState::Playing);
+    let playing = held.wants_playing();
     let idle = held.track().is_none();
     let playback = playback.clone();
 


### PR DESCRIPTION
## Summary

- report playing and seeked from the spotify engine only once the sink writes the first packet of the new audio
- drop the packets a seek or a new track left queued through a generation-tagged queue, and stop relying on rodio's counter, which hung the player after a clear
- park the clock at a seek target until the engine lands there, and send one seek at a time
- let the transport button follow the user's intent instead of waiting for the engine
- take the start position through the player's load, so a seek while loading needs no second seek
- report a seek from the local and youtube engines as seeked