### PR TITLE
refactor(library): hold one shelf per provider and list it by shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the slider under the moon button in the player bar, and hide the button altogether under
   Settings > Playback if you never use it.
 
+- Local albums and artists take a heart too: on their pages, in the library grids and in the
+  context menu.
+
+### Changed
+
+- Local Music lists every imported song, album and artist under the same four tabs as Your Library,
+  and a Favorites only filter narrows each of them to what you starred. The separate Favorites tab
+  is gone. Spotify and YouTube Music keep showing only what you saved.
+
 ### Fixed
 
 - A track that fails to load no longer stops playback. Sonora shows a toast, waits out the short

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -580,7 +580,7 @@ an `Unavailable` track.
 | Entity                                     | Responsibility                                                                                                                                                             |
 | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Session`                                  | auth lifecycle; emits `SessionEvent::{SignedIn, SignedOut}`; hands out `Arc<dyn MusicApi>` and `Arc<dyn PlaybackFactory>`                                                  |
-| `Library`                                  | saved tracks / playlists / albums / followed artists; `LibraryState` is `Empty \| Loading \| Ready{..,problems} \| Failed` — partial failure is normal, surface `problems` |
+| `Library`                                  | one shelf per live provider; `LibraryState` is `Empty \| Loading \| Ready(Ready) \| Failed` — partial failure is normal, surface `Ready::problems`                        |
 | `Playback`                                 | engine ownership, transport, shuffle/repeat, volume, `Origin` tracking, `toggle_origin`                                                                                    |
 | `Queue`                                    | past / current / upcoming; `start`, `next`, `next_random`, `previous`, `rewind`                                                                                            |
 | `Home`, `Detail`, `ArtistDetail`, `Search` | per-screen loaders, each owning its `Task`                                                                                                                                 |
@@ -611,14 +611,29 @@ toggles the group and nothing else, so a route change only ever comes from a tab
 also why an overlaid `SidebarLeft` survives opening a group — it dismisses on navigation, and there
 is none.
 
-**Local Music is a top-level route that reuses `LibraryView`.** `Destination::Local(LocalTab)` owns
-the imported library, and `Root` builds a second `LibraryView` with `Shelf::Local`; the shelf picks
-the state (`Library::local_state`, `local_favorites`) and the settings keys, and every
-`TableSource` takes it through a `shelved(.., local)` constructor. Local Music adds a Songs section
-holding every scanned track, with a heart on each row, beside the Favorites section the streaming
-shelf also has. Its `local-*` settings keys and the `nav-local` i18n key keep the old names so
-stored layouts survive; `Screen::Imported` keeps the stored id `imported` for the same reason.
-Rename the value, not the key.
+**A library has a shape, and the shape decides what its pages list.** `music::Shape` sits on
+`ProviderSession` beside `authenticated` and `playcounts`. `Saved` means the library is what the
+user starred, read through the `saved_*` methods; Spotify and YouTube say so. `Catalog` means the
+library is everything the provider has, read through `all_tracks`, `all_albums` and `all_artists`,
+with the `saved_*` set loaded beside it for hearts and a Favorites only filter; Local and any
+self-hosted server say so. The `saved_*` methods mean favorites on every provider, and the `all_*`
+methods default to an empty list, so a `Saved` provider never implements them. Spotify and YouTube
+get no filter, since their lists are the favorites already.
+
+**Two shelves, one code path.** `state::Shelf::{Streaming, Local}` names the two providers that can
+be live at once, and `Shelf::of(id)` routes an id by its prefix. `Library` holds one `Held` per
+shelf with the same loading, landing and favorites code, and every accessor takes the shelf:
+`state(shelf)`, `loading(shelf, part)`, `part_failed(shelf, part)`, `shape(shelf)`. `Session`
+answers `client_of(shelf)` and `shape_of(shelf)`. Do not add a `local_*` twin of anything; branch
+on `Shelf` or on `Shape`.
+
+**Local Music is a top-level route that reuses `LibraryView`.** `Destination::Local(LibraryTab)` owns
+the imported library, and `Root` builds a second `LibraryView` with `Shelf::Local`; both routes
+share `LibraryTab`, so the two shelves have the same four tabs, Songs included, whatever the shape.
+Every `TableSource` takes the shelf
+through a `shelved(.., shelf)` constructor. The `local-*` settings keys and the `nav-local` i18n key
+keep the old names so stored layouts survive; `Screen::Imported` keeps the stored id `imported` for
+the same reason. Rename the value, not the key.
 
 **Local files carry their own metadata.** `music::local::wire` resolves artwork by convention:
 embedded picture, then `cover`/`folder` beside the track, then the same beside the album folder;
@@ -628,12 +643,12 @@ an artist folder answers to `artist` first, then `folder`, then `cover`, in jpg,
 answers. `state::Tags` owns the read and the write and rescans the folder afterwards;
 `views::shared::tag_editor` is the dialog.
 
-**Saved tracks are called Favorites.** `LibraryTab::Songs`, `Section::Favorites`, the `songs`
-settings key and `library-liked-songs` all keep their old names; only the wording changed. Local
-favorites live in the local tables of `state.sqlite` and reach the same
-`MusicApi::set_track_saved` path, so
-`Library::saved`/`toggle` route by `music::is_local_id`. `MusicApi::all_tracks` is the odd one out:
-it defaults to `saved_tracks` and only the local provider gives it a different answer.
+**Saved tracks are called Favorites.** `LibraryTab::Songs`, the `songs` settings key and
+`library-liked-songs` all keep their old names; only the wording changed. Local favorites live in
+the `favorites`, `favorite_albums` and `favorite_artists` tables of `state.sqlite` and reach the
+same `MusicApi::set_*_saved` paths, so `Library::saved`/`toggle` route by `Shelf::of`. Hearts read
+the starred set on a `Catalog` shelf and the listed items on a `Saved` one. The songs table of a
+`Saved` shelf draws no heart at all, since every row there is a favorite already.
 
 **Which entries the sidebar shows is a setting.** `NavEntry::ALL` (router) is the list; a hidden one
 is stored by id in `hidden_nav` and read through `AppSettings::nav_shown`. Your Library still needs
@@ -665,10 +680,9 @@ add a sidebar entry in `views/src/chrome/sidebar_left.rs` if it's top-level.
 
 **New library section checklist:** `LibraryView` keeps one `TableState` per `Section`, and the
 fixed-size arrays (`views`, `sliders`, `Section::ALL`, `tables()`) are all indexed by
-`Section::slot()` — a new section means bumping every one of them, plus a `LibraryTab` or
-`LocalTab` variant, a `key(shelf)` for settings persistence, a `vacancy(shelf)` i18n key, a card
-renderer, a `deck` arm and a `LIBRARY_TABS` or `LOCAL_TABS` entry. `library/artists.rs` is the
-smallest complete example.
+`Section::slot()` — a new section means bumping every one of them, plus a `LibraryTab` variant, a
+`key(shelf)` for settings persistence, a `vacancy(shelf, shape)` i18n key, a card renderer, a `deck`
+arm and a `LIBRARY_TABS` entry. `library/artists.rs` is the smallest complete example.
 
 **Tables.** Implement `TableSource` (`columns`, `rows`, `cell`, and optionally `compare`, `matches`,
 `playing`, `is_loading`), define a `&'static [ColumnSpec<Field>]`, hold a

--- a/README.md
+++ b/README.md
@@ -164,17 +164,17 @@ AI-assisted proofreading and translation of human-written text are permitted.
 
 | Language | Translated | Coverage |
 | --- | --- | --- |
-| English (`en-US`) | 539/539 | 100% |
-| Deutsch (`de`) | 533/539 | 99% |
-| Español (`es`) | 510/539 | 95% |
-| Français (`fr`) | 492/539 | 91% |
-| Italiano (`it`) | 489/539 | 91% |
-| Bahasa Indonesia (`id`) | 527/539 | 98% |
-| 日本語 (`ja`) | 510/539 | 95% |
-| Русский (`ru`) | 500/539 | 93% |
-| Українська (`uk`) | 500/539 | 93% |
-| Polski (`pl`) | 531/539 | 99% |
-| Português (Brasil) (`pt-BR`) | 510/539 | 95% |
+| English (`en-US`) | 538/538 | 100% |
+| Deutsch (`de`) | 526/538 | 98% |
+| Español (`es`) | 503/538 | 93% |
+| Français (`fr`) | 487/538 | 91% |
+| Italiano (`it`) | 484/538 | 90% |
+| Bahasa Indonesia (`id`) | 520/538 | 97% |
+| 日本語 (`ja`) | 503/538 | 93% |
+| Русский (`ru`) | 500/538 | 93% |
+| Українська (`uk`) | 500/538 | 93% |
+| Polski (`pl`) | 530/538 | 99% |
+| Português (Brasil) (`pt-BR`) | 503/538 | 93% |
 
 <!-- i18n:end -->
 

--- a/assets/i18n/de/main.ftl
+++ b/assets/i18n/de/main.ftl
@@ -25,7 +25,6 @@ nav-search = Suche
 nav-library = Deine Bibliothek
 nav-settings = Einstellungen
 nav-songs = Songs
-nav-favorites = Favoriten
 nav-albums = Alben
 nav-playlists = Playlists
 nav-artists = Künstler
@@ -42,9 +41,7 @@ library-play-liked-songs = Abspielen
 library-no-songs = Noch keine Favoriten
 library-no-albums = Noch keine gespeicherten Alben
 library-no-playlists = Noch keine Playlists
-library-no-artists = Noch keine gefolgten Künstler
 library-no-local-songs = Keine importierten Songs gefunden
-library-no-local-favorites = Noch keine lokalen Favoriten
 library-no-local-albums = Keine importierten Alben gefunden
 library-no-local-artists = Keine importierten Künstler gefunden
 library-no-local-playlists = Noch keine lokalen Playlists
@@ -167,7 +164,6 @@ playlist-again-add = Erneut hinzufügen
 confirm-remove-library-title = Von Bibliothek entfernen
 confirm-remove-playlist-title = Von Playlist entfernen
 confirm-remove-history-title = Von Verlauf entfernen
