### PR TITLE
fix(music): paginate large YouTube playlists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,35 +1172,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cookie"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
-dependencies = [
- "cookie",
- "document-features",
- "idna",
- "log",
- "publicsuffix",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
- "url",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,7 +1739,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1998,7 +1969,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4534,7 +4505,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5668,12 +5639,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "psl-types"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
-
-[[package]]
 name = "psm"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5681,16 +5646,6 @@ checksum = "4dcd034599e63b970727f70d79e02d62390a4a84f7c6b827c27c46d5ac3fa622"
 dependencies = [
  "ar_archive_writer",
  "cc",
-]
-
-[[package]]
-name = "publicsuffix"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
-dependencies = [
- "idna",
- "psl-types",
 ]
 
 [[package]]
@@ -5818,7 +5773,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6186,8 +6141,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "cookie",
- "cookie_store",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -6219,18 +6172,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
-]
-
-[[package]]
-name = "reqwest_cookie_store"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e75bc88d954b228850d19e3685cedb38c030a17da34aa01c307f95d6e33de34"
-dependencies = [
- "bytes",
- "cookie_store",
- "reqwest",
- "url",
 ]
 
 [[package]]
@@ -6453,7 +6394,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7754,7 +7695,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9138,7 +9079,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9792,18 +9733,20 @@ dependencies = [
 [[package]]
 name = "ytmusic"
 version = "0.1.0"
-source = "git+https://github.com/sonorahq/ytmusic-rs?rev=736995285a283a7c1d8e158ac1361c30bcea2913#736995285a283a7c1d8e158ac1361c30bcea2913"
+source = "git+https://github.com/sonorahq/ytmusic-rs?rev=a6d2a734039e5b61f9360bf8639c327e094ee84e#a6d2a734039e5b61f9360bf8639c327e094ee84e"
 dependencies = [
+ "aes",
  "anyhow",
  "async-trait",
  "base64",
- "cookie_store",
+ "cbc",
  "log",
+ "pbkdf2",
  "rand 0.9.5",
  "regex-lite",
  "reqwest",
- "reqwest_cookie_store",
  "rquickjs",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ symphonia = { version = "0.5.5", default-features = false, features = ["mkv", "o
 tray-icon = { version = "0.24", default-features = false }
 unic-langid = { version = "0.9", features = ["macros"] }
 unicode-segmentation = "1.12"
-ytmusic = { git = "https://github.com/sonorahq/ytmusic-rs", rev = "736995285a283a7c1d8e158ac1361c30bcea2913" }
+ytmusic = { git = "https://github.com/sonorahq/ytmusic-rs", rev = "a6d2a734039e5b61f9360bf8639c327e094ee84e" }
 
 librespot-core = { version = "0.8.0", default-features = false, features = [
   "rustls-tls-native-roots",

--- a/crates/music/src/lib.rs
+++ b/crates/music/src/lib.rs
@@ -117,6 +117,13 @@ pub trait MusicApi: Send + Sync {
     async fn album(&self, album_id: &str) -> Result<AlbumDetail>;
     async fn album_tracks(&self, album_id: &str) -> Result<Vec<Track>>;
     async fn playlist(&self, playlist_id: &str) -> Result<PlaylistDetail>;
+    async fn playlist_continuation(
+        &self,
+        _continuation: &str,
+    ) -> Result<(Vec<Track>, Option<String>)> {
+        anyhow::bail!("playlist pagination is not supported")
+    }
+
     async fn playlist_tracks(&self, playlist_id: &str) -> Result<Vec<Track>>;
     async fn playlist_covers(&self, playlist_id: &str, wanted: usize) -> Result<Vec<String>>;
     async fn track_radio(&self, track_id: &str) -> Result<Vec<Track>>;

--- a/crates/music/src/local/client.rs
+++ b/crates/music/src/local/client.rs
@@ -50,6 +50,7 @@ impl LocalClient {
         Ok(PlaylistDetail {
             playlist: playlist_from(stored.id, stored.name, stored.modified_at, &tracks),
             tracks,
+            continuation: None,
         })
     }
 

--- a/crates/music/src/models.rs
+++ b/crates/music/src/models.rs
@@ -190,6 +190,7 @@ pub struct TrackTags {
 pub struct PlaylistDetail {
     pub playlist: Playlist,
     pub tracks: Vec<Track>,
+    pub continuation: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/music/src/spotify/playlists.rs
+++ b/crates/music/src/spotify/playlists.rs
@@ -130,7 +130,11 @@ pub async fn playlist(session: &Session, playlist_id: &str) -> Result<PlaylistDe
     let mut tracks = tracks_from(session, &content).await?;
     credit(session, &playlist, &mut tracks).await;
 
-    Ok(PlaylistDetail { playlist, tracks })
+    Ok(PlaylistDetail {
+        playlist,
+        tracks,
+        continuation: None,
+    })
 }
 
 async fn credit(session: &Session, playlist: &Playlist, tracks: &mut [Track]) {

--- a/crates/music/src/youtube/client.rs
+++ b/crates/music/src/youtube/client.rs
@@ -286,17 +286,34 @@ impl MusicApi for YouTubeClient {
     }
 
     async fn playlist(&self, playlist_id: &str) -> Result<PlaylistDetail> {
-        let mut detail = self.api.playlist(playlist_id).await?;
+        let mut detail = self.api.playlist_page(playlist_id).await?;
         detail.tracks = self.api.swap_playable(detail.tracks).await;
         Ok(wire::playlist_detail(detail))
     }
 
+    async fn playlist_continuation(
+        &self,
+        continuation: &str,
+    ) -> Result<(Vec<Track>, Option<String>)> {
+        let mut page = self.api.playlist_continuation(continuation).await?;
+        page.tracks = self.api.swap_playable(page.tracks).await;
+        Ok(wire::playlist_page(page))
+    }
+
     async fn playlist_tracks(&self, playlist_id: &str) -> Result<Vec<Track>> {
-        Ok(self.playlist(playlist_id).await?.tracks)
+        let mut detail = self.api.playlist(playlist_id).await?;
+        detail.tracks = self.api.swap_playable(detail.tracks).await;
+        Ok(wire::playlist_detail(detail).tracks)
     }
 
     async fn playlist_covers(&self, playlist_id: &str, wanted: usize) -> Result<Vec<String>> {
-        let tracks = self.playlist_tracks(playlist_id).await?;
+        let mut tracks = self.api.playlist_page(playlist_id).await?.tracks;
+        tracks = self.api.swap_playable(tracks).await;
+        let tracks: Vec<Track> = tracks
+            .into_iter()
+            .enumerate()
+            .map(|(index, track)| wire::track(track, index as u32))
+            .collect();
         Ok(crate::distinct_covers(&tracks, wanted))
     }
 

--- a/crates/music/src/youtube/mod.rs
+++ b/crates/music/src/youtube/mod.rs
@@ -73,7 +73,7 @@ impl YouTubeProvider {
         Arc::new(
             YtMusic::with_cookies(cookies)
                 .as_user(authuser)
-                .persist_cookies(self.cookies.clone())
+                .persist_to(self.cookies.clone())
                 .cache_resolutions(self.resolved.clone())
                 .cache_player(self.player.clone()),
         )

--- a/crates/music/src/youtube/wire.rs
+++ b/crates/music/src/youtube/wire.rs
@@ -119,7 +119,18 @@ pub fn playlist_detail(source: ytmusic::PlaylistDetail) -> PlaylistDetail {
     PlaylistDetail {
         playlist: playlist(source.playlist, owned, public),
         tracks,
+        continuation: source.continuation,
     }
+}
+
+pub fn playlist_page(source: ytmusic::PlaylistPage) -> (Vec<Track>, Option<String>) {
+    let tracks = source
+        .tracks
+        .into_iter()
+        .enumerate()
+        .map(|(index, item)| track(item, index as u32))
+        .collect();
+    (tracks, source.continuation)
 }
 
 pub fn artist(source: ytmusic::Artist) -> Artist {

--- a/crates/state/src/catalog.rs
+++ b/crates/state/src/catalog.rs
@@ -22,6 +22,10 @@ trait CatalogBackend: Send + Sync {
     async fn track_playcount(&self, id: &str) -> Result<Option<u64>>;
     async fn album(&self, id: &str) -> Result<AlbumDetail>;
     async fn playlist(&self, id: &str) -> Result<PlaylistDetail>;
+    async fn playlist_continuation(
+        &self,
+        continuation: &str,
+    ) -> Result<(Vec<Track>, Option<String>)>;
     async fn genre(&self, id: &str) -> Result<GenreDetail>;
 }
 
@@ -49,6 +53,12 @@ impl CatalogBackend for ApiBackend {
     }
     async fn playlist(&self, id: &str) -> Result<PlaylistDetail> {
         self.0.playlist(id).await
+    }
+    async fn playlist_continuation(
+        &self,
+        continuation: &str,
+    ) -> Result<(Vec<Track>, Option<String>)> {
+        self.0.playlist_continuation(continuation).await
     }
     async fn genre(&self, id: &str) -> Result<GenreDetail> {
         self.0.genre(id).await
@@ -169,6 +179,13 @@ impl CatalogSource {
 
     pub(crate) async fn invalidate_playlist(&self, id: &str) {
         self.playlists.invalidate(id).await;
+    }
+
+    pub(crate) async fn playlist_continuation(
+        &self,
+        continuation: &str,
+    ) -> Result<(Vec<Track>, Option<String>)> {
+        self.backend.playlist_continuation(continuation).await
     }
 
     pub(crate) fn peek_genre(&self, id: &str) -> Option<Arc<GenreDetail>> {
@@ -390,6 +407,7 @@ mod tests {
                     modified_at: None,
                 },
                 tracks: Vec::new(),
+                continuation: None,
             }
         }
     }
@@ -453,6 +471,12 @@ mod tests {
         async fn playlist(&self, id: &str) -> anyhow::Result<PlaylistDetail> {
             self.count("playlist", id);
             Ok(self.playlist_value(id))
+        }
+        async fn playlist_continuation(
+            &self,
+            _continuation: &str,
+        ) -> anyhow::Result<(Vec<Track>, Option<String>)> {
+            Ok((Vec::new(), None))
         }
         async fn genre(&self, id: &str) -> anyhow::Result<GenreDetail> {
             self.count("genre", id);

--- a/crates/state/src/detail.rs
+++ b/crates/state/src/detail.rs
@@ -7,6 +7,8 @@ use tokio::task::AbortHandle;
 
 use crate::{Io, Library, LibraryEvent, Session, SessionEvent, join, mosaic};
 
+const MAX_PAGED_TRACKS: usize = 200;
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Collection {
     Album,
@@ -36,7 +38,9 @@ pub struct Detail {
     album: Option<Album>,
     playlist: Option<Playlist>,
     tracks: Vec<Track>,
+    continuation: Option<String>,
     loading: bool,
+    loading_more: bool,
     loaded: bool,
     error: Option<String>,
     session: Entity<Session>,
@@ -132,7 +136,9 @@ impl Detail {
             album: None,
             playlist: None,
             tracks: Vec::new(),
+            continuation: None,
             loading: false,
+            loading_more: false,
             loaded: false,
             error: None,
             session,
@@ -166,6 +172,68 @@ impl Detail {
 
     pub fn is_loading(&self) -> bool {
         self.loading
+    }
+
+    pub fn has_more(&self) -> bool {
+        self.continuation.is_some()
+    }
+
+    pub fn is_loading_more(&self) -> bool {
+        self.loading_more
+    }
+
+    /// Appends one provider page up to the detail-screen limit.
+    pub fn load_more(&mut self, cx: &mut Context<Self>) {
+        if self.loading_more {
+            return;
+        }
+        let Some(continuation) = self.continuation.clone() else {
+            return;
+        };
+        let Some(id) = self.id.as_deref() else {
+            return;
+        };
+        let Some(catalog) = self.session.read(cx).catalog(id) else {
+            return;
+        };
+
+        self.continuation = None;
+        self.loading_more = true;
+        cx.notify();
+
+        let request = self
+            .io
+            .spawn(async move { catalog.playlist_continuation(&continuation).await });
+        self.request = Some(request.abort_handle());
+        self.task = Some(cx.spawn(async move |this, cx| {
+            let loaded = join(request).await;
+            this.update(cx, |this, cx| {
+                this.loading_more = false;
+                this.request = None;
+                match loaded {
+                    Ok((tracks, _)) => {
+                        let offset = this.tracks.len() as u32;
+                        let remaining = MAX_PAGED_TRACKS.saturating_sub(this.tracks.len());
+                        this.tracks
+                            .extend(tracks.into_iter().take(remaining).enumerate().map(
+                                |(index, mut track)| {
+                                    track.track_number = offset + index as u32 + 1;
+                                    track
+                                },
+                            ));
+                        if let Some(playlist) = this.playlist.as_mut()
+                            && playlist.track_count < this.tracks.len() as u32
+                        {
+                            playlist.track_count = this.tracks.len() as u32;
+                            this.header = Some(playlist_header(playlist));
+                        }
+                    }
+                    Err(error) => log::warn!("detail: cannot load more playlist tracks: {error:#}"),
+                }
+                cx.notify();
+            })
+            .ok();
+        }));
     }
 
     pub fn remove_from_playlist(&mut self, track_id: String, cx: &mut Context<Self>) {
@@ -338,6 +406,7 @@ impl Detail {
                 self.header = Some(album_header(&detail.album));
                 self.album = Some(detail.album.clone());
                 self.tracks = detail.tracks.clone();
+                self.continuation = None;
             }
             Loaded::Playlist(detail) => {
                 let mut playlist = detail.playlist.clone();
@@ -349,7 +418,15 @@ impl Detail {
                 }
                 self.header = Some(playlist_header(&playlist));
                 self.playlist = Some(playlist);
-                self.tracks = detail.tracks.clone();
+                self.tracks = detail
+                    .tracks
+                    .iter()
+                    .take(MAX_PAGED_TRACKS)
+                    .cloned()
+                    .collect();
+                self.continuation = (self.tracks.len() < MAX_PAGED_TRACKS)
+                    .then(|| detail.continuation.clone())
+                    .flatten();
             }
         }
         self.loaded = true;
@@ -367,7 +444,9 @@ impl Detail {
         self.album = None;
         self.playlist = None;
         self.tracks.clear();
+        self.continuation = None;
         self.loading = false;
+        self.loading_more = false;
         self.loaded = false;
         self.error = None;
     }

--- a/crates/views/src/screens/detail.rs
+++ b/crates/views/src/screens/detail.rs
@@ -56,6 +56,7 @@ pub(crate) struct DetailView {
     settings: Entity<AppSettings>,
     section: &'static str,
     sorted: Option<String>,
+    shown: Option<String>,
     context_menu: Option<Point<Pixels>>,
     toolbar: Entity<Toolbar>,
     popovers: Popovers,
@@ -121,12 +122,16 @@ impl DetailView {
             TableState::new(delegate, cx).follow(scroll)
         });
 
-        cx.observe(&detail, |this, _, cx| {
-            this.scrollbar
-                .read(cx)
-                .scroll()
-                .set_offset(gpui::Point::default());
-            this.restore_sorting(cx);
+        cx.observe(&detail, |this, detail, cx| {
+            let shown = detail.read(cx).id().map(str::to_owned);
+            if this.shown != shown {
+                this.shown = shown;
+                this.scrollbar
+                    .read(cx)
+                    .scroll()
+                    .set_offset(gpui::Point::default());
+                this.restore_sorting(cx);
+            }
             this.retune(cx);
             this.rebuild(cx);
             cx.notify();
@@ -203,6 +208,7 @@ impl DetailView {
             settings,
             section,
             sorted: None,
+            shown: None,
             context_menu: None,
             toolbar,
             popovers: Popovers::default(),
@@ -470,6 +476,17 @@ impl Render for DetailView {
             )
         });
 
+        let more = (self.section == "playlist" && self.detail.read(cx).has_more()).then(|| {
+            let detail = self.detail.clone();
+            Button::new("playlist-load-more")
+                .label(t!("common-more"))
+                .outline()
+                .disabled(self.detail.read(cx).is_loading_more())
+                .on_click(move |_, _, cx| {
+                    detail.update(cx, |detail, cx| detail.load_more(cx));
+                })
+        });
+
         div()
             .relative()
             .size_full()
@@ -478,7 +495,10 @@ impl Render for DetailView {
                     .pt(inset)
                     .pb(inset)
                     .child(div().px(inset).child(self.header(cx)))
-                    .child(table(&self.table)),
+                    .child(table(&self.table))
+                    .when_some(more, |this, more| {
+                        this.child(div().flex().justify_center().py(inset).child(more))
+                    }),
             )
             .when_some(context_menu, |this, menu| this.child(menu))
     }


### PR DESCRIPTION
## Summary

- load large YouTube Music playlists in two pages capped at 200 tracks
- preserve scroll position and update the loaded track count after loading more
- fix #357 by avoiding eager loading of every playlist page