### PR TITLE
feat(music): support youtube brand accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9982,7 +9982,7 @@ dependencies = [
 [[package]]
 name = "ytmusic"
 version = "0.1.0"
-source = "git+https://github.com/sonorahq/ytmusic-rs?rev=8ba7da6b313b9683b5bbe7eb9773cfcf5586604a#8ba7da6b313b9683b5bbe7eb9773cfcf5586604a"
+source = "git+https://github.com/sonorahq/ytmusic-rs?rev=e0a5174#e0a5174e20680374c2bfc771449516452b6ee18d"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ symphonia = { version = "0.5.5", default-features = false, features = ["mkv", "o
 tray-icon = { version = "0.24", default-features = false }
 unic-langid = { version = "0.9", features = ["macros"] }
 unicode-segmentation = "1.12"
-ytmusic = { git = "https://github.com/sonorahq/ytmusic-rs", rev = "8ba7da6b313b9683b5bbe7eb9773cfcf5586604a" }
+ytmusic = { git = "https://github.com/sonorahq/ytmusic-rs", rev = "e0a5174" }
 
 librespot-core = { version = "0.8.0", default-features = false, features = [
   "rustls-tls-native-roots",

--- a/crates/music/src/youtube/accounts.rs
+++ b/crates/music/src/youtube/accounts.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use ytmusic::{Profile, YtMusic};
+use ytmusic::{Identity, YtMusic};
 
 use crate::AccountChoice;
 
@@ -8,41 +8,50 @@ const LIMIT: usize = 8;
 
 pub struct Account {
     pub index: usize,
-    pub profile: Profile,
+    pub identity: Identity,
 }
 
 impl Account {
+    pub fn id(&self) -> String {
+        match &self.identity.page_id {
+            Some(page) => format!("{}:{page}", self.index),
+            None => self.index.to_string(),
+        }
+    }
+
     pub fn choice(&self) -> AccountChoice {
         AccountChoice {
-            id: self.index.to_string(),
-            name: self.profile.name.clone(),
-            detail: self.profile.email.clone(),
+            id: self.id(),
+            name: self.identity.profile.name.clone(),
+            detail: self.identity.profile.email.clone(),
         }
     }
 }
 
 pub async fn list(cookies: &str) -> Vec<Account> {
-    let mut found = Vec::new();
+    let mut found: Vec<Account> = Vec::new();
     let mut seen = HashSet::new();
     for index in 0..LIMIT {
-        let Ok(profile) = YtMusic::with_cookies(cookies)
+        let identities = match YtMusic::with_cookies(cookies)
             .as_user(index)
-            .profile()
+            .identities()
             .await
-        else {
-            break;
+        {
+            Ok(identities) => identities,
+            Err(error) => {
+                log::debug!("youtube: authuser {index} names no account: {error:#}");
+                break;
+            }
         };
-        if !seen.insert(identity(&profile)) {
+        let known = found.len();
+        for identity in identities {
+            if seen.insert(identity.key()) {
+                found.push(Account { index, identity });
+            }
+        }
+        if found.len() == known {
             break;
         }
-        found.push(Account { index, profile });
     }
     found
-}
-
-fn identity(profile: &Profile) -> String {
-    profile
-        .email
-        .clone()
-        .unwrap_or_else(|| profile.name.clone())
 }

--- a/crates/music/src/youtube/mod.rs
+++ b/crates/music/src/youtube/mod.rs
@@ -25,12 +25,15 @@ pub use client::YouTubeClient;
 
 const GUEST_ID: &str = "youtube-guest";
 
-/// What the credential file remembers between launches: a browser sign-in with the
-/// Google account index it belongs to, or the choice to listen as a guest.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 enum Saved {
-    Cookies { cookies: String, authuser: usize },
+    Cookies {
+        cookies: String,
+        authuser: usize,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        page_id: Option<String>,
+    },
     Guest,
 }
 
@@ -69,11 +72,14 @@ impl YouTubeProvider {
         }
     }
 
-    fn cookie_client(&self, cookies: &str, authuser: usize) -> Arc<YtMusic> {
+    fn cookie_client(&self, cookies: &str, authuser: usize, page_id: Option<&str>) -> Arc<YtMusic> {
+        let api = YtMusic::with_cookies(cookies).as_user(authuser);
+        let api = match page_id {
+            Some(page) => api.as_page(page),
+            None => api,
+        };
         Arc::new(
-            YtMusic::with_cookies(cookies)
-                .as_user(authuser)
-                .persist_cookies(self.cookies.clone())
+            api.persist_cookies(self.cookies.clone())
                 .cache_resolutions(self.resolved.clone())
                 .cache_player(self.player.clone()),
         )
@@ -124,30 +130,39 @@ impl YouTubeProvider {
             _ => pick(&found, prompt, input).await?,
         };
 
-        let profile = wire::profile(account.profile.clone());
+        let page_id = account.identity.page_id.clone();
+        let profile = wire::profile(account.identity.profile.clone());
         credentials::remove(&self.cookies);
-        let api = self.cookie_client(&cookies, account.index);
-        self.store_cookies(&cookies, account.index)?;
+        let api = self.cookie_client(&cookies, account.index, page_id.as_deref());
+        self.store_cookies(&cookies, account.index, page_id.clone())?;
         log::debug!(
-            "youtube: cookie sign-in succeeded for authuser {}",
+            "youtube: cookie sign-in succeeded for authuser {} page {page_id:?}",
             account.index
         );
         Ok(self.authenticated_session(api, profile))
     }
 
-    fn store_cookies(&self, cookies: &str, authuser: usize) -> Result<()> {
+    fn store_cookies(&self, cookies: &str, authuser: usize, page_id: Option<String>) -> Result<()> {
         self.save(&Saved::Cookies {
             cookies: cookies.to_owned(),
             authuser,
+            page_id,
         })
         .context("cannot store youtube cookies")
     }
 
-    async fn restore_cookies(&self, cookies: &str, authuser: usize) -> Option<ProviderSession> {
-        let api = self.cookie_client(cookies, authuser);
+    async fn restore_cookies(
+        &self,
+        cookies: &str,
+        authuser: usize,
+        page_id: Option<&str>,
+    ) -> Option<ProviderSession> {
+        let api = self.cookie_client(cookies, authuser, page_id);
         match api.profile().await {
             Ok(profile) => {
-                log::debug!("youtube: restored the session for authuser {authuser}");
+                log::debug!(
+                    "youtube: restored the session for authuser {authuser} page {page_id:?}"
+                );
                 Some(self.authenticated_session(api, wire::profile(profile)))
             }
             Err(error) => {
@@ -180,6 +195,7 @@ pub(crate) fn migrate() {
                     .ok()
                     .and_then(|stored| stored.trim().parse().ok())
                     .unwrap_or(0),
+                page_id: None,
             }),
             _ if guest.exists() => Some(Saved::Guest),
             _ => None,
@@ -212,7 +228,7 @@ async fn pick<'a>(
     let picked = input.recv().await.context("sign-in was cancelled")?;
     found
         .iter()
-        .find(|account| account.index.to_string() == picked.trim())
+        .find(|account| account.id() == picked.trim())
         .context("that account is no longer signed in")
 }
 
@@ -242,9 +258,13 @@ impl MusicProvider for YouTubeProvider {
 
     async fn restore(&self) -> Result<Option<ProviderSession>> {
         match self.saved() {
-            Some(Saved::Cookies { cookies, authuser }) => {
-                Ok(self.restore_cookies(&cookies, authuser).await)
-            }
+            Some(Saved::Cookies {
+                cookies,
+                authuser,
+                page_id,
+            }) => Ok(self
+                .restore_cookies(&cookies, authuser, page_id.as_deref())
+                .await),
             Some(Saved::Guest) => {
                 log::debug!("youtube: restoring guest session");
                 Ok(Some(self.guest_session(self.guest_client())))


### PR DESCRIPTION
## Summary

- list personal and brand identities during youtube sign-in
- persist the selected youtube page across sessions
- target the selected identity through the pinned ytmusic revision