### PR TITLE
build: point ytmusic at a revision that builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,6 +1195,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5718,6 +5747,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
 name = "psm"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5725,6 +5760,16 @@ checksum = "4dcd034599e63b970727f70d79e02d62390a4a84f7c6b827c27c46d5ac3fa622"
 dependencies = [
  "ar_archive_writer",
  "cc",
+]
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
 ]
 
 [[package]]
@@ -6221,6 +6266,8 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -6294,6 +6341,18 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "reqwest_cookie_store"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e75bc88d954b228850d19e3685cedb38c030a17da34aa01c307f95d6e33de34"
+dependencies = [
+ "bytes",
+ "cookie_store",
+ "reqwest 0.12.28",
+ "url",
 ]
 
 [[package]]
@@ -9923,20 +9982,18 @@ dependencies = [
 [[package]]
 name = "ytmusic"
 version = "0.1.0"
-source = "git+https://github.com/sonorahq/ytmusic-rs?rev=a6d2a734039e5b61f9360bf8639c327e094ee84e#a6d2a734039e5b61f9360bf8639c327e094ee84e"
+source = "git+https://github.com/sonorahq/ytmusic-rs?rev=8ba7da6b313b9683b5bbe7eb9773cfcf5586604a#8ba7da6b313b9683b5bbe7eb9773cfcf5586604a"
 dependencies = [
- "aes",
  "anyhow",
  "async-trait",
  "base64",
- "cbc",
+ "cookie_store",
  "log",
- "pbkdf2",
  "rand 0.9.5",
  "regex-lite",
  "reqwest 0.12.28",
+ "reqwest_cookie_store",
  "rquickjs",
- "rusqlite",
  "serde",
  "serde_json",
  "sha1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ symphonia = { version = "0.5.5", default-features = false, features = ["mkv", "o
 tray-icon = { version = "0.24", default-features = false }
 unic-langid = { version = "0.9", features = ["macros"] }
 unicode-segmentation = "1.12"
-ytmusic = { git = "https://github.com/sonorahq/ytmusic-rs", rev = "a6d2a734039e5b61f9360bf8639c327e094ee84e" }
+ytmusic = { git = "https://github.com/sonorahq/ytmusic-rs", rev = "8ba7da6b313b9683b5bbe7eb9773cfcf5586604a" }
 
 librespot-core = { version = "0.8.0", default-features = false, features = [
   "rustls-tls-native-roots",

--- a/crates/music/src/subsonic/client.rs
+++ b/crates/music/src/subsonic/client.rs
@@ -546,7 +546,11 @@ impl MusicApi for SubsonicClient {
         if playlist.cover.is_none() {
             playlist.cover = tracks.iter().find_map(|track| track.cover.clone());
         }
-        Ok(PlaylistDetail { playlist, tracks })
+        Ok(PlaylistDetail {
+            playlist,
+            tracks,
+            continuation: None,
+        })
     }
 
     async fn playlist_tracks(&self, playlist_id: &str) -> Result<Vec<Track>> {

--- a/crates/music/src/youtube/mod.rs
+++ b/crates/music/src/youtube/mod.rs
@@ -73,7 +73,7 @@ impl YouTubeProvider {
         Arc::new(
             YtMusic::with_cookies(cookies)
                 .as_user(authuser)
-                .persist_to(self.cookies.clone())
+                .persist_cookies(self.cookies.clone())
                 .cache_resolutions(self.resolved.clone())
                 .cache_player(self.player.clone()),
         )


### PR DESCRIPTION
## Summary

- point ytmusic at a revision on its own main line, which drops the browser cookie import instead of half-removing its helpers
- call persist_cookies for the youtube cookie store, the name that revision uses
- give a subsonic playlist detail the continuation field every other provider already fills