-confirm-unfollow-title = Entfolgen
 confirm-remove-songs = { $count ->
     [one] Den Song von der Bibliothek entfernen?
    *[other] { $count } Songs von der Bibliothek entfernen?
@@ -183,10 +179,6 @@ confirm-remove-history-songs = { $count ->
 confirm-remove-albums = { $count ->
     [one] Den Album von der Bibliothek entfernen?
    *[other] { $count } Alben von der Bibliothek entfernen?
-}
-confirm-unfollow-artists = { $count ->
-    [one] Den Künstler entfolgen?
-   *[other] { $count } Künstler entfolgen?
 }
 confirm-remove-playlists = { $count ->
     [one] Den Playlist von der Bibliothek entfernen?
@@ -296,8 +288,6 @@ artist-monthly-listeners = { $count ->
    *[other] { $value } monatliche Hörer
 }
 artist-play = Jetzt abspielen
-artist-follow = Folgen
-artist-unfollow = Nicht mehr folgen
 artist-popular = Beliebt
 artist-popular-eyebrow = Diesen Künstler entdecken
 artist-popular-empty = Von diesem Künstler gibt es noch nichts zum Abspielen

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -25,7 +25,6 @@ nav-search = Search
 nav-library = Your Library
 nav-settings = Settings
 nav-songs = Songs
-nav-favorites = Favorites
 nav-albums = Albums
 nav-playlists = Playlists
 nav-artists = Artists
@@ -42,12 +41,14 @@ library-play-liked-songs = Play
 library-no-songs = No favorites yet
 library-no-albums = No saved albums yet
 library-no-playlists = No playlists yet
-library-no-artists = No followed artists yet
+library-no-artists = No favorite artists yet
 library-no-local-songs = No imported songs found
-library-no-local-favorites = No local favorites yet
 library-no-local-albums = No imported albums found
 library-no-local-artists = No imported artists found
 library-no-local-playlists = No local playlists yet
+library-no-catalog-songs = No songs found
+library-no-catalog-albums = No albums found
+library-no-catalog-artists = No artists found
 library-no-matches = No matches
 library-not-loaded = Your library did not load
 library-part-not-loaded = This part of your library did not load
@@ -167,7 +168,6 @@ playlist-again-add = Add again
 confirm-remove-library-title = Remove from library
 confirm-remove-playlist-title = Remove from playlist
 confirm-remove-history-title = Remove from history
-confirm-unfollow-title = Unfollow
 confirm-remove-songs = { $count ->
     [one] Remove this song from your library?
    *[other] Remove { $count } songs from your library?
@@ -184,9 +184,9 @@ confirm-remove-albums = { $count ->
     [one] Remove this album from your library?
    *[other] Remove { $count } albums from your library?
 }
-confirm-unfollow-artists = { $count ->
-    [one] Unfollow this artist?
-   *[other] Unfollow { $count } artists?
+confirm-remove-artists = { $count ->
+    [one] Remove this artist from Favorites?
+   *[other] Remove { $count } artists from Favorites?
 }
 confirm-remove-playlists = { $count ->
     [one] Remove this playlist from your library?
@@ -238,6 +238,7 @@ filter-duration = Duration
 filter-year = Year
 filter-explicit = Explicit only
 filter-playable = Playable only
+filter-favorites = Favorites only
 filter-owned = By you
 
 # view
@@ -300,8 +301,6 @@ artist-monthly-listeners = { $count ->
    *[other] { $value } monthly listeners
 }
 artist-play = Play now
-artist-follow = Follow
-artist-unfollow = Unfollow
 artist-popular = Popular
 artist-popular-eyebrow = Explore this artist
 artist-popular-empty = Nothing to play from this artist yet

--- a/assets/i18n/es/main.ftl
+++ b/assets/i18n/es/main.ftl
@@ -25,7 +25,6 @@ nav-search = Buscar
 nav-library = Tu biblioteca
 nav-settings = Ajustes
 nav-songs = Canciones
-nav-favorites = Favoritos
 nav-albums = Álbumes
 nav-playlists = Listas de reproducción
 nav-artists = Artistas
@@ -42,9 +41,7 @@ library-play-liked-songs = Reproducir
 library-no-songs = Todavía no tienes favoritos
 library-no-albums = Todavía no tienes álbumes guardados
 library-no-playlists = Todavía no tienes listas de reproducción
-library-no-artists = Todavía no sigues a ningún artista
 library-no-local-songs = No se encontraron canciones importadas
-library-no-local-favorites = Todavía no tienes favoritos locales
 library-no-local-albums = No se encontraron álbumes importados
 library-no-local-artists = No se encontraron artistas importados
 library-no-local-playlists = Todavía no tienes listas locales
@@ -162,7 +159,6 @@ playlist-again-add = Añadir otra vez
 confirm-remove-library-title = Quitar de la biblioteca
 confirm-remove-playlist-title = Quitar de la lista
 confirm-remove-history-title = Quitar del historial
-confirm-unfollow-title = Dejar de seguir
 confirm-remove-songs = { $count ->
     [one] ¿Quitar esta canción de tu biblioteca?
    *[other] ¿Quitar { $count } canciones de tu biblioteca?
@@ -178,10 +174,6 @@ confirm-remove-history-songs = { $count ->
 confirm-remove-albums = { $count ->
     [one] ¿Quitar este álbum de tu biblioteca?
    *[other] ¿Quitar { $count } álbumes de tu biblioteca?
-}
-confirm-unfollow-artists = { $count ->
-    [one] ¿Dejar de seguir a este artista?
-   *[other] ¿Dejar de seguir a { $count } artistas?
 }
 confirm-remove-playlists = { $count ->
     [one] ¿Quitar esta lista de tu biblioteca?
@@ -289,8 +281,6 @@ artist-monthly-listeners = { $count ->
    *[other] { $value } oyentes mensuales
 }
 artist-play = Reproducir ahora
-artist-follow = Seguir
-artist-unfollow = Dejar de seguir
 artist-popular = Popular
 artist-popular-eyebrow = Descubre a este artista
 artist-popular-empty = Todavía no hay nada que reproducir de este artista

--- a/assets/i18n/fr/main.ftl
+++ b/assets/i18n/fr/main.ftl
@@ -25,7 +25,6 @@ nav-search = Recherche
 nav-library = Ma bibliothèque
 nav-settings = Paramètres
 nav-songs = Titres
-nav-favorites = Favoris
 nav-albums = Albums
 nav-playlists = Playlists
 nav-artists = Artistes
@@ -42,9 +41,7 @@ library-play-liked-songs = Lire
 library-no-songs = Aucun favori pour l’instant
 library-no-albums = Aucun album enregistré pour l'instant
 library-no-playlists = Aucune playlist pour l'instant
-library-no-artists = Aucun artiste suivi pour l'instant
 library-no-local-songs = Aucun titre importé trouvé
-library-no-local-favorites = Aucun favori local pour l’instant
 library-no-local-albums = Aucun album importé trouvé
 library-no-local-artists = Aucun artiste importé
 library-no-local-playlists = Aucune playlist locale
@@ -227,8 +224,6 @@ artist-monthly-listeners = { $count ->
    *[other] { $value } auditeurs mensuels
 }
 artist-play = Lire maintenant
-artist-follow = Suivre
-artist-unfollow = Ne plus suivre
 artist-popular = Populaires
 artist-popular-eyebrow = Découvrir cet artiste
 artist-popular-empty = Rien à écouter de cet artiste pour l'instant

--- a/assets/i18n/id/main.ftl
+++ b/assets/i18n/id/main.ftl
@@ -25,7 +25,6 @@ nav-search = Cari
 nav-library = Pustaka
 nav-settings = Pengaturan
 nav-songs = Lagu
-nav-favorites = Favorit
 nav-albums = Album
 nav-playlists = Playlist
 nav-artists = Artis
@@ -42,9 +41,7 @@ library-play-liked-songs = Putar
 library-no-songs = Belum ada favorit
 library-no-albums = Belum ada album tersimpan
 library-no-playlists = Belum ada playlist
-library-no-artists = Belum mengikuti artis
 library-no-local-songs = Tidak menemukan lagu yang diimpor
-library-no-local-favorites = Belum ada lagu favorit lokal
 library-no-local-albums = Tidak menemukan album yang diimpor
 library-no-local-artists = Tidak menemukan artis yang diimpor
 library-no-local-playlists = Belum ada playlist lokal
@@ -167,7 +164,6 @@ playlist-again-add = Tambahkan lagi
 confirm-remove-library-title = Hapus dari favorit
 confirm-remove-playlist-title = Hapus dari playlist
 confirm-remove-history-title = Hapus dari riwayat
-confirm-unfollow-title = Berhenti mengikuti
 confirm-remove-songs = { $count ->
     [one] Hapus lagu ini dari favorit?
    *[other] Hapus { $count } lagu dari favorit?
@@ -183,10 +179,6 @@ confirm-remove-history-songs = { $count ->
 confirm-remove-albums = { $count ->
     [one] Hapus album ini dari favorit?
    *[other] Hapus { $count } album dari favorit?
-}
-confirm-unfollow-artists = { $count ->
-    [one] Berhenti mengikuti artis ini?
-   *[other] Berhenti mengikuti { $count } artis?
 }
 confirm-remove-playlists = { $count ->
     [one] Hapus playlist ini dari favorit?
@@ -295,8 +287,6 @@ artist-monthly-listeners = { $count ->
    *[other] { $value } pendengar bulanan
 }
 artist-play = Putar sekarang
-artist-follow = Ikuti
-artist-unfollow = Berhenti mengikuti
 artist-popular = Populer
 artist-popular-eyebrow = Jelajahi artis ini
 artist-popular-empty = Belum ada yang bisa diputar dari artis ini

--- a/assets/i18n/it/main.ftl
+++ b/assets/i18n/it/main.ftl
@@ -25,7 +25,6 @@ nav-search = Cerca
 nav-library = La tua libreria
 nav-settings = Impostazioni
 nav-songs = Brani
-nav-favorites = Preferiti
 nav-albums = Album
 nav-playlists = Playlist
 nav-artists = Artisti
@@ -42,9 +41,7 @@ library-play-liked-songs = Riproduci
 library-no-songs = Ancora nessun preferito
 library-no-albums = Ancora nessun album salvato
 library-no-playlists = Ancora nessuna playlist
-library-no-artists = Ancora nessun artista seguito
 library-no-local-songs = Nessun brano importato trovato
-library-no-local-favorites = Ancora nessun preferito locale
 library-no-local-albums = Nessun album importato trovato
 library-no-local-artists = Nessun artista importato trovato
 library-no-local-playlists = Ancora nessuna playlist locale
@@ -227,8 +224,6 @@ artist-monthly-listeners = { $count ->
    *[other] { $value } ascoltatori al mese
 }
 artist-play = Riproduci
-artist-follow = Segui
-artist-unfollow = Non seguire più
 artist-popular = Popolari
 artist-popular-eyebrow = Esplora questo artista
 artist-popular-empty = Ancora nulla da riprodurre di questo artista

--- a/assets/i18n/ja/main.ftl
+++ b/assets/i18n/ja/main.ftl
@@ -25,7 +25,6 @@ nav-search = 検索
 nav-library = ライブラリ
 nav-settings = 設定
 nav-songs = 曲
-nav-favorites = お気に入り
 nav-albums = アルバム
 nav-playlists = プレイリスト
 nav-artists = アーティスト
@@ -42,9 +41,7 @@ library-play-liked-songs = 再生
 library-no-songs = お気に入りはまだありません
 library-no-albums = 保存したアルバムはまだありません
 library-no-playlists = プレイリストはまだありません
-library-no-artists = フォロー中のアーティストはまだいません
 library-no-local-songs = インポートされた曲が見つかりません
-library-no-local-favorites = ローカルのお気に入りはまだありません
 library-no-local-albums = インポートされたアルバムが見つかりません
 library-no-local-artists = インポートされたアーティストが見つかりません
 library-no-local-playlists = ローカルのプレイリストはまだありません
@@ -141,12 +138,10 @@ playlist-again-add = 再度追加
 confirm-remove-library-title = ライブラリから削除
 confirm-remove-playlist-title = プレイリストから削除
 confirm-remove-history-title = 履歴から削除
-confirm-unfollow-title = フォロー解除
 confirm-remove-songs = { $count }曲をライブラリから削除しますか？
 confirm-remove-playlist-songs = { $count }曲をプレイリストから削除しますか？
 confirm-remove-history-songs = { $count }曲を再生履歴から削除しますか？
 confirm-remove-albums = { $count }枚のアルバムをライブラリから削除しますか？
-confirm-unfollow-artists = { $count }人のアーティストのフォローを解除しますか？
 confirm-remove-playlists = { $count }件のプレイリストをライブラリから削除しますか？
 
 # queue panel
@@ -249,8 +244,6 @@ artist-monthly-listeners = { $count ->
    *[other] 月間リスナー { $value }人
 }
 artist-play = 今すぐ再生
-artist-follow = フォロー
-artist-unfollow = フォロー解除
 artist-popular = 人気の曲
 artist-popular-eyebrow = このアーティストを知る
 artist-popular-empty = このアーティストにはまだ再生できる曲がありません

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -25,7 +25,6 @@ nav-search = Szukaj
 nav-library = Twoja biblioteka
 nav-settings = Ustawienia
 nav-songs = Utwory
-nav-favorites = Ulubione
 nav-albums = Albumy
 nav-playlists = Playlisty
 nav-artists = Wykonawcy
@@ -42,12 +41,14 @@ library-play-liked-songs = Odtwórz
 library-no-songs = Brak ulubionych
 library-no-albums = Brak zapisanych albumów
 library-no-playlists = Brak playlist
-library-no-artists = Brak obserwowanych wykonawców
+library-no-artists = Brak ulubionych wykonawców
 library-no-local-songs = Nie znaleziono zaimportowanych utworów
-library-no-local-favorites = Brak lokalnych ulubionych
 library-no-local-albums = Nie znaleziono zaimportowanych albumów
 library-no-local-artists = Nie znaleziono zaimportowanych wykonawców
 library-no-local-playlists = Nie ma jeszcze lokalnych playlist
+library-no-catalog-songs = Nie znaleziono utworów
+library-no-catalog-albums = Nie znaleziono albumów
+library-no-catalog-artists = Nie znaleziono wykonawców
 library-no-matches = Brak wyników
 library-not-loaded = Biblioteka się nie wczytała
 library-part-not-loaded = Ta część biblioteki się nie wczytała
@@ -176,7 +177,6 @@ playlist-again-add = Dodaj ponownie
 confirm-remove-library-title = Usuń z biblioteki
 confirm-remove-playlist-title = Usuń z playlisty
 confirm-remove-history-title = Usuń z historii
-confirm-unfollow-title = Przestań obserwować
 confirm-remove-songs = { $count ->
     [one] Usunąć ten utwór z biblioteki?
     [few] Usunąć { $count } utwory z biblioteki?
@@ -197,9 +197,10 @@ confirm-remove-albums = { $count ->
     [few] Usunąć { $count } albumy z biblioteki?
    *[other] Usunąć { $count } albumów z biblioteki?
 }
-confirm-unfollow-artists = { $count ->
-    [one] Przestać obserwować tego artystę?
-   *[other] Przestać obserwować { $count } artystów?
+confirm-remove-artists = { $count ->
+    [one] Usunąć tego wykonawcę z ulubionych?
+    [few] Usunąć { $count } wykonawców z ulubionych?
+   *[other] Usunąć { $count } wykonawców z ulubionych?
 }
 confirm-remove-playlists = { $count ->
     [one] Usunąć tę playlistę z biblioteki?
@@ -248,6 +249,7 @@ filter-duration = Czas trwania
 filter-year = Rok
 filter-explicit = Tylko z wulgaryzmami
 filter-playable = Tylko dostępne
+filter-favorites = Tylko ulubione
 filter-owned = Moje
 
 # view
@@ -311,8 +313,6 @@ artist-monthly-listeners = { $count ->
    *[other] { $value } słuchaczy miesięcznie
 }
 artist-play = Odtwórz
-artist-follow = Obserwuj
-artist-unfollow = Nie obserwuj
 artist-popular = Popularne
 artist-popular-eyebrow = Poznaj tego wykonawcę
 artist-popular-empty = Nie ma jeszcze czego odtworzyć u tego wykonawcy

--- a/assets/i18n/pt-BR/main.ftl
+++ b/assets/i18n/pt-BR/main.ftl
@@ -25,7 +25,6 @@ nav-search = Buscar
 nav-library = Sua Biblioteca
 nav-settings = Configurações
 nav-songs = Músicas
-nav-favorites = Favoritas
 nav-albums = Álbuns
 nav-playlists = Playlists
 nav-artists = Artistas
@@ -42,9 +41,7 @@ library-play-liked-songs = Tocar
 library-no-songs = Nenhuma favorita ainda
 library-no-albums = Nenhum álbum salvo ainda
 library-no-playlists = Nenhuma playlist ainda
-library-no-artists = Nenhum artista seguido ainda
 library-no-local-songs = Nenhuma música importada encontrada
-library-no-local-favorites = Nenhuma favorita local ainda
 library-no-local-albums = Nenhum álbum importado encontrado
 library-no-local-artists = Nenhum artista importado encontrado
 library-no-local-playlists = Nenhuma playlist local ainda
@@ -162,7 +159,6 @@ playlist-again-add = Adicionar novamente
 confirm-remove-library-title = Remover da biblioteca
 confirm-remove-playlist-title = Remover da playlist
 confirm-remove-history-title = Remover do histórico
-confirm-unfollow-title = Deixar de seguir
 confirm-remove-songs = { $count ->
     [one] Remover esta música da sua biblioteca?
    *[other] Remover { $count } músicas da sua biblioteca?
@@ -178,10 +174,6 @@ confirm-remove-history-songs = { $count ->
 confirm-remove-albums = { $count ->
     [one] Remover este álbum da sua biblioteca?
    *[other] Remover { $count } álbuns da sua biblioteca?
-}
-confirm-unfollow-artists = { $count ->
-    [one] Deixar de seguir este artista?
-   *[other] Deixar de seguir { $count } artistas?
 }
 confirm-remove-playlists = { $count ->
     [one] Remover esta playlist da sua biblioteca?
@@ -289,8 +281,6 @@ artist-monthly-listeners = { $count ->
    *[other] { $value } ouvintes mensais
 }
 artist-play = Tocar agora
-artist-follow = Seguir
-artist-unfollow = Deixar de seguir
 artist-popular = Populares
 artist-popular-eyebrow = Explorar este artista
 artist-popular-empty = Nada para tocar deste artista ainda

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -25,7 +25,6 @@ nav-search = Поиск
 nav-library = Моя медиатека
 nav-settings = Настройки
 nav-songs = Треки
-nav-favorites = Избранное
 nav-albums = Альбомы
 nav-playlists = Плейлисты
 nav-artists = Исполнители
@@ -42,12 +41,14 @@ library-play-liked-songs = Слушать
 library-no-songs = Пока нет избранного
 library-no-albums = Пока нет сохранённых альбомов
 library-no-playlists = Пока нет плейлистов
-library-no-artists = Пока нет отслеживаемых исполнителей
+library-no-artists = Пока нет избранных исполнителей
 library-no-local-songs = Импортированные треки не найдены
-library-no-local-favorites = Пока нет локального избранного
 library-no-local-albums = Импортированные альбомы не найдены
 library-no-local-artists = Импортированные исполнители не найдены
 library-no-local-playlists = Локальных плейлистов пока нет
+library-no-catalog-songs = Треки не найдены
+library-no-catalog-albums = Альбомы не найдены
+library-no-catalog-artists = Исполнители не найдены
 library-no-matches = Ничего не найдено
 library-not-loaded = Библиотека не загрузилась
 library-part-not-loaded = Этот раздел библиотеки не загрузился
@@ -167,6 +168,7 @@ filter-duration = Длительность
 filter-year = Год
 filter-explicit = Только с ненормативной лексикой
 filter-playable = Только доступные
+filter-favorites = Только избранное
 
 # view
 view-list = Список
@@ -229,8 +231,6 @@ artist-monthly-listeners = { $count ->
    *[other] { $value } слушателей в месяц
 }
 artist-play = Слушать
-artist-follow = Отслеживать
-artist-unfollow = Не отслеживать
 artist-popular = Популярное
 artist-popular-eyebrow = Знакомство с исполнителем
 artist-popular-empty = Пока нечего слушать у этого исполнителя

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -25,7 +25,6 @@ nav-search = Пошук
 nav-library = Моя медіатека
 nav-settings = Налаштування
 nav-songs = Треки
-nav-favorites = Улюблене
 nav-albums = Альбоми
 nav-playlists = Плейлисти
 nav-artists = Виконавці
@@ -42,12 +41,14 @@ library-play-liked-songs = Слухати
 library-no-songs = Улюбленого ще немає
 library-no-albums = Поки немає збережених альбомів
 library-no-playlists = Поки немає плейлистів
-library-no-artists = Поки немає відстежуваних виконавців
+library-no-artists = Поки немає улюблених виконавців
 library-no-local-songs = Імпортовані треки не знайдено
-library-no-local-favorites = Локального улюбленого ще немає
 library-no-local-albums = Імпортовані альбоми не знайдено
 library-no-local-artists = Імпортованих виконавців не знайдено
 library-no-local-playlists = Локальних плейлистів ще немає
+library-no-catalog-songs = Треків не знайдено
+library-no-catalog-albums = Альбомів не знайдено
+library-no-catalog-artists = Виконавців не знайдено
 library-no-matches = Нічого не знайдено
 library-not-loaded = Бібліотека не завантажилася
 library-part-not-loaded = Цей розділ бібліотеки не завантажився
@@ -167,6 +168,7 @@ filter-duration = Тривалість
 filter-year = Рік
 filter-explicit = Лише з ненормативною лексикою
 filter-playable = Лише доступні
+filter-favorites = Лише улюблене
 
 # view
 view-list = Список
@@ -229,8 +231,6 @@ artist-monthly-listeners = { $count ->
    *[other] { $value } слухачів на місяць
 }
 artist-play = Слухати
-artist-follow = Відстежувати
-artist-unfollow = Не відстежувати
 artist-popular = Популярне
 artist-popular-eyebrow = Знайомство з виконавцем
 artist-popular-empty = Поки немає чого слухати в цього виконавця

--- a/crates/music/src/lib.rs
+++ b/crates/music/src/lib.rs
@@ -80,10 +80,14 @@ pub trait MusicApi: Send + Sync {
     async fn artist(&self, artist_id: &str) -> Result<Artist>;
     async fn artist_profile(&self, artist_id: &str) -> Result<ArtistProfile>;
     async fn artist_images(&self, ids: Vec<String>) -> Result<HashMap<String, String>>;
+
+    /// The tracks the user starred. On a `Shape::Saved` provider this is the whole songs
+    /// library; on a `Shape::Catalog` one it only feeds the hearts and the favorites filter.
     async fn saved_tracks(&self, limit: u32) -> Result<Vec<Track>>;
 
-    async fn all_tracks(&self, limit: u32) -> Result<Vec<Track>> {
-        self.saved_tracks(limit).await
+    /// Every track the provider has. Only a `Shape::Catalog` provider answers.
+    async fn all_tracks(&self, _limit: u32) -> Result<Vec<Track>> {
+        Ok(Vec::new())
     }
 
     async fn set_track_saved(&self, track_id: &str, saved: bool) -> Result<()>;
@@ -111,8 +115,20 @@ pub trait MusicApi: Send + Sync {
     async fn add_track_to_playlist(&self, playlist_id: &str, track_id: &str) -> Result<()>;
     async fn remove_track_from_playlist(&self, playlist_id: &str, track_id: &str) -> Result<()>;
     async fn saved_albums(&self, limit: u32) -> Result<Vec<Album>>;
+
+    /// Every album the provider has. Only a `Shape::Catalog` provider answers.
+    async fn all_albums(&self, _limit: u32) -> Result<Vec<Album>> {
+        Ok(Vec::new())
+    }
+
     async fn set_album_saved(&self, album_id: &str, saved: bool) -> Result<()>;
     async fn saved_artists(&self, limit: u32) -> Result<Vec<SavedArtist>>;
+
+    /// Every artist the provider has. Only a `Shape::Catalog` provider answers.
+    async fn all_artists(&self, _limit: u32) -> Result<Vec<SavedArtist>> {
+        Ok(Vec::new())
+    }
+
     async fn set_artist_saved(&self, artist_id: &str, saved: bool) -> Result<()>;
     async fn album(&self, album_id: &str) -> Result<AlbumDetail>;
     async fn album_tracks(&self, album_id: &str) -> Result<Vec<Track>>;
@@ -254,10 +270,22 @@ pub trait PlaybackFactory: Send + Sync {
     fn start(&self, config: PlaybackConfig) -> (Box<dyn Player>, Box<dyn PlaybackEvents>);
 }
 
+/// What a provider's library is made of. It decides which `MusicApi` methods fill the library
+/// pages and whether a favorites filter is offered on them.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Shape {
+    /// The library is what the user starred, read through the `saved_*` methods.
+    Saved,
+    /// The library is everything the provider has, read through the `all_*` methods, with the
+    /// `saved_*` set drawn on top as hearts and a filter.
+    Catalog,
+}
+
 pub struct ProviderSession {
     pub profile: UserProfile,
     pub api: Arc<dyn MusicApi>,
     pub playback: Arc<dyn PlaybackFactory>,
+    pub shape: Shape,
     pub authenticated: bool,
     pub playcounts: bool,
 }

--- a/crates/music/src/local/client.rs
+++ b/crates/music/src/local/client.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 use super::scan::Scanned;
-use super::store::Store;
+use super::store::{Starred, Store};
 use super::{tags, wire};
 
 const COVERS: usize = 4;
@@ -72,6 +72,37 @@ impl LocalClient {
             .filter_map(wire::path_from_track_id)
             .map(Path::to_path_buf)
             .collect()
+    }
+
+    /// Every artist in the scan, one per distinct artist string, sorted by name.
+    fn artists(&self) -> Vec<SavedArtist> {
+        let scanned = self.scanned.read().unwrap();
+        let mut artists: Vec<SavedArtist> = Vec::new();
+        for track in &scanned.tracks {
+            if let Some(known) = artists.iter_mut().find(|known| known.name == track.artists) {
+                known.added_at = known.added_at.max(track.added_at);
+                continue;
+            }
+            artists.push(SavedArtist {
+                id: wire::artist_id(&track.artists),
+                name: track.artists.clone(),
+                cover: scanned
+                    .portraits
+                    .get(&track.artists)
+                    .cloned()
+                    .or_else(|| {
+                        scanned
+                            .albums
+                            .iter()
+                            .find(|album| album.artists == track.artists)
+                            .and_then(|album| album.cover.clone())
+                    })
+                    .or_else(|| track.cover.clone()),
+                added_at: track.added_at,
+            });
+        }
+        artists.sort_by_key(|artist| artist.name.to_lowercase());
+        artists
     }
 }
 
@@ -157,9 +188,9 @@ impl MusicApi for LocalClient {
     }
 
     async fn saved_tracks(&self, limit: u32) -> Result<Vec<Track>> {
-        let favorites = self.store.favorites()?;
+        let starred = self.store.starred(Starred::Tracks)?;
         let scanned = self.scanned.read().unwrap();
-        Ok(favorites
+        Ok(starred
             .into_iter()
             .take(limit as usize)
             .filter_map(|(id, added_at)| {
@@ -185,7 +216,7 @@ impl MusicApi for LocalClient {
     }
 
     async fn set_track_saved(&self, track_id: &str, saved: bool) -> Result<()> {
-        self.store.set_favorite(track_id, saved)
+        self.store.set_starred(Starred::Tracks, track_id, saved)
     }
 
     async fn track_tags(&self, track_id: &str) -> Result<TrackTags> {
@@ -273,6 +304,24 @@ impl MusicApi for LocalClient {
     }
 
     async fn saved_albums(&self, limit: u32) -> Result<Vec<Album>> {
+        let starred = self.store.starred(Starred::Albums)?;
+        let scanned = self.scanned.read().unwrap();
+        Ok(starred
+            .into_iter()
+            .take(limit as usize)
+            .filter_map(|(id, added_at)| {
+                let mut album = scanned
+                    .albums
+                    .iter()
+                    .find(|album| album.id == id)
+                    .cloned()?;
+                album.added_at = Some(added_at);
+                Some(album)
+            })
+            .collect())
+    }
+
+    async fn all_albums(&self, limit: u32) -> Result<Vec<Album>> {
         let scanned = self.scanned.read().unwrap();
         Ok(scanned
             .albums
@@ -282,43 +331,32 @@ impl MusicApi for LocalClient {
             .collect())
     }
 
-    async fn set_album_saved(&self, _album_id: &str, _saved: bool) -> Result<()> {
-        Ok(())
+    async fn set_album_saved(&self, album_id: &str, saved: bool) -> Result<()> {
+        self.store.set_starred(Starred::Albums, album_id, saved)
     }
 
     async fn saved_artists(&self, limit: u32) -> Result<Vec<SavedArtist>> {
-        let scanned = self.scanned.read().unwrap();
-        let mut artists: Vec<SavedArtist> = Vec::new();
-        for track in &scanned.tracks {
-            if let Some(known) = artists.iter_mut().find(|known| known.name == track.artists) {
-                known.added_at = known.added_at.max(track.added_at);
-                continue;
-            }
-            artists.push(SavedArtist {
-                id: wire::artist_id(&track.artists),
-                name: track.artists.clone(),
-                cover: scanned
-                    .portraits
-                    .get(&track.artists)
-                    .cloned()
-                    .or_else(|| {
-                        scanned
-                            .albums
-                            .iter()
-                            .find(|album| album.artists == track.artists)
-                            .and_then(|album| album.cover.clone())
-                    })
-                    .or_else(|| track.cover.clone()),
-                added_at: track.added_at,
-            });
-        }
-        artists.sort_by_key(|artist| artist.name.to_lowercase());
+        let starred = self.store.starred(Starred::Artists)?;
+        let known = self.artists();
+        Ok(starred
+            .into_iter()
+            .take(limit as usize)
+            .filter_map(|(id, added_at)| {
+                let mut artist = known.iter().find(|artist| artist.id == id).cloned()?;
+                artist.added_at = Some(added_at);
+                Some(artist)
+            })
+            .collect())
+    }
+
+    async fn all_artists(&self, limit: u32) -> Result<Vec<SavedArtist>> {
+        let mut artists = self.artists();
         artists.truncate(limit as usize);
         Ok(artists)
     }
 
-    async fn set_artist_saved(&self, _artist_id: &str, _saved: bool) -> Result<()> {
-        Ok(())
+    async fn set_artist_saved(&self, artist_id: &str, saved: bool) -> Result<()> {
+        self.store.set_starred(Starred::Artists, artist_id, saved)
     }
 
     async fn album(&self, album_id: &str) -> Result<AlbumDetail> {

--- a/crates/music/src/local/mod.rs
+++ b/crates/music/src/local/mod.rs
@@ -13,8 +13,8 @@ use async_trait::async_trait;
 use storage::Database;
 
 use crate::{
-    InputSource, MusicApi, MusicProvider, PlaybackFactory, PromptSink, ProviderSession, SignIn,
-    UserProfile,
+    InputSource, MusicApi, MusicProvider, PlaybackFactory, PromptSink, ProviderSession, Shape,
+    SignIn, UserProfile,
 };
 
 pub struct LocalProvider {
@@ -47,6 +47,7 @@ impl LocalProvider {
             },
             api,
             playback,
+            shape: Shape::Catalog,
             authenticated: false,
             playcounts: false,
         })

--- a/crates/music/src/local/store.rs
+++ b/crates/music/src/local/store.rs
@@ -10,6 +10,32 @@ pub struct Stored {
     pub modified_at: i64,
 }
 
+/// Which local favorites table a star lands in.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Starred {
+    Tracks,
+    Albums,
+    Artists,
+}
+
+impl Starred {
+    fn table(self) -> &'static str {
+        match self {
+            Self::Tracks => "favorites",
+            Self::Albums => "favorite_albums",
+            Self::Artists => "favorite_artists",
+        }
+    }
+
+    fn column(self) -> &'static str {
+        match self {
+            Self::Tracks => "track_id",
+            Self::Albums => "album_id",
+            Self::Artists => "artist_id",
+        }
+    }
+}
+
 pub struct Store {
     database: Database,
 }
@@ -23,10 +49,15 @@ impl Store {
         self.database.open().context("cannot open local playlists")
     }
 
-    pub fn favorites(&self) -> Result<Vec<(String, i64)>> {
+    /// The starred ids of one kind, newest first, with the moment each was starred.
+    pub fn starred(&self, kind: Starred) -> Result<Vec<(String, i64)>> {
         let connection = self.open()?;
         let mut query = connection
-            .prepare("SELECT track_id, added_at FROM favorites ORDER BY added_at DESC")
+            .prepare(&format!(
+                "SELECT {}, added_at FROM {} ORDER BY added_at DESC",
+                kind.column(),
+                kind.table()
+            ))
             .context("cannot read local favorites")?;
         let rows = query
             .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
@@ -36,16 +67,20 @@ impl Store {
             .context("cannot read local favorites")
     }
 
-    pub fn set_favorite(&self, track_id: &str, saved: bool) -> Result<()> {
+    pub fn set_starred(&self, kind: Starred, id: &str, saved: bool) -> Result<()> {
         let connection = self.open()?;
         match saved {
             true => connection.execute(
-                "INSERT OR REPLACE INTO favorites (track_id, added_at) VALUES (?, ?)",
-                params![track_id, stamp()],
+                &format!(
+                    "INSERT OR REPLACE INTO {} ({}, added_at) VALUES (?, ?)",
+                    kind.table(),
+                    kind.column()
+                ),
+                params![id, stamp()],
             ),
             false => connection.execute(
-                "DELETE FROM favorites WHERE track_id = ?",
-                params![track_id],
+                &format!("DELETE FROM {} WHERE {} = ?", kind.table(), kind.column()),
+                params![id],
             ),
         }
         .context("cannot update a local favorite")?;

--- a/crates/music/src/spotify/mod.rs
+++ b/crates/music/src/spotify/mod.rs
@@ -22,7 +22,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use crate::spotify::playback::Factory;
-use crate::{MusicApi as _, MusicProvider, ProviderSession, SignInFailure, SignInProblem};
+use crate::{MusicApi as _, MusicProvider, ProviderSession, Shape, SignInFailure, SignInProblem};
 
 pub use auth::AuthConfig;
 pub use client::LibrespotClient;
@@ -57,6 +57,7 @@ impl SpotifyProvider {
             profile,
             api: Arc::new(client),
             playback,
+            shape: Shape::Saved,
             authenticated: true,
             playcounts: true,
         })

--- a/crates/music/src/youtube/mod.rs
+++ b/crates/music/src/youtube/mod.rs
@@ -18,8 +18,8 @@ use ytmusic::YtMusic;
 use crate::youtube::playback::Factory;
 
 use crate::{
-    InputSource, MusicProvider, PromptSink, ProviderSession, SignIn, SignInPrompt, UserProfile,
-    credentials,
+    InputSource, MusicProvider, PromptSink, ProviderSession, Shape, SignIn, SignInPrompt,
+    UserProfile, credentials,
 };
 pub use client::YouTubeClient;
 
@@ -89,6 +89,7 @@ impl YouTubeProvider {
             profile,
             api: Arc::new(client),
             playback: Arc::new(Factory::new(api)),
+            shape: Shape::Saved,
             authenticated: true,
             playcounts: false,
         }
@@ -102,6 +103,7 @@ impl YouTubeProvider {
             },
             api: Arc::new(YouTubeClient::new(api.clone())),
             playback: Arc::new(Factory::new(api)),
+            shape: Shape::Saved,
             authenticated: false,
             playcounts: false,
         }

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -17,35 +17,6 @@ pub enum LibraryTab {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum LocalTab {
-    Songs,
-    Favorites,
-    Albums,
-    Artists,
-    Playlists,
-}
-
-impl LocalTab {
-    pub const ALL: [Self; 5] = [
-        Self::Favorites,
-        Self::Songs,
-        Self::Albums,
-        Self::Artists,
-        Self::Playlists,
-    ];
-
-    pub fn key(self) -> &'static str {
-        match self {
-            Self::Songs => "nav-songs",
-            Self::Favorites => "nav-favorites",
-            Self::Albums => "nav-albums",
-            Self::Artists => "nav-artists",
-            Self::Playlists => "nav-playlists",
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NavEntry {
     Home,
     Search,
@@ -126,7 +97,7 @@ impl Screen {
             Self::Home => "nav-home",
             Self::Search => "nav-search",
             Self::History => "nav-history",
-            Self::Songs => "nav-favorites",
+            Self::Songs => "nav-songs",
             Self::Albums => "nav-albums",
             Self::Playlists => "nav-playlists",
             Self::Artists => "nav-artists",
@@ -147,7 +118,7 @@ impl Screen {
             Self::Albums => Destination::Library(LibraryTab::Albums),
             Self::Playlists => Destination::Library(LibraryTab::Playlists),
             Self::Artists => Destination::Library(LibraryTab::Artists),
-            Self::Imported => Destination::Local(LocalTab::Songs),
+            Self::Imported => Destination::Local(LibraryTab::Songs),
         }
     }
 }
@@ -166,7 +137,7 @@ pub enum Destination {
     Home,
     History,
     Library(LibraryTab),
-    Local(LocalTab),
+    Local(LibraryTab),
     Album(SharedString),
     Song(SharedString),
     Playlist(SharedString),

--- a/crates/sonora/src/actions.rs
+++ b/crates/sonora/src/actions.rs
@@ -5,7 +5,7 @@ use input::{
     SignOut, SongNext, SongPrevious, TogglePlayback, ZoomWindow,
 };
 use router::Destination;
-use state::Sonora;
+use state::{Shelf, Sonora};
 use ui::{Copy, Cut, Paste, SelectAll};
 
 pub fn register(lingers: bool, cx: &mut App) {
@@ -39,9 +39,13 @@ pub fn register(lingers: bool, cx: &mut App) {
                 let history = Sonora::global(cx).history.clone();
                 history.update(cx, |history, cx| history.refresh(cx));
             }
-            _ => {
+            at => {
+                let shelf = match at {
+                    Destination::Local(_) => Shelf::Local,
+                    _ => Shelf::Streaming,
+                };
                 let library = Sonora::global(cx).library.clone();
-                library.update(cx, |library, cx| library.refresh(cx));
+                library.update(cx, |library, cx| library.refresh(shelf, cx));
             }
         },
     );

--- a/crates/state/src/detail.rs
+++ b/crates/state/src/detail.rs
@@ -188,10 +188,7 @@ impl Detail {
 
     pub fn open_album(&mut self, id: &str, cx: &mut Context<Self>) {
         let library = self.library.read(cx);
-        let known = library
-            .album(id)
-            .or_else(|| library.local_album(id))
-            .cloned();
+        let known = library.album(id).cloned();
         let header = known.as_ref().map(album_header);
         if self.open(Collection::Album, id, header, cx) && !self.loaded {
             self.album = known;

--- a/crates/state/src/home.rs
+++ b/crates/state/src/home.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use gpui::{App, Context, Entity, Task};
 use music::{GenreItem, GenreSection, Track};
 
-use crate::{Io, Library, LibraryPart, LibraryState, Session, SessionEvent, join};
+use crate::{Io, Library, LibraryPart, LibraryState, Session, SessionEvent, Shelf, join};
 
 const GROUP_SIZE: usize = 10;
 const LIMIT: usize = GROUP_SIZE * 3;
@@ -48,8 +48,8 @@ impl Home {
         .detach();
 
         cx.observe(&library, |this, library, cx| {
-            match library.read(cx).state() {
-                LibraryState::Ready { .. } if this.quick_picks.is_empty() => {
+            match library.read(cx).state(Shelf::Streaming) {
+                LibraryState::Ready(_) if this.quick_picks.is_empty() => {
                     this.quick_picks = picks(&library, this.quick_picks_seed, cx);
                 }
                 LibraryState::Empty | LibraryState::Failed(_) => {
@@ -154,7 +154,9 @@ impl Home {
     }
 
     pub fn is_loading(&self, cx: &App) -> bool {
-        self.library.read(cx).loading(LibraryPart::Tracks)
+        self.library
+            .read(cx)
+            .loading(Shelf::Streaming, LibraryPart::Tracks)
     }
 }
 
@@ -185,11 +187,8 @@ fn pruned(sections: &[GenreSection]) -> Vec<GenreSection> {
 }
 
 fn picks(library: &Entity<Library>, seed: u64, cx: &App) -> Rc<Vec<Track>> {
-    let tracks = match library.read(cx).state() {
-        LibraryState::Ready { tracks, .. } => mixed_tracks(tracks, seed),
-        _ => Vec::new(),
-    };
-    Rc::new(tracks)
+    let tracks = library.read(cx).state(Shelf::Streaming).tracks();
+    Rc::new(mixed_tracks(tracks, seed))
 }
 
 fn mixed_tracks(tracks: &[Track], seed: u64) -> Vec<Track> {

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -28,7 +28,7 @@ pub use detail::{Collection, Detail, Header};
 pub use genre::{GenreDetails, Genres};
 pub use history::{History, HistoryState};
 pub use home::Home;
-pub use library::{Library, LibraryEvent, LibraryPart, LibraryState, Problem};
+pub use library::{Library, LibraryEvent, LibraryPart, LibraryState, Problem, Ready, Shelf};
 pub use lyrics::{Lyrics, LyricsState};
 pub use playback::{Origin, Playback, PlaybackState, Repeat, Sleep, Whence};
 pub use profile::Profile;

--- a/crates/state/src/library.rs
+++ b/crates/state/src/library.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use gpui::{Context, Entity, SharedString, Task};
-use music::{Album, MusicApi, Playlist, SavedArtist, Track};
+use music::{Album, MusicApi, Playlist, SavedArtist, Shape, Track};
 
 use crate::{Io, Outcome, Session, SessionEvent, Target, Toasts, join, mosaic};
 
@@ -16,6 +16,140 @@ const FATAL: [LibraryPart; 3] = [
     LibraryPart::Albums,
 ];
 const FATAL_LOCAL: [LibraryPart; 2] = [LibraryPart::Tracks, LibraryPart::Albums];
+
+/// Which provider a library page, an id or a playlist belongs to. The streaming shelf follows
+/// the signed-in provider; the local shelf follows the imported folder.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Shelf {
+    Streaming,
+    Local,
+}
+
+impl Shelf {
+    /// The shelf an id belongs to, by its prefix.
+    pub fn of(id: &str) -> Self {
+        match music::is_local_id(id) {
+            true => Self::Local,
+            false => Self::Streaming,
+        }
+    }
+
+    pub fn local(self) -> bool {
+        self == Self::Local
+    }
+
+    fn slot(self) -> usize {
+        match self {
+            Self::Streaming => 0,
+            Self::Local => 1,
+        }
+    }
+
+    /// The parts whose joint failure marks the whole shelf failed, rather than one problem.
+    fn fatal(self) -> &'static [LibraryPart] {
+        match self {
+            Self::Streaming => &FATAL,
+            Self::Local => &FATAL_LOCAL,
+        }
+    }
+}
+
+/// Everything the library holds for one shelf. On a `Shape::Saved` shelf the lists in `state`
+/// are the favorites; on a `Shape::Catalog` shelf they are the whole catalog and `starred`
+/// carries the favorites beside them.
+struct Held {
+    shape: Shape,
+    state: LibraryState,
+    awaited: Vec<LibraryPart>,
+    starred: Starred,
+    tasks: Vec<Task<()>>,
+}
+
+impl Held {
+    fn empty() -> Self {
+        Self {
+            shape: Shape::Saved,
+            state: LibraryState::Empty,
+            awaited: Vec::new(),
+            starred: Starred::default(),
+            tasks: Vec::new(),
+        }
+    }
+
+    fn clear(&mut self) {
+        *self = Self::empty();
+    }
+
+    fn ready(&self) -> Option<&Ready> {
+        match &self.state {
+            LibraryState::Ready(ready) => Some(ready),
+            _ => None,
+        }
+    }
+
+    fn ready_mut(&mut self) -> Option<&mut Ready> {
+        match &mut self.state {
+            LibraryState::Ready(ready) => Some(ready),
+            _ => None,
+        }
+    }
+
+    /// The favorites of each kind, wherever the shape keeps them.
+    fn favorites(&self) -> Option<Favorites<'_>> {
+        match self.shape {
+            Shape::Saved => {
+                let ready = self.ready()?;
+                Some(Favorites {
+                    tracks: &ready.tracks,
+                    albums: &ready.albums,
+                    artists: &ready.artists,
+                })
+            }
+            Shape::Catalog => Some(Favorites {
+                tracks: &self.starred.tracks,
+                albums: &self.starred.albums,
+                artists: &self.starred.artists,
+            }),
+        }
+    }
+
+    fn favorites_mut(&mut self) -> Option<FavoritesMut<'_>> {
+        match self.shape {
+            Shape::Saved => {
+                let ready = self.ready_mut()?;
+                Some(FavoritesMut {
+                    tracks: &mut ready.tracks,
+                    albums: &mut ready.albums,
+                    artists: &mut ready.artists,
+                })
+            }
+            Shape::Catalog => Some(FavoritesMut {
+                tracks: &mut self.starred.tracks,
+                albums: &mut self.starred.albums,
+                artists: &mut self.starred.artists,
+            }),
+        }
+    }
+}
+
+#[derive(Default)]
+struct Starred {
+    tracks: Vec<Track>,
+    albums: Vec<Album>,
+    artists: Vec<SavedArtist>,
+}
+
+struct Favorites<'a> {
+    tracks: &'a [Track],
+    albums: &'a [Album],
+    artists: &'a [SavedArtist],
+}
+
+struct FavoritesMut<'a> {
+    tracks: &'a mut Vec<Track>,
+    albums: &'a mut Vec<Album>,
+    artists: &'a mut Vec<SavedArtist>,
+}
 
 enum Landed {
     Tracks(anyhow::Result<Vec<Track>>),
@@ -41,7 +175,7 @@ struct PlaylistMutation {
     name: Option<String>,
     target: Option<Target>,
     invalidated: Option<String>,
-    local: bool,
+    shelf: Shelf,
 }
 
 fn place(
@@ -51,27 +185,21 @@ fn place(
     fatal: &[LibraryPart],
 ) {
     awaited.retain(|part| *part != landed.part());
-    if !matches!(state, LibraryState::Ready { .. }) {
-        *state = LibraryState::Ready {
-            tracks: Vec::new(),
-            playlists: Vec::new(),
-            albums: Vec::new(),
-            artists: Vec::new(),
-            problems: Vec::new(),
-        };
+    if !matches!(state, LibraryState::Ready(_)) {
+        *state = LibraryState::Ready(Ready::default());
     }
 
     let failure = {
-        let LibraryState::Ready {
+        let LibraryState::Ready(ready) = state else {
+            return;
+        };
+        let Ready {
             tracks,
             playlists,
             albums,
             artists,
             problems,
-        } = state
-        else {
-            return;
-        };
+        } = ready;
         let part = landed.part();
         match landed {
             Landed::Tracks(result) => *tracks = take(part, result, problems),
@@ -92,6 +220,24 @@ fn place(
     if let Some(reason) = failure {
         *state = LibraryState::Failed(reason);
     }
+}
+
+/// Puts one loaded favorites set onto a catalog shelf; a failure only logs, since the catalog
+/// itself is still there to show.
+fn star(held: &mut Held, landed: Landed) {
+    match landed {
+        Landed::Tracks(result) => held.starred.tracks = lenient("tracks", result),
+        Landed::Albums(result) => held.starred.albums = lenient("albums", result),
+        Landed::Artists(result) => held.starred.artists = lenient("artists", result),
+        Landed::Playlists(_) => {}
+    }
+}
+
+fn lenient<T>(what: &str, result: anyhow::Result<Vec<T>>) -> Vec<T> {
+    result.unwrap_or_else(|error| {
+        log::warn!("library: cannot load the starred {what}: {error:#}");
+        Vec::new()
+    })
 }
 
 fn stamp() -> i64 {
@@ -124,12 +270,7 @@ impl Library {
         if S::requests(self).contains_key(&id) {
             return;
         }
-        let session = self.session.read(cx);
-        let picked = match music::is_local_id(&id) {
-            true => session.local_client(),
-            false => session.client(),
-        };
-        let Some(client) = picked else {
+        let Some(client) = self.session.read(cx).client_of(Shelf::of(&id)) else {
             return;
         };
 
@@ -210,8 +351,9 @@ impl Savable for Track {
     }
 
     fn saved_now(library: &Library, id: &str) -> Option<Self> {
-        library
-            .favorites(id)
+        let favorites = library.favorites(id)?;
+        favorites
+            .tracks
             .iter()
             .find(|track| track.id.as_deref() == Some(id))
             .cloned()
@@ -246,7 +388,12 @@ impl Savable for Album {
     }
 
     fn saved_now(library: &Library, id: &str) -> Option<Self> {
-        library.album(id).cloned()
+        let favorites = library.favorites(id)?;
+        favorites
+            .albums
+            .iter()
+            .find(|album| album.id == id)
+            .cloned()
     }
 
     fn requests(library: &mut Library) -> &mut HashMap<String, Task<()>> {
@@ -263,7 +410,7 @@ impl Savable for Album {
 }
 
 impl Savable for SavedArtist {
-    const TROUBLE: &'static str = "followed artist";
+    const TROUBLE: &'static str = "favorite artist";
 
     fn id(&self) -> Option<&str> {
         Some(&self.id)
@@ -282,7 +429,12 @@ impl Savable for SavedArtist {
     }
 
     fn saved_now(library: &Library, id: &str) -> Option<Self> {
-        library.artist(id).cloned()
+        let favorites = library.favorites(id)?;
+        favorites
+            .artists
+            .iter()
+            .find(|artist| artist.id == id)
+            .cloned()
     }
 
     fn requests(library: &mut Library) -> &mut HashMap<String, Task<()>> {
@@ -330,32 +482,54 @@ pub struct Problem {
     pub reason: String,
 }
 
+/// What a shelf shows once loaded. A part that failed is empty and named in `problems`.
+#[derive(Default)]
+pub struct Ready {
+    pub tracks: Vec<Track>,
+    pub playlists: Vec<Playlist>,
+    pub albums: Vec<Album>,
+    pub artists: Vec<SavedArtist>,
+    pub problems: Vec<Problem>,
+}
+
 pub enum LibraryState {
     Empty,
     Loading,
-    Ready {
-        tracks: Vec<Track>,
-        playlists: Vec<Playlist>,
-        albums: Vec<Album>,
-        artists: Vec<SavedArtist>,
-        problems: Vec<Problem>,
-    },
+    Ready(Ready),
     Failed(String),
+}
+
+impl LibraryState {
+    pub fn ready(&self) -> Option<&Ready> {
+        match self {
+            Self::Ready(ready) => Some(ready),
+            _ => None,
+        }
+    }
+
+    pub fn tracks(&self) -> &[Track] {
+        self.ready().map_or(&[], |ready| ready.tracks.as_slice())
+    }
+
+    pub fn playlists(&self) -> &[Playlist] {
+        self.ready().map_or(&[], |ready| ready.playlists.as_slice())
+    }
+
+    pub fn albums(&self) -> &[Album] {
+        self.ready().map_or(&[], |ready| ready.albums.as_slice())
+    }
+
+    pub fn artists(&self) -> &[SavedArtist] {
+        self.ready().map_or(&[], |ready| ready.artists.as_slice())
+    }
 }
 
 impl gpui::EventEmitter<LibraryEvent> for Library {}
 
 pub struct Library {
-    state: LibraryState,
-    local: LibraryState,
-    local_favorites: Vec<Track>,
-    local_favorites_loading: bool,
-    awaited: Vec<LibraryPart>,
-    local_awaited: Vec<LibraryPart>,
+    shelves: [Held; 2],
     session: Entity<Session>,
     io: Io,
-    tasks: Vec<Task<()>>,
-    local_tasks: Vec<Task<()>>,
     playlist_task: Option<Task<()>>,
     pending: HashMap<String, Task<()>>,
     pending_albums: HashMap<String, Task<()>>,
@@ -370,65 +544,42 @@ impl Library {
         cx.subscribe(&session, |this, session, event, cx| match event {
             SessionEvent::SignedIn => {
                 if !session.read(cx).authenticated() {
-                    this.state = LibraryState::Empty;
+                    this.held_mut(Shelf::Streaming).clear();
                     cx.notify();
                     return;
                 }
-                let client = session.read(cx).client();
-                if let Some(client) = client {
-                    this.load(client, cx);
-                }
+                this.load(Shelf::Streaming, cx);
             }
             SessionEvent::SignedOut => {
                 this.contents.clear();
                 this.reading.clear();
                 this.mosaics.clear();
-                this.tasks.clear();
-                this.awaited.clear();
                 this.playlist_task = None;
                 this.pending.clear();
                 this.pending_albums.clear();
                 this.pending_artists.clear();
-                this.state = LibraryState::Empty;
+                this.held_mut(Shelf::Streaming).clear();
                 cx.notify();
             }
             SessionEvent::Reconnected => {
-                if matches!(this.state, LibraryState::Failed(_))
-                    && let Some(client) = session.read(cx).client()
-                {
-                    this.load(client, cx);
+                if matches!(this.held(Shelf::Streaming).state, LibraryState::Failed(_)) {
+                    this.load(Shelf::Streaming, cx);
                 }
             }
-            SessionEvent::LocalChanged => {
-                let client = session.read(cx).local_client();
-                match client {
-                    Some(client) => this.load_local(client, cx),
-                    None => {
-                        this.local_tasks.clear();
-                        this.local_awaited.clear();
-                        this.local = LibraryState::Empty;
-                        this.local_favorites.clear();
-                        this.local_favorites_loading = false;
-                        cx.notify();
-                    }
+            SessionEvent::LocalChanged => match session.read(cx).client_of(Shelf::Local) {
+                Some(_) => this.load(Shelf::Local, cx),
+                None => {
+                    this.held_mut(Shelf::Local).clear();
+                    cx.notify();
                 }
-            }
+            },
         })
         .detach();
 
-        let local_client = session.read(cx).local_client();
-
         let mut library = Self {
-            state: LibraryState::Loading,
-            local: LibraryState::Empty,
-            local_favorites: Vec::new(),
-            local_favorites_loading: false,
-            awaited: Vec::new(),
-            local_awaited: Vec::new(),
+            shelves: [Held::empty(), Held::empty()],
             session,
             io,
-            tasks: Vec::new(),
-            local_tasks: Vec::new(),
             playlist_task: None,
             pending: HashMap::new(),
             pending_albums: HashMap::new(),
@@ -437,34 +588,34 @@ impl Library {
             reading: HashMap::new(),
             mosaics: HashMap::new(),
         };
-        if let Some(client) = local_client {
-            library.load_local(client, cx);
+        library.held_mut(Shelf::Streaming).state = LibraryState::Loading;
+        if library.session.read(cx).client_of(Shelf::Local).is_some() {
+            library.load(Shelf::Local, cx);
         }
         library
     }
 
-    pub fn state(&self) -> &LibraryState {
-        &self.state
+    fn held(&self, shelf: Shelf) -> &Held {
+        &self.shelves[shelf.slot()]
     }
 
-    pub fn local_state(&self) -> &LibraryState {
-        &self.local
+    fn held_mut(&mut self, shelf: Shelf) -> &mut Held {
+        &mut self.shelves[shelf.slot()]
     }
 
-    pub fn part_failed(&self, part: LibraryPart) -> bool {
-        Self::failed_parts(&self.state).any(|failed| failed == part)
+    pub fn state(&self, shelf: Shelf) -> &LibraryState {
+        &self.held(shelf).state
     }
 
-    pub fn local_part_failed(&self, part: LibraryPart) -> bool {
-        Self::failed_parts(&self.local).any(|failed| failed == part)
+    /// What the shelf's pages list: favorites on a `Saved` shelf, everything on a `Catalog` one.
+    pub fn shape(&self, shelf: Shelf) -> Shape {
+        self.held(shelf).shape
     }
 
-    fn failed_parts(state: &LibraryState) -> impl Iterator<Item = LibraryPart> + '_ {
-        let problems = match state {
-            LibraryState::Ready { problems, .. } => problems.as_slice(),
-            _ => &[],
-        };
-        problems.iter().map(|problem| problem.part)
+    pub fn part_failed(&self, shelf: Shelf, part: LibraryPart) -> bool {
+        self.held(shelf)
+            .ready()
+            .is_some_and(|ready| ready.problems.iter().any(|problem| problem.part == part))
     }
 
     pub fn rescan_local(&mut self, path: PathBuf, cx: &mut Context<Self>) {
@@ -477,36 +628,22 @@ impl Library {
             .update(cx, |session, cx| session.clear_local_folder(cx));
     }
 
-    pub fn loading(&self, part: LibraryPart) -> bool {
-        matches!(self.state, LibraryState::Loading) || self.awaited.contains(&part)
-    }
-
-    pub fn local_loading(&self, part: LibraryPart) -> bool {
-        matches!(self.local, LibraryState::Loading) || self.local_awaited.contains(&part)
-    }
-
-    pub fn local_favorites_loading(&self) -> bool {
-        self.local_favorites_loading
+    pub fn loading(&self, shelf: Shelf, part: LibraryPart) -> bool {
+        let held = self.held(shelf);
+        matches!(held.state, LibraryState::Loading) || held.awaited.contains(&part)
     }
 
     pub fn saved(&self, track_id: &str) -> bool {
-        self.favorites(track_id)
-            .iter()
-            .any(|track| track.id.as_deref() == Some(track_id))
+        self.favorites(track_id).is_some_and(|favorites| {
+            favorites
+                .tracks
+                .iter()
+                .any(|track| track.id.as_deref() == Some(track_id))
+        })
     }
 
-    pub fn local_favorites(&self) -> &[Track] {
-        &self.local_favorites
-    }
-
-    fn favorites(&self, track_id: &str) -> &[Track] {
-        if music::is_local_id(track_id) {
-            return &self.local_favorites;
-        }
-        match &self.state {
-            LibraryState::Ready { tracks, .. } => tracks.as_slice(),
-            _ => &[],
-        }
+    fn favorites(&self, id: &str) -> Option<Favorites<'_>> {
+        self.held(Shelf::of(id)).favorites()
     }
 
     pub fn pending(&self, track_id: &str) -> bool {
@@ -530,7 +667,8 @@ impl Library {
     }
 
     pub fn saved_album(&self, album_id: &str) -> bool {
-        self.album(album_id).is_some()
+        self.favorites(album_id)
+            .is_some_and(|favorites| favorites.albums.iter().any(|album| album.id == album_id))
     }
 
     pub fn pending_album(&self, album_id: &str) -> bool {
@@ -542,9 +680,10 @@ impl Library {
     }
 
     fn set_album_saved(&mut self, album: Album, saved: bool) {
-        let LibraryState::Ready { albums, .. } = &mut self.state else {
+        let Some(favorites) = self.held_mut(Shelf::of(&album.id)).favorites_mut() else {
             return;
         };
+        let albums = favorites.albums;
         match saved {
             true if !albums.iter().any(|known| known.id == album.id) => albums.push(album),
             false => albums.retain(|known| known.id != album.id),
@@ -553,18 +692,26 @@ impl Library {
     }
 
     pub fn saved_artist(&self, artist_id: &str) -> bool {
-        self.artist(artist_id).is_some()
+        self.favorites(artist_id).is_some_and(|favorites| {
+            favorites
+                .artists
+                .iter()
+                .any(|artist| artist.id == artist_id)
+        })
     }
 
     pub fn pending_artist(&self, artist_id: &str) -> bool {
         self.pending_artists.contains_key(artist_id)
     }
 
+    /// A listed artist, from the shelf's pages or its favorites.
     pub fn artist(&self, id: &str) -> Option<&SavedArtist> {
-        let LibraryState::Ready { artists, .. } = &self.state else {
-            return None;
-        };
-        artists.iter().find(|artist| artist.id == id)
+        let held = self.held(Shelf::of(id));
+        held.state
+            .artists()
+            .iter()
+            .chain(&held.starred.artists)
+            .find(|artist| artist.id == id)
     }
 
     pub fn toggle_artist(&mut self, artist: SavedArtist, cx: &mut Context<Self>) {
@@ -572,9 +719,10 @@ impl Library {
     }
 
     fn set_artist_saved(&mut self, artist: SavedArtist, saved: bool) {
-        let LibraryState::Ready { artists, .. } = &mut self.state else {
+        let Some(favorites) = self.held_mut(Shelf::of(&artist.id)).favorites_mut() else {
             return;
         };
+        let artists = favorites.artists;
         match saved {
             true if !artists.iter().any(|known| known.id == artist.id) => artists.push(artist),
             false => artists.retain(|known| known.id != artist.id),
@@ -586,7 +734,7 @@ impl Library {
         &mut self,
         name: String,
         tracks: Vec<String>,
-        local: bool,
+        shelf: Shelf,
         cx: &mut Context<Self>,
     ) {
         self.mutate_playlist(
@@ -596,7 +744,7 @@ impl Library {
                 name: None,
                 target: None,
                 invalidated: None,
-                local,
+                shelf,
             },
             move |client| async move {
                 let id = client.create_playlist(&name).await?;
@@ -634,7 +782,7 @@ impl Library {
                 done: "toast-playlist-renamed",
                 name: None,
                 target: None,
-                local: music::is_local_id(&id),
+                shelf: Shelf::of(&id),
                 invalidated: Some(id.clone()),
             },
             move |client| async move { client.rename_playlist(&id, &name).await },
@@ -654,7 +802,7 @@ impl Library {
                 done: "toast-playlist-visibility",
                 name: None,
                 target: None,
-                local: music::is_local_id(&id),
+                shelf: Shelf::of(&id),
                 invalidated: Some(id.clone()),
             },
             move |client| async move { client.set_playlist_public(&id, public).await },
@@ -696,7 +844,7 @@ impl Library {
                 done: "toast-track-added",
                 name,
                 target,
-                local: music::is_local_id(&playlist_id),
+                shelf: Shelf::of(&playlist_id),
                 invalidated: Some(playlist_id.clone()),
             },
             move |client| async move {
@@ -747,7 +895,7 @@ impl Library {
                 done: "toast-track-removed",
                 name,
                 target,
-                local: music::is_local_id(&playlist_id),
+                shelf: Shelf::of(&playlist_id),
                 invalidated: Some(playlist_id.clone()),
             },
             move |client| async move {
@@ -790,7 +938,7 @@ impl Library {
                 done: "toast-playlist-deleted",
                 name: None,
                 target: None,
-                local: music::is_local_id(&id),
+                shelf: Shelf::of(&id),
                 invalidated: Some(id.clone()),
             },
             move |client| async move { client.delete_playlist(&id).await },
@@ -807,7 +955,7 @@ impl Library {
                 done: "toast-playlist-added",
                 name: None,
                 target: None,
-                local: music::is_local_id(&id),
+                shelf: Shelf::of(&id),
                 invalidated: Some(id.clone()),
             },
             move |client| async move { client.add_playlist_to_library(&id).await },
@@ -824,7 +972,7 @@ impl Library {
                 done: "toast-playlist-removed",
                 name: None,
                 target: None,
-                local: music::is_local_id(&id),
+                shelf: Shelf::of(&id),
                 invalidated: Some(id.clone()),
             },
             move |client| async move { client.remove_playlist_from_library(&id).await },
@@ -833,18 +981,14 @@ impl Library {
         );
     }
 
+    /// A listed album, from the shelf's pages or its favorites.
     pub fn album(&self, id: &str) -> Option<&Album> {
-        let LibraryState::Ready { albums, .. } = &self.state else {
-            return None;
-        };
-        albums.iter().find(|album| album.id == id)
-    }
-
-    pub fn local_album(&self, id: &str) -> Option<&Album> {
-        let LibraryState::Ready { albums, .. } = &self.local else {
-            return None;
-        };
-        albums.iter().find(|album| album.id == id)
+        let held = self.held(Shelf::of(id));
+        held.state
+            .albums()
+            .iter()
+            .chain(&held.starred.albums)
+            .find(|album| album.id == id)
     }
 
     pub fn holds(&self, playlist_id: &str, track_id: &str) -> Option<bool> {
@@ -852,9 +996,10 @@ impl Library {
     }
 
     fn adopt_mosaics(&mut self) -> Vec<(String, u32)> {
-        let LibraryState::Ready { playlists, .. } = &mut self.state else {
+        let Some(ready) = self.held_mut(Shelf::Streaming).ready_mut() else {
             return Vec::new();
         };
+        let playlists = &mut ready.playlists;
 
         let mut wanted = Vec::new();
         for playlist in playlists.iter_mut() {
@@ -906,23 +1051,14 @@ impl Library {
     }
 
     fn mosaic_stamp(&self, id: &str) -> Option<u32> {
-        let LibraryState::Ready { playlists, .. } = &self.state else {
-            return None;
-        };
-        let playlist = playlists.iter().find(|playlist| playlist.id == id)?;
+        let playlist = self.playlist(id)?;
 
         (playlist.cover.is_none() && playlist.track_count as usize >= mosaic::TILES)
             .then_some(playlist.track_count)
     }
 
     fn is_editable(&self, id: &str) -> bool {
-        let LibraryState::Ready { playlists, .. } = &self.state else {
-            return false;
-        };
-
-        playlists
-            .iter()
-            .find(|playlist| playlist.id == id)
+        self.playlist(id)
             .is_some_and(|playlist| playlist.owned || playlist.collaborative)
     }
 
@@ -963,40 +1099,23 @@ impl Library {
     }
 
     fn set_playlist_cover(&mut self, id: &str, cover: String) {
-        let LibraryState::Ready { playlists, .. } = &mut self.state else {
-            return;
-        };
-        if let Some(playlist) = playlists.iter_mut().find(|playlist| playlist.id == id) {
-            playlist.cover = Some(cover);
-        }
+        self.amend_playlist_quietly(id, |playlist| playlist.cover = Some(cover));
     }
 
-    pub fn read_local_playlists(&mut self, cx: &mut Context<Self>) {
-        let LibraryState::Ready { playlists, .. } = &self.local else {
-            return;
-        };
-        let wanted: Vec<String> = playlists
-            .iter()
-            .map(|playlist| playlist.id.clone())
-            .filter(|id| !self.reading.contains_key(id))
-            .collect();
-        let Some(client) = self.session.read(cx).local_client() else {
-            return;
-        };
-        self.read_contents(wanted, client, cx);
-    }
-
-    pub fn read_playlists(&mut self, cx: &mut Context<Self>) {
-        let LibraryState::Ready { playlists, .. } = &self.state else {
-            return;
-        };
-        let wanted: Vec<String> = playlists
+    /// Reads the contents of every editable playlist on a shelf that is not known yet. A local
+    /// playlist is always re-read, since its contents change without a mutation here.
+    pub fn read_playlists(&mut self, shelf: Shelf, cx: &mut Context<Self>) {
+        let wanted: Vec<String> = self
+            .state(shelf)
+            .playlists()
             .iter()
             .filter(|playlist| playlist.owned || playlist.collaborative)
             .map(|playlist| playlist.id.clone())
-            .filter(|id| !self.contents.contains_key(id) && !self.reading.contains_key(id))
+            .filter(|id| {
+                (shelf.local() || !self.contents.contains_key(id)) && !self.reading.contains_key(id)
+            })
             .collect();
-        let Some(client) = self.session.read(cx).client() else {
+        let Some(client) = self.session.read(cx).client_of(shelf) else {
             return;
         };
         self.read_contents(wanted, client, cx);
@@ -1041,29 +1160,16 @@ impl Library {
     }
 
     pub fn playlist(&self, id: &str) -> Option<&Playlist> {
-        self.shelf(id).iter().find(|playlist| playlist.id == id)
+        self.state(Shelf::of(id))
+            .playlists()
+            .iter()
+            .find(|playlist| playlist.id == id)
     }
 
-    fn shelf(&self, id: &str) -> &[Playlist] {
-        let state = match music::is_local_id(id) {
-            true => &self.local,
-            false => &self.state,
-        };
-        match state {
-            LibraryState::Ready { playlists, .. } => playlists.as_slice(),
-            _ => &[],
-        }
-    }
-
-    fn shelf_mut(&mut self, id: &str) -> Option<&mut Vec<Playlist>> {
-        let state = match music::is_local_id(id) {
-            true => &mut self.local,
-            false => &mut self.state,
-        };
-        match state {
-            LibraryState::Ready { playlists, .. } => Some(playlists),
-            _ => None,
-        }
+    fn playlists_mut(&mut self, id: &str) -> Option<&mut Vec<Playlist>> {
+        self.held_mut(Shelf::of(id))
+            .ready_mut()
+            .map(|ready| &mut ready.playlists)
     }
 
     fn mutate_playlist<F, R, T, A>(
@@ -1084,19 +1190,14 @@ impl Library {
             name,
             target,
             invalidated,
-            local,
+            shelf,
         } = mutation_info;
         if self.playlist_task.is_some() {
             log::warn!("library: cannot {action} while another change is running");
             Toasts::show(Outcome::Failed, "toast-playlist-busy", cx);
             return;
         }
-        let session = self.session.read(cx);
-        let picked = match local {
-            true => session.local_client(),
-            false => session.client(),
-        };
-        let Some(client) = picked else {
+        let Some(client) = self.session.read(cx).client_of(shelf) else {
             log::warn!("library: cannot {action} while signed out");
             Toasts::show(Outcome::Failed, "toast-playlist-signed-out", cx);
             return;
@@ -1134,7 +1235,7 @@ impl Library {
     }
 
     fn insert_playlist(&mut self, playlist: Playlist, cx: &mut Context<Self>) {
-        let Some(playlists) = self.shelf_mut(&playlist.id) else {
+        let Some(playlists) = self.playlists_mut(&playlist.id) else {
             return;
         };
         playlists.retain(|known| known.id != playlist.id);
@@ -1148,7 +1249,7 @@ impl Library {
     }
 
     fn drop_playlist(&mut self, id: &str, cx: &mut Context<Self>) {
-        let Some(playlists) = self.shelf_mut(id) else {
+        let Some(playlists) = self.playlists_mut(id) else {
             return;
         };
         playlists.retain(|playlist| playlist.id != id);
@@ -1161,128 +1262,127 @@ impl Library {
         amend: impl FnOnce(&mut Playlist),
         cx: &mut Context<Self>,
     ) {
-        let Some(playlists) = self.shelf_mut(id) else {
-            return;
+        if self.amend_playlist_quietly(id, amend) {
+            cx.notify();
+        }
+    }
+
+    fn amend_playlist_quietly(&mut self, id: &str, amend: impl FnOnce(&mut Playlist)) -> bool {
+        let Some(playlists) = self.playlists_mut(id) else {
+            return false;
         };
         let Some(playlist) = playlists.iter_mut().find(|playlist| playlist.id == id) else {
-            return;
+            return false;
         };
         amend(playlist);
-        cx.notify();
+        true
     }
 
     fn set_saved(&mut self, track: Track, saved: bool) {
-        let local = track.id.as_deref().is_some_and(music::is_local_id);
-        if local {
-            let id = track.id.clone();
-            match saved {
-                true if !self.local_favorites.iter().any(|held| held.id == id) => {
-                    self.local_favorites.insert(0, track)
-                }
-                false => self.local_favorites.retain(|held| held.id != id),
-                _ => {}
-            }
-            return;
-        }
-
-        let LibraryState::Ready { tracks, .. } = &mut self.state else {
+        let Some(id) = track.id.clone() else {
             return;
         };
-        let id = track.id.as_deref();
+        let Some(favorites) = self.held_mut(Shelf::of(&id)).favorites_mut() else {
+            return;
+        };
+        let tracks = favorites.tracks;
+        let same = |held: &Track| held.id.as_deref() == Some(id.as_str());
         match saved {
-            true if !tracks.iter().any(|saved| saved.id.as_deref() == id) => tracks.push(track),
-            false => tracks.retain(|saved| saved.id.as_deref() != id),
+            true if !tracks.iter().any(same) => tracks.push(track),
+            false => tracks.retain(|held| !same(held)),
             _ => {}
         }
     }
 
-    pub fn refresh(&mut self, cx: &mut Context<Self>) {
-        let client = self.session.read(cx).client();
-        if let Some(client) = client {
-            self.load(client, cx);
+    pub fn refresh(&mut self, shelf: Shelf, cx: &mut Context<Self>) {
+        self.load(shelf, cx);
+    }
+
+    /// Loads a shelf from its provider. A `Saved` shape reads the `saved_*` lists; a `Catalog`
+    /// shape reads the `all_*` lists and the `saved_*` ones beside them for hearts and filters.
+    fn load(&mut self, shelf: Shelf, cx: &mut Context<Self>) {
+        let session = self.session.read(cx);
+        let Some(client) = session.client_of(shelf) else {
+            return;
+        };
+        let shape = session.shape_of(shelf);
+        if shelf == Shelf::Streaming {
+            self.playlist_task = None;
+            self.pending.clear();
+            self.pending_albums.clear();
+            self.pending_artists.clear();
         }
-    }
 
-    fn load(&mut self, client: Arc<dyn MusicApi>, cx: &mut Context<Self>) {
-        self.playlist_task = None;
-        self.pending.clear();
-        self.pending_albums.clear();
-        self.pending_artists.clear();
-        self.state = LibraryState::Loading;
-        self.awaited = LibraryPart::ALL.to_vec();
-        cx.notify();
-
-        let tracks = client.clone();
-        let playlists = client.clone();
-        let albums = client.clone();
-        self.tasks = vec![
-            self.fetch(
-                async move { tracks.saved_tracks(PAGE_LIMIT).await },
-                |this, loaded, cx| this.land(Landed::Tracks(loaded), cx),
-                cx,
-            ),
-            self.fetch(
-                async move { playlists.playlists(PAGE_LIMIT).await },
-                |this, loaded, cx| this.land(Landed::Playlists(loaded), cx),
-                cx,
-            ),
-            self.fetch(
-                async move { albums.saved_albums(PAGE_LIMIT).await },
-                |this, loaded, cx| this.land(Landed::Albums(loaded), cx),
-                cx,
-            ),
-            self.fetch(
-                async move { client.saved_artists(PAGE_LIMIT).await },
-                |this, loaded, cx| this.land(Landed::Artists(loaded), cx),
-                cx,
-            ),
-        ];
-    }
-
-    fn load_local(&mut self, client: Arc<dyn MusicApi>, cx: &mut Context<Self>) {
-        self.local = LibraryState::Loading;
-        self.local_awaited = LibraryPart::ALL.to_vec();
-        self.local_favorites_loading = true;
+        let held = self.held_mut(shelf);
+        held.shape = shape;
+        held.state = LibraryState::Loading;
+        held.awaited = LibraryPart::ALL.to_vec();
+        held.starred = Starred::default();
         cx.notify();
 
         let tracks = client.clone();
         let playlists = client.clone();
         let albums = client.clone();
         let artists = client.clone();
-        self.local_tasks = vec![
+        let mut tasks = vec![
             self.fetch(
-                async move { tracks.all_tracks(PAGE_LIMIT).await },
-                |this, loaded, cx| this.land_local(Landed::Tracks(loaded), cx),
+                async move {
+                    match shape {
+                        Shape::Saved => tracks.saved_tracks(PAGE_LIMIT).await,
+                        Shape::Catalog => tracks.all_tracks(PAGE_LIMIT).await,
+                    }
+                },
+                move |this, loaded, cx| this.land(shelf, Landed::Tracks(loaded), cx),
                 cx,
             ),
             self.fetch(
                 async move { playlists.playlists(PAGE_LIMIT).await },
-                |this, loaded, cx| this.land_local(Landed::Playlists(loaded), cx),
+                move |this, loaded, cx| this.land(shelf, Landed::Playlists(loaded), cx),
                 cx,
             ),
             self.fetch(
-                async move { albums.saved_albums(PAGE_LIMIT).await },
-                |this, loaded, cx| this.land_local(Landed::Albums(loaded), cx),
-                cx,
-            ),
-            self.fetch(
-                async move { artists.saved_artists(PAGE_LIMIT).await },
-                |this, loaded, cx| this.land_local(Landed::Artists(loaded), cx),
-                cx,
-            ),
-            self.fetch(
-                async move { client.saved_tracks(PAGE_LIMIT).await },
-                |this, loaded, cx| {
-                    this.local_favorites = loaded.unwrap_or_else(|error| {
-                        log::warn!("library: cannot load the local favorites: {error:#}");
-                        Vec::new()
-                    });
-                    this.local_favorites_loading = false;
-                    cx.notify();
+                async move {
+                    match shape {
+                        Shape::Saved => albums.saved_albums(PAGE_LIMIT).await,
+                        Shape::Catalog => albums.all_albums(PAGE_LIMIT).await,
+                    }
                 },
+                move |this, loaded, cx| this.land(shelf, Landed::Albums(loaded), cx),
+                cx,
+            ),
+            self.fetch(
+                async move {
+                    match shape {
+                        Shape::Saved => artists.saved_artists(PAGE_LIMIT).await,
+                        Shape::Catalog => artists.all_artists(PAGE_LIMIT).await,
+                    }
+                },
+                move |this, loaded, cx| this.land(shelf, Landed::Artists(loaded), cx),
                 cx,
             ),
         ];
+        if shape == Shape::Catalog {
+            let tracks = client.clone();
+            let albums = client.clone();
+            tasks.extend([
+                self.fetch(
+                    async move { tracks.saved_tracks(PAGE_LIMIT).await },
+                    move |this, loaded, cx| this.land_starred(shelf, Landed::Tracks(loaded), cx),
+                    cx,
+                ),
+                self.fetch(
+                    async move { albums.saved_albums(PAGE_LIMIT).await },
+                    move |this, loaded, cx| this.land_starred(shelf, Landed::Albums(loaded), cx),
+                    cx,
+                ),
+                self.fetch(
+                    async move { client.saved_artists(PAGE_LIMIT).await },
+                    move |this, loaded, cx| this.land_starred(shelf, Landed::Artists(loaded), cx),
+                    cx,
+                ),
+            ]);
+        }
+        self.held_mut(shelf).tasks = tasks;
     }
 
     fn fetch<T, R, A>(&self, work: R, apply: A, cx: &mut Context<Self>) -> Task<()>
@@ -1298,27 +1398,21 @@ impl Library {
         })
     }
 
-    fn land(&mut self, landed: Landed, cx: &mut Context<Self>) {
+    fn land(&mut self, shelf: Shelf, landed: Landed, cx: &mut Context<Self>) {
         let part = landed.part();
-        place(&mut self.state, &mut self.awaited, landed, &FATAL);
+        let held = self.held_mut(shelf);
+        place(&mut held.state, &mut held.awaited, landed, shelf.fatal());
         if part == LibraryPart::Playlists {
-            self.read_playlists(cx);
-            self.build_mosaics(cx);
+            self.read_playlists(shelf, cx);
+            if shelf == Shelf::Streaming {
+                self.build_mosaics(cx);
+            }
         }
         cx.notify();
     }
 
-    fn land_local(&mut self, landed: Landed, cx: &mut Context<Self>) {
-        let part = landed.part();
-        place(
-            &mut self.local,
-            &mut self.local_awaited,
-            landed,
-            &FATAL_LOCAL,
-        );
-        if part == LibraryPart::Playlists {
-            self.read_local_playlists(cx);
-        }
+    fn land_starred(&mut self, shelf: Shelf, landed: Landed, cx: &mut Context<Self>) {
+        star(self.held_mut(shelf), landed);
         cx.notify();
     }
 }

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -93,7 +93,6 @@ const RESTART_WINDOW: Duration = Duration::from_secs(3);
 const KEY_COOLDOWN: Duration = Duration::from_secs(6);
 const RESUME_STEP: Duration = Duration::from_secs(5);
 const TAPER_DB: f32 = 50.;
-const LOCAL_FAVORITES: &str = "favorites";
 const SIMILAR_LIMIT: usize = 20;
 
 /// The position shown between the engine's reports. It runs on wall time from `reset` and is
@@ -270,10 +269,6 @@ impl Origin {
 
     pub fn local() -> Self {
         Self::of(Whence::Local, String::new())
-    }
-
-    pub fn local_favorites() -> Self {
-        Self::of(Whence::Local, LOCAL_FAVORITES)
     }
 
     pub fn named(mut self, name: impl Into<SharedString>) -> Self {

--- a/crates/state/src/search.rs
+++ b/crates/state/src/search.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use gpui::{Context, Entity, Task};
 use music::{Album, ArtistRef, Playlist, Track};
 
-use crate::{Io, Library, LibraryState, Session, SessionEvent, join};
+use crate::{Io, Library, Session, SessionEvent, Shelf, join};
 
 const DEBOUNCE: Duration = Duration::from_millis(250);
 const LIMIT: usize = 20;
@@ -321,19 +321,11 @@ impl Search {
 
         self.hits = {
             let held = self.library.read(cx);
-            let (tracks, albums, playlists) = match held.state() {
-                LibraryState::Ready {
-                    tracks,
-                    albums,
-                    playlists,
-                    ..
-                } => (tracks.as_slice(), albums.as_slice(), playlists.as_slice()),
-                _ => (&[][..], &[][..], &[][..]),
-            };
+            let state = held.state(Shelf::Streaming);
             rank(
-                tracks,
-                albums,
-                playlists,
+                state.tracks(),
+                state.albums(),
+                state.playlists(),
                 &self.catalog,
                 &self.portraits,
                 query,

--- a/crates/state/src/session.rs
+++ b/crates/state/src/session.rs
@@ -5,11 +5,12 @@ use std::time::Duration;
 use anyhow::Error;
 use gpui::{Context, Entity, EventEmitter, Task};
 use music::{
-    MusicApi, MusicProvider, PlaybackFactory, PromptSink, ProviderSession, SignIn, SignInFailure,
-    SignInProblem, SignInPrompt, UserProfile,
+    MusicApi, MusicProvider, PlaybackFactory, PromptSink, ProviderSession, Shape, SignIn,
+    SignInFailure, SignInProblem, SignInPrompt, UserProfile,
 };
 use tokio::sync::mpsc::UnboundedSender;
 
+use crate::Shelf;
 use crate::catalog::CatalogSource;
 use crate::settings::AppSettings;
 use crate::{Io, join};
@@ -85,6 +86,7 @@ pub struct Session {
     client: Option<Arc<dyn MusicApi>>,
     catalog: Option<Arc<CatalogSource>>,
     playback: Option<Arc<dyn PlaybackFactory>>,
+    shape: Shape,
     authenticated: bool,
     playcounts: bool,
     io: Io,
@@ -129,6 +131,7 @@ impl Session {
             client: None,
             catalog: None,
             playback: None,
+            shape: Shape::Saved,
             authenticated: false,
             playcounts: false,
             io,
@@ -164,6 +167,22 @@ impl Session {
 
     pub fn local_client(&self) -> Option<Arc<dyn MusicApi>> {
         self.local_client.clone()
+    }
+
+    /// The client serving a shelf, if that shelf has a provider right now.
+    pub fn client_of(&self, shelf: Shelf) -> Option<Arc<dyn MusicApi>> {
+        match shelf {
+            Shelf::Streaming => self.client.clone(),
+            Shelf::Local => self.local_client.clone(),
+        }
+    }
+
+    /// What a shelf's library is made of. The local shelf is always a catalog.
+    pub fn shape_of(&self, shelf: Shelf) -> Shape {
+        match shelf {
+            Shelf::Streaming => self.shape,
+            Shelf::Local => Shape::Catalog,
+        }
     }
 
     pub(crate) fn catalog(&self, id: &str) -> Option<Arc<CatalogSource>> {
@@ -441,6 +460,7 @@ impl Session {
         self.client = None;
         self.catalog = None;
         self.playback = None;
+        self.shape = Shape::Saved;
         self.authenticated = false;
         self.playcounts = false;
         self.state = SessionState::SignedOut;
@@ -466,6 +486,7 @@ impl Session {
         self.catalog = Some(Arc::new(CatalogSource::new(session.api.clone())));
         self.client = Some(session.api);
         self.playback = Some(session.playback);
+        self.shape = session.shape;
         self.authenticated = session.authenticated;
         self.playcounts = session.playcounts;
         self.state = SessionState::SignedIn(session.profile);
@@ -479,6 +500,7 @@ impl Session {
         self.client = None;
         self.catalog = None;
         self.playback = None;
+        self.shape = Shape::Saved;
         self.authenticated = false;
         self.playcounts = false;
         self.watch = None;
@@ -550,6 +572,7 @@ impl Session {
         self.catalog = Some(Arc::new(CatalogSource::new(session.api.clone())));
         self.client = Some(session.api);
         self.playback = Some(session.playback);
+        self.shape = session.shape;
         self.authenticated = session.authenticated;
         self.playcounts = session.playcounts;
         log::debug!("session: reconnected");

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -48,6 +48,14 @@ const SCHEMA: &str = "
     CREATE TABLE IF NOT EXISTS favorites (
         track_id TEXT PRIMARY KEY,
         added_at INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS favorite_albums (
+        album_id TEXT PRIMARY KEY,
+        added_at INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS favorite_artists (
+        artist_id TEXT PRIMARY KEY,
+        added_at INTEGER NOT NULL
     );";
 
 #[derive(Clone)]

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -10,7 +10,7 @@ use gpui::{
 };
 use i18n::t;
 use music::{Track, Voice};
-use router::{Destination, LibraryTab, Link as _, LocalTab};
+use router::{Destination, LibraryTab, Link as _};
 use state::{
     AppSettings, Lyrics, LyricsState, Playback, PlaybackState, Queue, RomanizationScripts, SideTab,
     Sonora, Whence,
@@ -1597,17 +1597,11 @@ impl Aside {
             Whence::Artist => Destination::Artist(id),
             Whence::Radio => Destination::Song(id),
             Whence::Saved => Destination::Library(LibraryTab::Songs),
-            Whence::Local => match origin.id.is_empty() {
-                true => Destination::Local(LocalTab::Songs),
-                false => Destination::Local(LocalTab::Favorites),
-            },
+            Whence::Local => Destination::Local(LibraryTab::Songs),
         };
         let name = match origin.whence {
             Whence::Saved => t!("library-liked-songs"),
-            Whence::Local => match origin.id.is_empty() {
-                true => t!("nav-local"),
-                false => t!("library-liked-songs"),
-            },
+            Whence::Local => t!("nav-local"),
             _ => origin.name.clone()?,
         };
 

--- a/crates/views/src/chrome/sidebar_left.rs
+++ b/crates/views/src/chrome/sidebar_left.rs
@@ -10,7 +10,7 @@ use gpui::{
 };
 use gpui::{Window, div, px};
 use router::{
-    Destination, LibraryTab, LocalTab, NavEntry, Navigation, NavigationEvent, SettingsTab, navigate,
+    Destination, LibraryTab, NavEntry, Navigation, NavigationEvent, SettingsTab, navigate,
 };
 use state::{AppSettings, Origin, Playback, PlaybackState, Session, Sonora};
 
@@ -31,7 +31,7 @@ const NAV: [(Option<NavEntry>, &str, Destination); 6] = [
     (
         Some(NavEntry::Local),
         "icons/file-music.svg",
-        Destination::Local(LocalTab::Songs),
+        Destination::Local(LibraryTab::Songs),
     ),
     (
         Some(NavEntry::History),
@@ -46,18 +46,10 @@ const NAV: [(Option<NavEntry>, &str, Destination); 6] = [
 ];
 
 const LIBRARY_TABS: [(&str, LibraryTab); 4] = [
-    ("nav-favorites", LibraryTab::Songs),
+    ("nav-songs", LibraryTab::Songs),
     ("nav-albums", LibraryTab::Albums),
     ("nav-artists", LibraryTab::Artists),
     ("nav-playlists", LibraryTab::Playlists),
-];
-
-const LOCAL_TABS: [(&str, LocalTab); 5] = [
-    ("nav-favorites", LocalTab::Favorites),
-    ("nav-songs", LocalTab::Songs),
-    ("nav-albums", LocalTab::Albums),
-    ("nav-artists", LocalTab::Artists),
-    ("nav-playlists", LocalTab::Playlists),
 ];
 
 const SETTINGS_TABS: [(&str, SettingsTab); 5] = [
@@ -420,27 +412,19 @@ impl Render for SidebarLeft {
                 if self.local_open {
                     rows.push(
                         Tabs::new()
-                            .items(
-                                LOCAL_TABS
-                                    .into_iter()
-                                    .enumerate()
-                                    .map(|(slot, (name, tab))| {
-                                        let chosen = current == Destination::Local(tab);
-                                        let tint = if chosen { foreground } else { muted };
+                            .items(LIBRARY_TABS.into_iter().enumerate().map(
+                                |(slot, (name, tab))| {
+                                    let chosen = current == Destination::Local(tab);
+                                    let tint = if chosen { foreground } else { muted };
 
-                                        nav_row(
-                                            ("local-tab", slot as u32),
-                                            name,
-                                            tint,
-                                            sidebar_accent,
-                                        )
+                                    nav_row(("local-tab", slot as u32), name, tint, sidebar_accent)
                                         .flex_1()
                                         .when(chosen, |button| button.bg(sidebar_accent))
-                                        .on_click(
-                                            move |_, _, cx| navigate(Destination::Local(tab), cx),
-                                        )
-                                    }),
-                            )
+                                        .on_click(move |_, _, cx| {
+                                            navigate(Destination::Local(tab), cx)
+                                        })
+                                },
+                            ))
                             .into_any_element(),
                     );
                 }
@@ -622,7 +606,7 @@ fn nav_row(id: impl Into<ElementId>, key: &'static str, tint: Hsla, accent: Hsla
 
 #[cfg(test)]
 mod tests {
-    use router::{Destination, LibraryTab, LocalTab, SettingsTab};
+    use router::{Destination, LibraryTab, SettingsTab};
 
     use super::expanded;
 
@@ -633,7 +617,7 @@ mod tests {
             (true, false, false)
         );
         assert_eq!(
-            expanded(&Destination::Local(LocalTab::Albums)),
+            expanded(&Destination::Local(LibraryTab::Albums)),
             (false, true, false)
         );
         assert_eq!(

--- a/crates/views/src/lib.rs
+++ b/crates/views/src/lib.rs
@@ -10,7 +10,7 @@ use screens::detail::DetailView;
 use screens::genre::GenreView;
 use screens::history::HistoryView;
 use screens::home::HomeView;
-pub use screens::library::{LibraryView, Shelf};
+pub use screens::library::LibraryView;
 pub use screens::login::LoginView;
 pub use screens::settings::SettingsView;
 use screens::song::SongView;

--- a/crates/views/src/root.rs
+++ b/crates/views/src/root.rs
@@ -8,7 +8,7 @@ use input::{
 use router::{Destination, NavigationEvent, SettingsTab, back, forward, navigate};
 use state::{
     ArtistDetail, Detail, GenreDetails, Genres, Home, Io, Library, Playback, Profile, Queue,
-    SYSTEM_FONT, Search, Session, SessionState, SideTab, SongDetail, Sonora,
+    SYSTEM_FONT, Search, Session, SessionState, Shelf, SideTab, SongDetail, Sonora,
 };
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use ui::WindowFrame;
@@ -21,7 +21,7 @@ use crate::shells::Shell;
 use crate::shells::workspace::Workspace;
 use crate::{
     Adaptive, ArtistView, DetailView, FullscreenView, GenreView, HistoryView, HomeView,
-    LibraryView, LoginView, SettingsView, Shelf, SongView, UserView,
+    LibraryView, LoginView, SettingsView, SongView, UserView,
 };
 
 struct Screens {
@@ -117,7 +117,13 @@ impl Root {
         .detach();
 
         let library_view = cx.new(|cx| {
-            LibraryView::new(Shelf::Saved, library.clone(), playback.clone(), window, cx)
+            LibraryView::new(
+                Shelf::Streaming,
+                library.clone(),
+                playback.clone(),
+                window,
+                cx,
+            )
         });
         let local_view = cx.new(|cx| {
             LibraryView::new(Shelf::Local, library.clone(), playback.clone(), window, cx)

--- a/crates/views/src/screens/artist.rs
+++ b/crates/views/src/screens/artist.rs
@@ -318,7 +318,7 @@ impl ArtistView {
                 )
                 .from(self.playing_from(cx)),
             )
-            .children(self.follow_button(cx))
+            .children(self.favorite_button(cx))
             .children(overflow);
 
         let cover = artist.and_then(|artist| artist.cover_large.clone());
@@ -352,33 +352,30 @@ impl ArtistView {
         })
     }
 
-    fn follow_button(&self, cx: &App) -> Option<Button> {
+    fn favorite_button(&self, cx: &App) -> Option<Button> {
         let theme = *cx.theme();
         let library = Sonora::global(cx).library.clone();
         let target = self.saved_artist(cx)?;
-        if music::is_local_id(&target.id) {
-            return None;
-        }
-        let followed = library.read(cx).saved_artist(&target.id);
+        let saved = library.read(cx).saved_artist(&target.id);
 
         let heart = Button::new("artist-toggle-library")
             .outline()
-            .icon(match followed {
+            .icon(match saved {
                 true => "icons/heart-filled.svg",
                 false => "icons/heart.svg",
             })
-            .tooltip(match followed {
-                true => "artist-unfollow",
-                false => "artist-follow",
+            .tooltip(match saved {
+                true => "menu-remove-from-library",
+                false => "menu-add-to-library",
             })
             .disabled(library.read(cx).pending_artist(&target.id));
 
         Some(
-            match followed {
+            match saved {
                 true => heart.tint(theme.primary),
                 false => heart,
             }
-            .on_click(move |_, _, cx| match followed {
+            .on_click(move |_, _, cx| match saved {
                 true => Confirm::artists(vec![target.clone()], cx),
                 false => {
                     library.update(cx, |library, cx| library.toggle_artist(target.clone(), cx));

--- a/crates/views/src/screens/library/albums.rs
+++ b/crates/views/src/screens/library/albums.rs
@@ -1,11 +1,11 @@
 use std::cell::RefCell;
 use std::cmp::Ordering;
-use ui::{ActiveTheme as _, Filter, FilterChange, RangeAxis, Unit};
+use ui::{ActiveTheme as _, Filter, FilterChange, FlagAxis, RangeAxis, Unit};
 
 use gpui::{AnyElement, App, Entity, SharedString, TextAlign};
 use i18n::t;
-use music::Album;
-use state::{Library, LibraryPart, LibraryState, Origin, Playback};
+use music::{Album, Shape};
+use state::{Library, LibraryPart, Origin, Playback, Shelf};
 use ui::rank::{HANDY, NICE, SPARE, USEFUL};
 use ui::{Cell, ColumnSpec, Menu, Pin, TableSource, Width};
 
@@ -91,8 +91,9 @@ pub(super) const COLUMNS: &[ColumnSpec<AlbumField>] = &[
 pub(super) struct AlbumSource {
     library: Entity<Library>,
     playback: Entity<Playback>,
-    local: bool,
+    shelf: Shelf,
     year_span: Option<(f32, f32)>,
+    starred: bool,
     spread: RefCell<Option<Spread>>,
 }
 
@@ -105,13 +106,14 @@ impl AlbumSource {
     pub(super) fn shelved(
         library: Entity<Library>,
         playback: Entity<Playback>,
-        local: bool,
+        shelf: Shelf,
     ) -> Self {
         Self {
             library,
             playback,
-            local,
+            shelf,
             year_span: None,
+            starred: false,
             spread: RefCell::new(None),
         }
     }
@@ -156,15 +158,12 @@ impl AlbumSource {
     }
 
     fn albums<'a>(&self, cx: &'a App) -> &'a [Album] {
-        let library = self.library.read(cx);
-        let state = match self.local {
-            true => library.local_state(),
-            false => library.state(),
-        };
-        match state {
-            LibraryState::Ready { albums, .. } => albums.as_slice(),
-            _ => &[],
-        }
+        self.library.read(cx).state(self.shelf).albums()
+    }
+
+    /// Whether the shelf lists more than the favorites, so a favorites filter has something to do.
+    fn catalog(&self, cx: &App) -> bool {
+        self.library.read(cx).shape(self.shelf) == Shape::Catalog
     }
 }
 
@@ -181,6 +180,9 @@ impl TableSource for AlbumSource {
 
     fn matches(&self, row: usize, query: &str, cx: &App) -> bool {
         self.at(row, cx).is_some_and(|album| {
+            if self.starred && !self.library.read(cx).saved_album(&album.id) {
+                return false;
+            }
             if let Some((low, high)) = self.year_span {
                 let year = album.year as f32;
                 if album.year == 0 || year < low - 0.5 || year > high + 0.5 {
@@ -192,24 +194,31 @@ impl TableSource for AlbumSource {
     }
 
     fn filter_axes(&self, query: &str, cx: &App) -> Vec<Filter> {
+        let mut axes = Vec::new();
         let years = self.years(query, cx);
-        let (Some(first), Some(last)) = (years.first(), years.last()) else {
-            return Vec::new();
-        };
-        let bounds = (*first, *last);
-        let value = self.year_span.unwrap_or(bounds);
-
-        vec![Filter::Range(
-            RangeAxis {
-                key: "filter-year",
-                label: t!("filter-year"),
-                bounds,
-                value,
-                unit: Unit::Plain,
-                values: Some(years),
-            }
-            .clamped(),
-        )]
+        if let (Some(first), Some(last)) = (years.first(), years.last()) {
+            let bounds = (*first, *last);
+            let value = self.year_span.unwrap_or(bounds);
+            axes.push(Filter::Range(
+                RangeAxis {
+                    key: "filter-year",
+                    label: t!("filter-year"),
+                    bounds,
+                    value,
+                    unit: Unit::Plain,
+                    values: Some(years),
+                }
+                .clamped(),
+            ));
+        }
+        if self.catalog(cx) {
+            axes.push(Filter::Flag(FlagAxis {
+                key: "filter-favorites",
+                label: t!("filter-favorites"),
+                on: self.starred,
+            }));
+        }
+        axes
     }
 
     fn filter(&mut self, change: FilterChange, _cx: &App) -> bool {
@@ -218,8 +227,13 @@ impl TableSource for AlbumSource {
                 self.year_span = Some(value);
                 true
             }
+            FilterChange::Flag("filter-favorites", value) => {
+                self.starred = value;
+                true
+            }
             FilterChange::Reset => {
                 self.year_span = None;
+                self.starred = false;
                 true
             }
             _ => false,
@@ -227,7 +241,7 @@ impl TableSource for AlbumSource {
     }
 
     fn filtered(&self, _cx: &App) -> bool {
-        self.year_span.is_some()
+        self.year_span.is_some() || self.starred
     }
 
     fn playing(&self, row: usize, cx: &App) -> bool {
@@ -238,10 +252,9 @@ impl TableSource for AlbumSource {
     }
 
     fn is_loading(&self, cx: &App) -> bool {
-        match self.local {
-            true => self.library.read(cx).local_loading(LibraryPart::Albums),
-            false => self.library.read(cx).loading(LibraryPart::Albums),
-        }
+        self.library
+            .read(cx)
+            .loading(self.shelf, LibraryPart::Albums)
     }
 
     fn pin(&self, row: usize, cx: &App) -> Option<Pin> {

--- a/crates/views/src/screens/library/artists.rs
+++ b/crates/views/src/screens/library/artists.rs
@@ -1,9 +1,10 @@
 use std::cmp::Ordering;
-use ui::ActiveTheme as _;
+use ui::{ActiveTheme as _, Filter, FilterChange, FlagAxis};
 
 use gpui::{AnyElement, App, Entity, SharedString};
-use music::SavedArtist;
-use state::{Library, LibraryPart, LibraryState, Origin, Playback};
+use i18n::t;
+use music::{SavedArtist, Shape};
+use state::{Library, LibraryPart, Origin, Playback, Shelf};
 use ui::rank::{ESSENTIAL, HANDY};
 use ui::{Cell, ColumnSpec, Menu, Pin, TableSource, Width};
 
@@ -49,19 +50,21 @@ pub(super) const COLUMNS: &[ColumnSpec<ArtistField>] = &[INDEX, COVER, NAME, ADD
 pub(super) struct ArtistSource {
     library: Entity<Library>,
     playback: Entity<Playback>,
-    local: bool,
+    shelf: Shelf,
+    starred: bool,
 }
 
 impl ArtistSource {
     pub(super) fn shelved(
         library: Entity<Library>,
         playback: Entity<Playback>,
-        local: bool,
+        shelf: Shelf,
     ) -> Self {
         Self {
             library,
             playback,
-            local,
+            shelf,
+            starred: false,
         }
     }
 
@@ -81,15 +84,12 @@ impl ArtistSource {
     }
 
     fn artists<'a>(&self, cx: &'a App) -> &'a [SavedArtist] {
-        let library = self.library.read(cx);
-        let state = match self.local {
-            true => library.local_state(),
-            false => library.state(),
-        };
-        match state {
-            LibraryState::Ready { artists, .. } => artists.as_slice(),
-            _ => &[],
-        }
+        self.library.read(cx).state(self.shelf).artists()
+    }
+
+    /// Whether the shelf lists more than the favorites, so a favorites filter has something to do.
+    fn catalog(&self, cx: &App) -> bool {
+        self.library.read(cx).shape(self.shelf) == Shape::Catalog
     }
 }
 
@@ -105,8 +105,41 @@ impl TableSource for ArtistSource {
     }
 
     fn matches(&self, row: usize, query: &str, cx: &App) -> bool {
-        self.at(row, cx)
-            .is_some_and(|artist| holds(&artist.name, query))
+        self.at(row, cx).is_some_and(|artist| {
+            if self.starred && !self.library.read(cx).saved_artist(&artist.id) {
+                return false;
+            }
+            holds(&artist.name, query)
+        })
+    }
+
+    fn filter_axes(&self, _query: &str, cx: &App) -> Vec<Filter> {
+        match self.catalog(cx) {
+            true => vec![Filter::Flag(FlagAxis {
+                key: "filter-favorites",
+                label: t!("filter-favorites"),
+                on: self.starred,
+            })],
+            false => Vec::new(),
+        }
+    }
+
+    fn filter(&mut self, change: FilterChange, _cx: &App) -> bool {
+        match change {
+            FilterChange::Flag("filter-favorites", value) => {
+                self.starred = value;
+                true
+            }
+            FilterChange::Reset => {
+                self.starred = false;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn filtered(&self, _cx: &App) -> bool {
+        self.starred
     }
 
     fn playing(&self, row: usize, cx: &App) -> bool {
@@ -117,10 +150,9 @@ impl TableSource for ArtistSource {
     }
 
     fn is_loading(&self, cx: &App) -> bool {
-        match self.local {
-            true => self.library.read(cx).local_loading(LibraryPart::Artists),
-            false => self.library.read(cx).loading(LibraryPart::Artists),
-        }
+        self.library
+            .read(cx)
+            .loading(self.shelf, LibraryPart::Artists)
     }
 
     fn pin(&self, row: usize, cx: &App) -> Option<Pin> {

--- a/crates/views/src/screens/library/mod.rs
+++ b/crates/views/src/screens/library/mod.rs
@@ -16,10 +16,10 @@ use gpui::{
     SharedString, WeakEntity, Window, div, point, px, relative,
 };
 use i18n::t;
-use music::Track;
-use router::{Destination, LibraryTab, LocalTab, navigate};
+use music::{Shape, Track};
+use router::{Destination, LibraryTab, navigate};
 use state::{
-    AppSettings, Library, LibraryPart, LibraryState, Origin, Playback, PlaybackState, Sonora,
+    AppSettings, Library, LibraryPart, LibraryState, Origin, Playback, PlaybackState, Shelf, Sonora,
 };
 use ui::{
     ActiveTheme as _, Button, Card, Deck, FilterChange, LEADING, Mode, Pinnable, Popovers, Popup,
@@ -38,22 +38,10 @@ use albums::{AlbumField, AlbumSource};
 use artists::{ArtistField, ArtistSource};
 use playlists::{PlaylistField, PlaylistSource};
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum Shelf {
-    Saved,
-    Local,
-}
-
-impl Shelf {
-    fn local(self) -> bool {
-        self == Shelf::Local
-    }
-}
-
 impl From<LibraryTab> for Section {
     fn from(tab: LibraryTab) -> Self {
         match tab {
-            LibraryTab::Songs => Section::Favorites,
+            LibraryTab::Songs => Section::Songs,
             LibraryTab::Albums => Section::Albums,
             LibraryTab::Playlists => Section::Playlists,
             LibraryTab::Artists => Section::Artists,
@@ -61,21 +49,10 @@ impl From<LibraryTab> for Section {
     }
 }
 
-impl From<LocalTab> for Section {
-    fn from(tab: LocalTab) -> Self {
-        match tab {
-            LocalTab::Songs => Section::Songs,
-            LocalTab::Favorites => Section::Favorites,
-            LocalTab::Albums => Section::Albums,
-            LocalTab::Playlists => Section::Playlists,
-            LocalTab::Artists => Section::Artists,
-        }
-    }
-}
-
+/// One page of a shelf. Songs lists the favorites on a `Shape::Saved` shelf and every song on a
+/// `Shape::Catalog` one; the other three follow the same rule for their kind.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Section {
-    Favorites,
     Songs,
     Albums,
     Playlists,
@@ -105,21 +82,16 @@ enum DeckKey {
 }
 
 impl Section {
-    const ALL: [Self; 5] = [
-        Self::Favorites,
-        Self::Songs,
-        Self::Albums,
-        Self::Playlists,
-        Self::Artists,
-    ];
+    const ALL: [Self; 4] = [Self::Songs, Self::Albums, Self::Playlists, Self::Artists];
 
+    /// The settings key a section's layout is stored under. The names predate the shelves and
+    /// stay so stored layouts survive.
     fn key(self, shelf: Shelf) -> &'static str {
         match (shelf, self) {
-            (Shelf::Saved, Section::Favorites | Section::Songs) => "songs",
-            (Shelf::Saved, Section::Albums) => "albums",
-            (Shelf::Saved, Section::Playlists) => "playlists",
-            (Shelf::Saved, Section::Artists) => "artists",
-            (Shelf::Local, Section::Favorites) => "local-favorites",
+            (Shelf::Streaming, Section::Songs) => "songs",
+            (Shelf::Streaming, Section::Albums) => "albums",
+            (Shelf::Streaming, Section::Playlists) => "playlists",
+            (Shelf::Streaming, Section::Artists) => "artists",
             (Shelf::Local, Section::Songs) => "local-songs",
             (Shelf::Local, Section::Albums) => "local-albums",
             (Shelf::Local, Section::Playlists) => "local-playlists",
@@ -129,99 +101,84 @@ impl Section {
 
     fn mode(self) -> Mode {
         match self {
-            Section::Favorites | Section::Songs => Mode::List,
+            Section::Songs => Mode::List,
             Section::Albums | Section::Playlists | Section::Artists => Mode::Grid,
         }
     }
 
     fn slot(self) -> usize {
         match self {
-            Section::Favorites => 0,
-            Section::Songs => 1,
-            Section::Albums => 2,
-            Section::Playlists => 3,
-            Section::Artists => 4,
+            Section::Songs => 0,
+            Section::Albums => 1,
+            Section::Playlists => 2,
+            Section::Artists => 3,
         }
     }
 
     fn listing(self) -> bool {
-        matches!(self, Section::Favorites | Section::Songs)
+        self == Section::Songs
     }
 
-    fn vacancy(self, shelf: Shelf) -> &'static str {
-        match (shelf, self) {
-            (Shelf::Saved, Section::Favorites | Section::Songs) => "library-no-songs",
-            (Shelf::Saved, Section::Albums) => "library-no-albums",
-            (Shelf::Saved, Section::Playlists) => "library-no-playlists",
-            (Shelf::Saved, Section::Artists) => "library-no-artists",
-            (Shelf::Local, Section::Favorites) => "library-no-local-favorites",
-            (Shelf::Local, Section::Songs) => "library-no-local-songs",
-            (Shelf::Local, Section::Albums) => "library-no-local-albums",
-            (Shelf::Local, Section::Playlists) => "library-no-local-playlists",
-            (Shelf::Local, Section::Artists) => "library-no-local-artists",
+    fn vacancy(self, shelf: Shelf, shape: Shape) -> &'static str {
+        match (shelf, shape, self) {
+            (Shelf::Local, _, Section::Songs) => "library-no-local-songs",
+            (Shelf::Local, _, Section::Albums) => "library-no-local-albums",
+            (Shelf::Local, _, Section::Playlists) => "library-no-local-playlists",
+            (Shelf::Local, _, Section::Artists) => "library-no-local-artists",
+            (Shelf::Streaming, Shape::Saved, Section::Songs) => "library-no-songs",
+            (Shelf::Streaming, Shape::Saved, Section::Albums) => "library-no-albums",
+            (Shelf::Streaming, Shape::Saved, Section::Artists) => "library-no-artists",
+            (Shelf::Streaming, Shape::Catalog, Section::Songs) => "library-no-catalog-songs",
+            (Shelf::Streaming, Shape::Catalog, Section::Albums) => "library-no-catalog-albums",
+            (Shelf::Streaming, Shape::Catalog, Section::Artists) => "library-no-catalog-artists",
+            (Shelf::Streaming, _, Section::Playlists) => "library-no-playlists",
         }
     }
 
-    fn glyph(self) -> &'static str {
-        match self {
-            Section::Favorites => "icons/heart.svg",
-            Section::Songs => "icons/music.svg",
-            Section::Albums => "icons/disc-3.svg",
-            Section::Playlists => "icons/list-music.svg",
-            Section::Artists => "icons/user-round.svg",
+    fn glyph(self, shape: Shape) -> &'static str {
+        match (self, shape) {
+            (Section::Songs, Shape::Saved) => "icons/heart.svg",
+            (Section::Songs, Shape::Catalog) => "icons/music.svg",
+            (Section::Albums, _) => "icons/disc-3.svg",
+            (Section::Playlists, _) => "icons/list-music.svg",
+            (Section::Artists, _) => "icons/user-round.svg",
         }
     }
 
     fn part(self) -> LibraryPart {
         match self {
-            Section::Favorites | Section::Songs => LibraryPart::Tracks,
+            Section::Songs => LibraryPart::Tracks,
             Section::Albums => LibraryPart::Albums,
             Section::Playlists => LibraryPart::Playlists,
             Section::Artists => LibraryPart::Artists,
         }
     }
+}
 
-    fn origin(self, shelf: Shelf) -> Origin {
-        match (shelf, self) {
-            (Shelf::Saved, _) => Origin::saved(),
-            (Shelf::Local, Section::Songs) => Origin::local(),
-            (Shelf::Local, _) => Origin::local_favorites(),
-        }
+fn origin(shelf: Shelf) -> Origin {
+    match shelf {
+        Shelf::Streaming => Origin::saved(),
+        Shelf::Local => Origin::local(),
     }
 }
 
 struct ShelfTracks {
     library: Entity<Library>,
     shelf: Shelf,
-    section: Section,
 }
 
 impl Tracks for ShelfTracks {
     fn tracks<'a>(&self, cx: &'a App) -> &'a [Track] {
-        let library = self.library.read(cx);
-        let state = match (self.shelf, self.section) {
-            (Shelf::Local, Section::Favorites) => return library.local_favorites(),
-            (Shelf::Local, _) => library.local_state(),
-            (Shelf::Saved, _) => library.state(),
-        };
-        match state {
-            LibraryState::Ready { tracks, .. } => tracks.as_slice(),
-            _ => &[],
-        }
+        self.library.read(cx).state(self.shelf).tracks()
     }
 
     fn is_loading(&self, cx: &App) -> bool {
-        loading(&self.library, self.shelf, self.section, cx)
+        loading(&self.library, self.shelf, Section::Songs, cx)
     }
 }
 
 fn loading(library: &Entity<Library>, shelf: Shelf, section: Section, cx: &App) -> bool {
-    let library = library.read(cx);
-    match (shelf, section) {
-        (Shelf::Local, Section::Favorites) => library.local_favorites_loading(),
-        (Shelf::Local, _) => library.local_loading(section.part()),
-        (Shelf::Saved, _) => library.loading(section.part()),
-    }
+    library.read(cx).loading(shelf, section.part())
 }
 
 pub struct LibraryView {
@@ -231,7 +188,7 @@ pub struct LibraryView {
     playback: Entity<Playback>,
     playback_status: PlaybackStatus,
     section: Section,
-    views: [Mode; 5],
+    views: [Mode; 4],
     width: Pixels,
     card_columns: usize,
     card_tile: Pixels,
@@ -240,7 +197,6 @@ pub struct LibraryView {
     cards_dirty: bool,
     card_scrollbar: Entity<Scrollbar>,
     scrollbar: Entity<Scrollbar>,
-    favorites: Entity<TableState<TrackSource>>,
     songs: Entity<TableState<TrackSource>>,
     albums: Entity<TableState<AlbumSource>>,
     playlists: Entity<TableState<PlaylistSource>>,
@@ -248,7 +204,7 @@ pub struct LibraryView {
     context_menu: Option<(LibraryMenu, Point<Pixels>)>,
     toolbar: Entity<Toolbar>,
     popovers: Popovers,
-    sliders: [Sliders; 5],
+    sliders: [Sliders; 4],
     me: WeakEntity<Self>,
 }
 
@@ -280,47 +236,35 @@ impl LibraryView {
         let scrollbar = cx.new(|_| Scrollbar::new(ScrollHandle::new()).watching(id));
         let scroll = scrollbar.read(cx).scroll().clone();
 
-        let listed = |section: Section, cx: &mut Context<TableState<TrackSource>>| {
+        let songs = cx.new(|cx| {
             let playlist_scrollbar = cx.new(|_| Scrollbar::inset().watching(id));
-            let origin = section.origin(shelf);
+            let from = origin(shelf);
             let source = TrackSource::new(
                 LIBRARY_COLUMNS,
                 ShelfTracks {
                     library: library.clone(),
                     shelf,
-                    section,
                 },
                 playback.clone(),
                 playlist_scrollbar,
             )
-            .from(move |_| Some(origin.clone()));
-            let source = match section == Section::Songs {
-                true => source.with_liked(library.clone()),
-                false => source,
-            };
-            let source = source.table(cx.weak_entity());
+            .from(move |_| Some(from.clone()))
+            .with_liked(library.clone())
+            .starrable(shelf)
+            .table(cx.weak_entity());
             let mut delegate = TableDelegate::new(source, width, cx);
-            if section == Section::Favorites {
+            if shelf == Shelf::Streaming {
                 delegate = delegate.with_sort(TrackField::AddedAt, Sort::Descending, cx);
             }
-            let (layout, sorting) = stored(section, cx);
+            let (layout, sorting) = stored(Section::Songs, cx);
             delegate.set_layout(layout, cx);
             if let Some(sorting) = sorting {
                 delegate.set_sorting(sorting, cx);
             }
-            delegate
-        };
-
-        let favorites = cx.new(|cx| {
-            let delegate = listed(Section::Favorites, cx);
-            TableState::new(delegate, cx).follow(scroll.clone())
-        });
-        let songs = cx.new(|cx| {
-            let delegate = listed(Section::Songs, cx);
             TableState::new(delegate, cx).follow(scroll.clone())
         });
         let albums = cx.new(|cx| {
-            let source = AlbumSource::shelved(library.clone(), playback.clone(), shelf.local());
+            let source = AlbumSource::shelved(library.clone(), playback.clone(), shelf);
             let mut delegate =
                 TableDelegate::new(source, width, cx).with_sort(AlbumField::AddedAt, RECENT, cx);
             let (layout, sorting) = stored(Section::Albums, cx);
@@ -331,7 +275,7 @@ impl LibraryView {
             TableState::new(delegate, cx).follow(scroll.clone())
         });
         let playlists = cx.new(|cx| {
-            let source = PlaylistSource::shelved(library.clone(), playback.clone(), shelf.local());
+            let source = PlaylistSource::shelved(library.clone(), playback.clone(), shelf);
             let mut delegate = TableDelegate::new(source, width, cx).with_sort(
                 PlaylistField::Modified,
                 RECENT,
@@ -345,7 +289,7 @@ impl LibraryView {
             TableState::new(delegate, cx).follow(scroll.clone())
         });
         let artists = cx.new(|cx| {
-            let source = ArtistSource::shelved(library.clone(), playback.clone(), shelf.local());
+            let source = ArtistSource::shelved(library.clone(), playback.clone(), shelf);
             let mut delegate =
                 TableDelegate::new(source, width, cx).with_sort(ArtistField::AddedAt, RECENT, cx);
             let (layout, sorting) = stored(Section::Artists, cx);
@@ -379,24 +323,18 @@ impl LibraryView {
         })
         .detach();
 
-        cx.subscribe(&favorites, |this, _, event, cx| match event {
-            TableEvent::DoubleClicked(display) => this.play(*display, cx),
-            TableEvent::Activated(display) => {
-                let table = this.tracks().clone();
-                page::play_or_toggle(&table, &this.playback, *display, cx)
-            }
-            TableEvent::Removed => tracks::drop_picked(&this.favorites, cx),
-            _ => this.persist(Section::Favorites, cx),
-        })
-        .detach();
-
         cx.subscribe(&songs, |this, _, event, cx| match event {
             TableEvent::DoubleClicked(display) => this.play(*display, cx),
             TableEvent::Activated(display) => {
                 let table = this.tracks().clone();
                 page::play_or_toggle(&table, &this.playback, *display, cx)
             }
-            TableEvent::Removed => {}
+            // on a saved shelf the list is the favorites, so removing a row unstars it
+            TableEvent::Removed => {
+                if this.shape(cx) == Shape::Saved {
+                    tracks::drop_picked(&this.songs, cx);
+                }
+            }
             _ => this.persist(Section::Songs, cx),
         })
         .detach();
@@ -448,7 +386,7 @@ impl LibraryView {
             settings,
             playback,
             playback_status: current_playback,
-            section: Section::Favorites,
+            section: Section::Songs,
             views,
             width,
             card_columns: 0,
@@ -458,7 +396,6 @@ impl LibraryView {
             cards_dirty: true,
             card_scrollbar,
             scrollbar,
-            favorites,
             songs,
             albums,
             playlists,
@@ -476,7 +413,7 @@ impl LibraryView {
         PlaylistEditor::open(
             Edit::Create {
                 tracks: Vec::new(),
-                local: self.shelf.local(),
+                shelf: self.shelf,
             },
             window,
             cx,
@@ -490,7 +427,6 @@ impl LibraryView {
 
     fn table(&self, section: Section) -> &dyn ui::Listing {
         match section {
-            Section::Favorites => &self.favorites,
             Section::Songs => &self.songs,
             Section::Albums => &self.albums,
             Section::Playlists => &self.playlists,
@@ -498,21 +434,16 @@ impl LibraryView {
         }
     }
 
-    fn tables(&self) -> [&dyn ui::Listing; 5] {
-        [
-            &self.favorites,
-            &self.songs,
-            &self.albums,
-            &self.playlists,
-            &self.artists,
-        ]
+    fn tables(&self) -> [&dyn ui::Listing; 4] {
+        [&self.songs, &self.albums, &self.playlists, &self.artists]
     }
 
     fn tracks(&self) -> &Entity<TableState<TrackSource>> {
-        match self.section {
-            Section::Songs => &self.songs,
-            _ => &self.favorites,
-        }
+        &self.songs
+    }
+
+    fn shape(&self, cx: &App) -> Shape {
+        self.library.read(cx).shape(self.shelf)
     }
 
     fn column_toggles(&self, cx: &App) -> Vec<Toggle> {
@@ -550,35 +481,30 @@ impl LibraryView {
         }
         let library = self.library.read(cx);
         let table = self.table(self.section);
-        let state = match self.shelf {
-            Shelf::Local => library.local_state(),
-            Shelf::Saved => library.state(),
-        };
-        match state {
+        match library.state(self.shelf) {
             LibraryState::Loading => return None,
             LibraryState::Failed(_) => return Some(Vacancy::new(t!("library-not-loaded"))),
             _ if table.row_count(cx) > 0 => return None,
             _ => {}
         }
 
-        let failed = match self.shelf {
-            Shelf::Local => library.local_part_failed(self.section.part()),
-            Shelf::Saved => library.part_failed(self.section.part()),
-        };
+        let failed = library.part_failed(self.shelf, self.section.part());
+        let shape = library.shape(self.shelf);
 
         Some(match (table.filtering(cx), failed) {
             (true, _) => Vacancy::new(t!("library-no-matches")),
             (false, true) => Vacancy::new(t!("library-part-not-loaded")),
-            (false, false) => Vacancy::new(i18n::lookup(self.section.vacancy(self.shelf), None))
-                .icon(self.section.glyph()),
+            (false, false) => {
+                Vacancy::new(i18n::lookup(self.section.vacancy(self.shelf, shape), None))
+                    .icon(self.section.glyph(shape))
+            }
         })
     }
 
     pub fn refresh(&mut self, cx: &mut Context<Self>) {
-        if self.shelf.local() {
-            return;
-        }
-        self.library.update(cx, |library, cx| library.refresh(cx));
+        let shelf = self.shelf;
+        self.library
+            .update(cx, |library, cx| library.refresh(shelf, cx));
     }
 
     pub fn select(&mut self, section: Section, cx: &mut Context<Self>) {
@@ -615,10 +541,14 @@ impl LibraryView {
         if !duration.is_zero() {
             strip = strip.text(clock(duration));
         }
-        let songs = self.section == Section::Songs;
-        let (title, icon, eyebrow) = match songs {
-            true => (t!("nav-songs"), "icons/disc-3.svg", t!("nav-local")),
-            false => (
+        let (title, icon, eyebrow) = match (self.shape(cx), self.shelf) {
+            (Shape::Catalog, Shelf::Local) => {
+                (t!("nav-songs"), "icons/disc-3.svg", t!("nav-local"))
+            }
+            (Shape::Catalog, Shelf::Streaming) => {
+                (t!("nav-songs"), "icons/disc-3.svg", t!("nav-library"))
+            }
+            (Shape::Saved, _) => (
                 t!("library-liked-songs"),
                 "icons/heart-filled.svg",
                 t!("detail-playlist"),
@@ -839,7 +769,6 @@ impl LibraryView {
         }
         if self.cards_dirty {
             self.card_rows = match self.section {
-                Section::Favorites => deck(&self.favorites, columns, cx),
                 Section::Songs => deck(&self.songs, columns, cx),
                 Section::Albums => deck(&self.albums, columns, cx),
                 Section::Playlists => deck(&self.playlists, columns, cx),
@@ -888,9 +817,6 @@ impl LibraryView {
                         match row {
                             DeckRow::Heading(display) => {
                                 let label = match section {
-                                    Section::Favorites => {
-                                        view.favorites.read(cx).delegate().group(*display, cx)
-                                    }
                                     Section::Songs => {
                                         view.songs.read(cx).delegate().group(*display, cx)
                                     }
@@ -912,7 +838,7 @@ impl LibraryView {
                             }
                             DeckRow::Cards(cards) => {
                                 let row = match section {
-                                    Section::Favorites | Section::Songs => CardGrid::new(room)
+                                    Section::Songs => CardGrid::new(room)
                                         .children(cards.iter().filter_map(|&(display, row)| {
                                             view.track_card(display, row, card, cx)
                                         }))
@@ -1256,11 +1182,12 @@ impl Tooled for LibraryView {
         let mut tools = Vec::new();
         tools.extend(create);
         tools.extend(columns);
-        if self.section != Section::Artists {
+        let filters = self.table(self.section).filters(cx);
+        if !filters.is_empty() {
             tools.push(tools::filters(
                 &self.popovers,
                 &self.sliders[self.section.slot()],
-                self.table(self.section).filters(cx),
+                filters,
                 move |change, cx| {
                     filtered.update(cx, |view, cx| view.filter(change, cx)).ok();
                 },

--- a/crates/views/src/screens/library/playlists.rs
+++ b/crates/views/src/screens/library/playlists.rs
@@ -5,7 +5,7 @@ use gpui::{AnyElement, App, Entity, TextAlign};
 use i18n::t;
 use music::Playlist;
 use router::Destination;
-use state::{Library, LibraryPart, LibraryState, Origin, Playback};
+use state::{Library, LibraryPart, Origin, Playback, Shelf};
 use ui::rank::{ESSENTIAL, HANDY, NICE, SPARE};
 use ui::{Cell, ColumnSpec, Menu, Pin, TableSource, Width};
 
@@ -73,7 +73,7 @@ pub(super) const COLUMNS: &[ColumnSpec<PlaylistField>] =
 pub(super) struct PlaylistSource {
     library: Entity<Library>,
     playback: Entity<Playback>,
-    local: bool,
+    shelf: Shelf,
     owned: bool,
 }
 
@@ -81,12 +81,12 @@ impl PlaylistSource {
     pub(super) fn shelved(
         library: Entity<Library>,
         playback: Entity<Playback>,
-        local: bool,
+        shelf: Shelf,
     ) -> Self {
         Self {
             library,
             playback,
-            local,
+            shelf,
             owned: false,
         }
     }
@@ -107,15 +107,7 @@ impl PlaylistSource {
     }
 
     fn playlists<'a>(&self, cx: &'a App) -> &'a [Playlist] {
-        let library = self.library.read(cx);
-        let state = match self.local {
-            true => library.local_state(),
-            false => library.state(),
-        };
-        match state {
-            LibraryState::Ready { playlists, .. } => playlists.as_slice(),
-            _ => &[],
-        }
+        self.library.read(cx).state(self.shelf).playlists()
     }
 }
 
@@ -171,10 +163,9 @@ impl TableSource for PlaylistSource {
     }
 
     fn is_loading(&self, cx: &App) -> bool {
-        match self.local {
-            true => self.library.read(cx).local_loading(LibraryPart::Playlists),
-            false => self.library.read(cx).loading(LibraryPart::Playlists),
-        }
+        self.library
+            .read(cx)
+            .loading(self.shelf, LibraryPart::Playlists)
     }
 
     fn pin(&self, row: usize, cx: &App) -> Option<Pin> {

--- a/crates/views/src/shared/confirm.rs
+++ b/crates/views/src/shared/confirm.rs
@@ -20,7 +20,6 @@ impl Kind {
         match self {
             Self::PlaylistSongs(_) => t!("confirm-remove-playlist-title"),
             Self::History(_) => t!("confirm-remove-history-title"),
-            Self::Artists(_) => t!("confirm-unfollow-title"),
             _ => t!("confirm-remove-library-title"),
         }
     }
@@ -31,16 +30,13 @@ impl Kind {
             Self::PlaylistSongs(count) => t!("confirm-remove-playlist-songs", count = count),
             Self::History(count) => t!("confirm-remove-history-songs", count = count),
             Self::Albums(count) => t!("confirm-remove-albums", count = count),
-            Self::Artists(count) => t!("confirm-unfollow-artists", count = count),
+            Self::Artists(count) => t!("confirm-remove-artists", count = count),
             Self::Playlists(count) => t!("confirm-remove-playlists", count = count),
         }
     }
 
     fn action(&self) -> gpui::SharedString {
-        match self {
-            Self::Artists(_) => t!("artist-unfollow"),
-            _ => t!("common-delete"),
-        }
+        t!("common-delete")
     }
 }
 

--- a/crates/views/src/shared/menus/context.rs
+++ b/crates/views/src/shared/menus/context.rs
@@ -2,7 +2,7 @@ use gpui::{App, ClickEvent, ClipboardItem, Entity, SharedString, Styled as _, Wi
 use i18n::t;
 use music::{Album, MediaKind, Playlist, SavedArtist, Track};
 use router::{Destination, navigate};
-use state::{Detail, History, Library, LibraryState, Origin, Playback, Sonora};
+use state::{Detail, History, Library, Origin, Playback, Shelf, Sonora};
 use ui::{Menu, MenuItem, Pin, PinKind, Scrollbar, SubmenuState};
 
 use crate::shared::confirm::Confirm;
@@ -165,17 +165,17 @@ impl ItemMenu {
         };
         let barren = ids.is_empty();
         let shelf = match imported {
-            true => library.read(cx).local_state(),
-            false => library.read(cx).state(),
+            true => Shelf::Local,
+            false => Shelf::Streaming,
         };
-        let playlists: Vec<Playlist> = match shelf {
-            LibraryState::Ready { playlists, .. } => playlists
-                .iter()
-                .filter(|playlist| playlist.owned || playlist.collaborative)
-                .cloned()
-                .collect(),
-            _ => Vec::new(),
-        };
+        let playlists: Vec<Playlist> = library
+            .read(cx)
+            .state(shelf)
+            .playlists()
+            .iter()
+            .filter(|playlist| playlist.owned || playlist.collaborative)
+            .cloned()
+            .collect();
         let created = ids.clone();
         let new_playlist = MenuItem::new("new-playlist", t!("menu-new-playlist"))
             .icon("icons/plus.svg")
@@ -183,7 +183,7 @@ impl ItemMenu {
                 PlaylistEditor::open(
                     Edit::Create {
                         tracks: created.clone(),
-                        local: imported,
+                        shelf,
                     },
                     window,
                     cx,
@@ -663,26 +663,23 @@ pub(crate) fn artist_menu(
 }
 
 fn artist_library_item(artist: SavedArtist, cx: &App) -> Option<MenuItem> {
-    if music::is_local_id(&artist.id) {
-        return None;
-    }
     let library = Sonora::global(cx).library.clone();
-    let followed = library.read(cx).saved_artist(&artist.id);
+    let saved = library.read(cx).saved_artist(&artist.id);
     let item = MenuItem::new(
         "toggle-artist-library",
-        match followed {
-            true => t!("artist-unfollow"),
-            false => t!("artist-follow"),
+        match saved {
+            true => t!("menu-remove-from-library"),
+            false => t!("menu-add-to-library"),
         },
     )
-    .icon(match followed {
+    .icon(match saved {
         true => "icons/heart-off.svg",
         false => "icons/heart.svg",
     });
 
     Some(match library.read(cx).pending_artist(&artist.id) {
         true => item.disabled(),
-        false => item.on_click(move |_, _, cx| match followed {
+        false => item.on_click(move |_, _, cx| match saved {
             true => Confirm::artists(vec![artist.clone()], cx),
             false => {
                 let library = Sonora::global(cx).library.clone();
@@ -969,12 +966,11 @@ fn media_kind(kind: PinKind) -> MediaKind {
 }
 
 fn saved_track(id: &str, cx: &App) -> Option<Track> {
-    let library = Sonora::global(cx).library.read(cx);
-    let LibraryState::Ready { tracks, .. } = library.state() else {
-        return None;
-    };
-
-    tracks
+    Sonora::global(cx)
+        .library
+        .read(cx)
+        .state(Shelf::of(id))
+        .tracks()
         .iter()
         .find(|track| track.id.as_deref() == Some(id))
         .cloned()

--- a/crates/views/src/shared/playlist_editor.rs
+++ b/crates/views/src/shared/playlist_editor.rs
@@ -2,13 +2,13 @@ use gpui::prelude::*;
 use gpui::{App, Context, Entity, FocusHandle, Global, Render, Window, div};
 use i18n::t;
 use music::Playlist;
-use state::Sonora;
+use state::{Shelf, Sonora};
 use ui::{ActiveTheme as _, Button, Modal};
 use ui::{Dismiss, FORM_CONTEXT, Input, Submit};
 
 #[derive(Clone)]
 pub(crate) enum Edit {
-    Create { tracks: Vec<String>, local: bool },
+    Create { tracks: Vec<String>, shelf: Shelf },
     Rename(Playlist),
     Delete(Playlist),
     Again { playlist: Playlist, track: String },
@@ -78,9 +78,9 @@ impl PlaylistEditor {
         let library = Sonora::global(cx).library.clone();
 
         match edit {
-            Edit::Create { tracks, local } if !name.is_empty() => {
+            Edit::Create { tracks, shelf } if !name.is_empty() => {
                 library.update(cx, |library, cx| {
-                    library.create_playlist(name, tracks, local, cx);
+                    library.create_playlist(name, tracks, shelf, cx);
                 })
             }
             Edit::Rename(playlist) if !name.is_empty() && name != playlist.name => {

--- a/crates/views/src/shared/tracks/mod.rs
+++ b/crates/views/src/shared/tracks/mod.rs
@@ -14,9 +14,9 @@ use gpui::{
     AnyElement, App, Entity, Hsla, InteractiveElement as _, IntoElement as _, SharedString,
     Styled as _, WeakEntity,
 };
-use music::Track;
+use music::{Shape, Track};
 use router::Destination;
-use state::{Detail, History, Library, Origin, Playback, PlaybackState, Sonora};
+use state::{Detail, History, Library, Origin, Playback, PlaybackState, Shelf, Sonora};
 use ui::{
     Button, Cell, ColumnSpec, Menu, Pin, ROW_GROUP, Scrollbar, TableSource, TableState, clock,
 };
@@ -152,6 +152,7 @@ pub(crate) struct TrackSource {
     provider: Rc<dyn Tracks>,
     playback: Entity<Playback>,
     is_liked: Option<Entity<Library>>,
+    starrable: Option<Shelf>,
     album: Option<Entity<Detail>>,
     playlist: Option<Entity<Detail>>,
     history: Option<Entity<History>>,
@@ -179,6 +180,7 @@ impl TrackSource {
             provider: Rc::new(provider),
             playback,
             is_liked: None,
+            starrable: None,
             album: None,
             playlist: None,
             history: None,
@@ -242,6 +244,27 @@ impl TrackSource {
     pub(crate) fn with_liked(mut self, library: Entity<Library>) -> Self {
         self.is_liked = Some(library);
         self
+    }
+
+    /// Offers a favorites filter, and hearts on the rows, only when the shelf lists more than the
+    /// favorites. Needs `with_liked`, which supplies the library both ask.
+    pub(crate) fn starrable(mut self, shelf: Shelf) -> Self {
+        self.starrable = Some(shelf);
+        self
+    }
+
+    fn catalog(&self, cx: &App) -> bool {
+        match (self.starrable, &self.is_liked) {
+            (Some(shelf), Some(library)) => library.read(cx).shape(shelf) == Shape::Catalog,
+            _ => false,
+        }
+    }
+
+    fn starred(&self, track: &Track, cx: &App) -> bool {
+        match (&self.is_liked, track.id.as_deref()) {
+            (Some(library), Some(id)) => library.read(cx).saved(id),
+            _ => false,
+        }
     }
 
     pub(crate) fn with_playlist(mut self, detail: Entity<Detail>) -> Self {
@@ -334,6 +357,10 @@ impl TrackSource {
 
     fn liked_button(&self, cell: &Cell<TrackField>, track: &Track, cx: &App) -> Option<AnyElement> {
         let library = self.is_liked.as_ref()?;
+        // on a saved shelf every listed track is a favorite, so the heart would say nothing
+        if self.starrable.is_some() && !self.catalog(cx) {
+            return None;
+        }
         let id = track.id.clone()?;
         let theme = *cx.theme();
         let state = library.read(cx);
@@ -436,6 +463,9 @@ impl TableSource for TrackSource {
             if !self.sieve.keeps(&track) {
                 return false;
             }
+            if self.sieve.favorites && !self.starred(&track, cx) {
+                return false;
+            }
             hits(&track, query)
         })
     }
@@ -446,7 +476,7 @@ impl TableSource for TrackSource {
         };
         let value = self.sieve.duration.unwrap_or(bounds);
 
-        vec![
+        let mut axes = vec![
             Filter::Range(
                 RangeAxis {
                     key: "filter-duration",
@@ -468,7 +498,15 @@ impl TableSource for TrackSource {
                 label: t!("filter-playable"),
                 on: self.sieve.playable,
             }),
-        ]
+        ];
+        if self.catalog(cx) {
+            axes.push(Filter::Flag(FlagAxis {
+                key: "filter-favorites",
+                label: t!("filter-favorites"),
+                on: self.sieve.favorites,
+            }));
+        }
+        axes
     }
 
     fn filter(&mut self, change: FilterChange, _cx: &App) -> bool {
@@ -483,6 +521,10 @@ impl TableSource for TrackSource {
             }
             FilterChange::Flag("filter-playable", value) => {
                 self.sieve.playable = value;
+                true
+            }
+            FilterChange::Flag("filter-favorites", value) => {
+                self.sieve.favorites = value;
                 true
             }
             FilterChange::Reset => {

--- a/crates/views/src/shared/tracks/sieve.rs
+++ b/crates/views/src/shared/tracks/sieve.rs
@@ -5,11 +5,13 @@ pub(crate) struct TrackSieve {
     pub duration: Option<(f32, f32)>,
     pub explicit: bool,
     pub playable: bool,
+    /// Keep only starred tracks. `keeps` cannot see the library, so the source applies it.
+    pub favorites: bool,
 }
 
 impl TrackSieve {
     pub(crate) fn active(&self) -> bool {
-        self.duration.is_some() || self.explicit || self.playable
+        self.duration.is_some() || self.explicit || self.playable || self.favorites
     }
 
     pub(super) fn keeps(&self, track: &Track) -> bool {
@@ -55,6 +57,7 @@ mod tests {
             duration: Some((60., 180.)),
             explicit: true,
             playable: true,
+            favorites: false,
         };
 
         assert!(sieve.keeps(&track(120, true, true)));


### PR DESCRIPTION
## Summary

- lay the groundwork for #368: a self-hosted provider lists its whole catalog with a favorites filter, the way local music does now
- give every provider session a library shape: saved lists what the user starred, catalog lists everything the provider has
- add all_albums and all_artists beside all_tracks, and make the saved_* methods mean favorites on every provider
- hold one library shelf per provider in state, with the same loading, landing and favorites code for both
- list local music under the same four tabs as your library and replace its favorites tab with a favorites only filter
- show hearts on every catalog shelf and let local albums and artists be favorited from their pages and the context menu
- name artist favoriting add to favorites and remove from favorites, matching songs and albums