### PR TITLE
feat(i18n): add turkish translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Sonora speaks Turkish. Pick Türkçe under Settings > General > Language, or leave the language
+  on System and it follows a Turkish desktop on its own.
+
 ## [0.33.0] - 2026-09-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -166,17 +166,18 @@ AI-assisted proofreading and translation of human-written text are permitted.
 
 | Language | Translated | Coverage |
 | --- | --- | --- |
-| English (`en-US`) | 545/545 | 100% |
-| Deutsch (`de`) | 531/545 | 97% |
-| Español (`es`) | 531/545 | 97% |
-| Français (`fr`) | 492/545 | 90% |
-| Italiano (`it`) | 489/545 | 90% |
-| Bahasa Indonesia (`id`) | 519/545 | 95% |
-| 日本語 (`ja`) | 502/545 | 92% |
-| Русский (`ru`) | 507/545 | 93% |
-| Українська (`uk`) | 507/545 | 93% |
-| Polski (`pl`) | 537/545 | 99% |
-| Português (Brasil) (`pt-BR`) | 508/545 | 93% |
+| English (`en-US`) | 547/547 | 100% |
+| Deutsch (`de`) | 531/547 | 97% |
+| Español (`es`) | 531/547 | 97% |
+| Français (`fr`) | 492/547 | 90% |
+| Italiano (`it`) | 489/547 | 89% |
+| Bahasa Indonesia (`id`) | 519/547 | 95% |
+| 日本語 (`ja`) | 502/547 | 92% |
+| Русский (`ru`) | 509/547 | 93% |
+| Українська (`uk`) | 509/547 | 93% |
+| Polski (`pl`) | 539/547 | 99% |
+| Português (Brasil) (`pt-BR`) | 508/547 | 93% |
+| Türkçe (`tr`) | 547/547 | 100% |
 
 <!-- i18n:end -->
 

--- a/assets/i18n/tr/main.ftl
+++ b/assets/i18n/tr/main.ftl
@@ -1,0 +1,652 @@
+# common
+common-on = Açık
+common-off = Kapalı
+common-left = Sol
+common-right = Sağ
+common-search = Ara
+common-unknown = Bilinmiyor
+common-not-provided = Belirtilmemiş
+common-not-available = Kullanılamıyor
+common-cancel = Vazgeç
+common-save = Kaydet
+common-delete = Sil
+common-play = Çal
+common-more = Daha fazla
+common-previous = Önceki
+common-next = Sonraki
+common-dismiss = Kapat
+common-clear = Temizle
+number-group = { "." }
+
+# navigation
+nav-history = Geçmiş
+nav-home = Ana sayfa
+nav-search = Ara
+nav-library = Kitaplığın
+nav-settings = Ayarlar
+nav-songs = Şarkılar
+nav-albums = Albümler
+nav-playlists = Çalma listeleri
+nav-artists = Sanatçılar
+nav-local = Yerel Müzik
+nav-back = Geri
+nav-forward = İleri
+nav-sidebar = Kenar çubuğunu aç veya kapat
+nav-sidebar-right = Şarkı sözlerini ve sırayı göster veya gizle
+nav-pinned = Sabitlenenler
+nav-unpin = Sabitlemeyi kaldır
+nav-pin-hint = Sabitlemek için buraya bırak
+library-liked-songs = Favoriler
+library-play-liked-songs = Çal
+library-no-songs = Henüz favori yok
+library-no-albums = Henüz kaydedilmiş albüm yok
+library-no-playlists = Henüz çalma listesi yok
+library-no-artists = Henüz favori sanatçı yok
+library-no-local-songs = İçe aktarılmış şarkı bulunamadı
+library-no-local-albums = İçe aktarılmış albüm bulunamadı
+library-no-local-artists = İçe aktarılmış sanatçı bulunamadı
+library-no-local-playlists = Henüz yerel çalma listesi yok
+library-no-catalog-songs = Şarkı bulunamadı
+library-no-catalog-albums = Albüm bulunamadı
+library-no-catalog-artists = Sanatçı bulunamadı
+library-no-matches = Eşleşme yok
+library-not-loaded = Kitaplığın yüklenemedi
+library-part-not-loaded = Kitaplığının bu bölümü yüklenemedi
+library-local-unconfigured = Yerel kitaplığını yapılandır
+
+# app menu
+app-refresh-library = Kitaplığı Yenile
+app-sign-out = Oturumu Kapat
+app-quit = Çık
+app-settings = Ayarlar…
+app-hide = Sonora'yı Gizle
+app-hide-others = Diğerlerini Gizle
+app-show-all = Tümünü Göster
+app-edit = Düzen
+app-cut = Kes
+app-copy = Kopyala
+app-paste = Yapıştır
+app-select-all = Tümünü Seç
+app-window = Pencere
+app-close-window = Pencereyi Kapat
+app-minimize = Simge Durumuna Küçült
+app-zoom = Yakınlaştır
+
+# tray menu
+tray-show = Sonora'yı Göster
+tray-play = Çal
+tray-pause = Duraklat
+
+# table columns
+column-played-at = Çalınma
+column-index = #
+column-title = Başlık
+column-artist = Sanatçı
+column-album = Albüm
+column-date-added = Eklenme tarihi
+column-added-by = Ekleyen
+column-modified = Değiştirilme
+column-length = Süre
+column-plays = Dinlenme
+column-name = Ad
+column-owner = Sahibi
+column-year = Yıl
+column-tracks = Parçalar
+
+# track menu
+menu-add-to-playlist = Çalma listesine ekle
+menu-add-tracks-to-playlist = { $count } parçayı çalma listesine ekle
+menu-new-playlist = Yeni çalma listesi
+menu-edit-tags = Etiketleri düzenle
+menu-no-playlists = Çalma listesi yok
+menu-add-to-library = Favorilere ekle
+menu-add-tracks-to-library = { $count } parçayı favorilere ekle
+menu-remove-from-library = Favorilerden çıkar
+menu-remove-tracks-from-library = { $count } parçayı favorilerden çıkar
+menu-remove-from-playlist = Çalma listesinden çıkar
+menu-remove-tracks-from-playlist = { $count } parçayı çalma listesinden çıkar
+menu-remove-from-history = Geçmişten kaldır
+menu-remove-tracks-from-history = { $count } parçayı geçmişten kaldır
+menu-play-next = Sıradaki olarak çal
+menu-play-tracks-next = { $count } parçayı sıradaki olarak çal
+menu-add-to-queue = Sıraya ekle
+menu-add-tracks-to-queue = { $count } parçayı sıraya ekle
+menu-song-radio = Şarkı radyosuna git
+menu-go-to-album = Albüme git
+menu-go-to-artist = Sanatçıya git
+menu-view-details = Ayrıntıları gör
+menu-copy-link = Bağlantıyı kopyala
+menu-cut = Kes
+menu-copy = Kopyala
+menu-paste = Yapıştır
+menu-select-all = Tümünü seç
+menu-remove-from-queue = Sıradan çıkar
+menu-open-playlist = Çalma listesini aç
+menu-play-playlist = Çalma listesini çal
+menu-rename-playlist = Çalma listesini yeniden adlandır
+menu-delete-playlist = Çalma listesini sil
+menu-add-playlist-to-library = Kitaplığa ekle
+menu-remove-playlist-from-library = Kitaplıktan çıkar
+menu-make-playlist-public = Herkese açık yap
+menu-make-playlist-private = Gizli yap
+menu-open-album = Albümü aç
+menu-play-album = Albümü çal
+menu-play-artist = Sanatçıyı çal
+
+# playlist editor
+playlist-name-placeholder = Çalma listesi adı
+playlist-create-title = Çalma listesi oluştur
+playlist-rename-title = Çalma listesini yeniden adlandır
+playlist-delete-title = Çalma listesini sil
+playlist-delete-confirm = “{ $name }” silinsin mi? Bu işlem geri alınamaz.
+playlist-again-title = Yeniden eklensin mi?
+playlist-again-confirm = Bu parça zaten “{ $name }” içinde. Bir kopya daha eklensin mi?
+playlist-again-add = Yeniden ekle
+
+# confirm
+confirm-remove-library-title = Kitaplıktan çıkar
+confirm-remove-playlist-title = Çalma listesinden çıkar
+confirm-remove-history-title = Geçmişten kaldır
+confirm-remove-songs =
+    { $count ->
+        [one] Bu şarkı kitaplığından çıkarılsın mı?
+       *[other] { $count } şarkı kitaplığından çıkarılsın mı?
+    }
+confirm-remove-playlist-songs =
+    { $count ->
+        [one] Bu şarkı çalma listesinden çıkarılsın mı?
+       *[other] { $count } şarkı çalma listesinden çıkarılsın mı?
+    }
+confirm-remove-history-songs =
+    { $count ->
+        [one] Bu şarkı dinleme geçmişinden kaldırılsın mı?
+       *[other] { $count } şarkı dinleme geçmişinden kaldırılsın mı?
+    }
+confirm-remove-albums =
+    { $count ->
+        [one] Bu albüm kitaplığından çıkarılsın mı?
+       *[other] { $count } albüm kitaplığından çıkarılsın mı?
+    }
+confirm-remove-artists =
+    { $count ->
+        [one] Bu sanatçı favorilerden çıkarılsın mı?
+       *[other] { $count } sanatçı favorilerden çıkarılsın mı?
+    }
+confirm-remove-playlists =
+    { $count ->
+        [one] Bu çalma listesi kitaplığından çıkarılsın mı?
+       *[other] { $count } çalma listesi kitaplığından çıkarılsın mı?
+    }
+
+# queue panel
+queue-title = Sıra
+queue-history = Geçmiş
+queue-now-playing = Şimdi çalıyor
+queue-from = Kaynak
+queue-up-next = Sırada
+queue-reset = Sıfırla
+queue-clear = Temizle
+queue-empty = Sıran boş
+queue-similar = Benzer parçalar
+queue-radio = Benzer parçaları kendiliğinden çal
+
+# player bar
+player-nothing-playing = Çalan bir şey yok
+player-percent = { $value }%
+player-shuffle = Karıştır
+player-repeat = Tekrarla
+player-repeat-all = Tümünü tekrarla
+player-repeat-one = Birini tekrarla
+player-mute = Sesi kapat
+player-unmute = Sesi aç
+player-previous = Önceki parça
+player-next = Sonraki parça
+player-fullscreen = Tam ekran
+player-fullscreen-leave = Tam ekrandan çık
+player-sleep = Uyku zamanlayıcısı
+player-sleep-off = Kapalı
+player-sleep-end-of-track = Parçanın sonunda
+player-sleep-minutes = { $count } dk
+fullscreen-artwork = Kapak
+
+# filters
+filter-history = Dinleme geçmişini süz
+history-empty = Çaldığın parçalar burada görünecek.
+history-not-loaded = Dinleme geçmişi yüklenemedi.
+history-clear = Geçmişi temizle
+history-clear-title = Dinleme geçmişini temizle
+history-clear-confirm = Bu cihazdaki her dinleme silinir. Bu işlem geri alınamaz.
+filter-library = Kitaplığını süz
+filter-album = Albüm parçalarını süz
+filter-reset = Süzgeçleri sıfırla
+filter-duration = Süre
+filter-year = Yıl
+filter-explicit = Yalnızca müstehcen
+filter-playable = Yalnızca çalınabilir
+filter-favorites = Yalnızca favoriler
+filter-owned = Senin
+
+# view
+view-list = Liste
+view-cards = Izgara
+
+# toolbar
+tool-columns = Sütunlar
+tool-sort = Sırala
+tool-filters = Süzgeçler
+
+# login
+login-signed-out = Müzik kitaplığını yüklemek için oturum aç
+login-restoring = Kayıtlı oturumun denetleniyor…
+login-authorizing = Tarayıcında izin verilmesi bekleniyor…
+login-signed-in = { $name } olarak oturum açıldı
+login-failed-title = Oturum açılamadı
+login-problem-region = Spotify, bulunduğun ülkeden oturum açılmasına izin vermiyor. Kendi ülkenden oturum aç ya da Spotify hesabındaki ülkeyi değiştir.
+login-problem-credentials = Kayıtlı Spotify oturumun artık geçerli değil. Sürdürmek için yeniden oturum aç.
+login-problem-network = Sonora, Spotify'a ulaşamadı. İnternet bağlantını denetleyip yeniden dene.
+login-problem-cancelled = Oturum açmayı onaylamadan tarayıcı sayfasını kapattın. Bitirmek için yeniden başla.
+login-problem-refused = Spotify oturum açma isteğini geri çevirdi. Biraz bekleyip yeniden dene.
+login-problem-premium = Sonora, Spotify Premium üzerinden yayın yapar ve bu hesapta Premium yok. Sürdürmek için Premium bir hesapla oturum aç.
+login-sign-in = { $provider } ile oturum aç
+login-connect-cookies = Çerezleri elle yapıştır
+login-use = { $provider } kullan
+login-guest-title = Konuk modu
+login-guest-use = Konuk modunu kullan
+login-guest-detail = Hesap olmadan gez ve çal. Kitaplığın, beğenilerin ve çalma listelerin erişim dışında kalır.
+login-usage-consent = Sonora'yı kaç kişinin kullandığını tahmin etmemize yardımcı ol.
+login-device-code = Bu kodu { $url } adresinde gir
+login-cookie-open = YouTube Music'i aç
+login-cookie-submit = Sürdür
+login-cookie-hint = Cookie istek başlığını buraya yapıştır
+login-cookie-step-1 = music.youtube.com adresini aç ve oturumunun açık olduğundan emin ol.
+login-cookie-step-2 = F12'ye bas, Network sekmesini aç ve sayfayı yeniden yükle.
+login-cookie-step-3 = "browse" ya da "next" adlı herhangi bir isteği seç.
+login-cookie-step-4 = Headers içinde Request Headers altındaki Cookie'yi bul, sağ tıklayıp değerini kopyala.
+login-cookie-step-note = SAPISID ve __Secure-3PAPISID dahil olmak üzere değerin tamamını yapıştırdığından emin ol.
+login-cookie-title = Oturum açmayı bitirmek için YouTube Music çerezlerini yapıştır
+login-server-title = Subsonic sunucuna bağlan
+login-server-detail = Herhangi bir Subsonic ya da OpenSubsonic sunucusunun (Navidrome, Airsonic, Gonic, …) adresini gir, sonra sunucu kullanıcı adın ve parolanla oturum aç. Oturum bu cihazda kalır.
+login-server-hint = https://muzik.ornek.com
+login-username-hint = Kullanıcı adı
+login-password-hint = Parola
+login-server-submit = Bağlan
+login-account-title = Bir hesap seç
+login-account-detail = Bu oturumda birden çok Google hesabı açık. Sonora'nın kullanacağı hesabı seç.
+
+# album and playlist pages
+detail-album = Albüm
+detail-playlist = Çalma listesi
+detail-play-album = Albümü çal
+detail-play-playlist = Çalma listesini çal
+
+# play button
+play-pause = Duraklat
+play-resume = Sürdür
+play-loading = Yükleniyor…
+play-shuffle = Karıştır
+
+# artist page
+artist-eyebrow = Sanatçı
+artist-monthly-listeners =
+    { $count ->
+       *[other] { $value } aylık dinleyici
+    }
+artist-play = Şimdi çal
+artist-popular = Popüler
+artist-popular-eyebrow = Bu sanatçıyı keşfet
+artist-popular-empty = Bu sanatçıdan çalınacak bir şey henüz yok
+artist-popular-more = Tümünü göster
+artist-popular-less = Daha az göster
+artist-releases = Yayınlar
+artist-releases-more = Tümünü göster
+artist-releases-less = Daha az göster
+artist-filter-all = Tümü
+artist-filter-albums = Albümler
+artist-filter-singles = Tekliler
+artist-filter-eps = EP'ler
+
+# user profile page
+user-eyebrow = Profil
+user-followers =
+    { $count ->
+       *[other] { $value } takipçi
+    }
+user-following =
+    { $count ->
+       *[other] { $value } takip ediliyor
+    }
+user-playlists = Herkese açık çalma listeleri
+user-playlists-empty = Henüz herkese açık çalma listesi yok
+
+# release kinds
+release-album = Albüm
+release-single = Tekli
+release-compilation = Derleme
+release-ep = EP
+release-audiobook = Sesli kitap
+release-podcast = Podcast
+release-meta = { $year } • { $kind }
+
+# home page
+home-quick-picks = Hızlı seçimler
+home-listen-again = Yeniden dinle
+home-quick-picks-eyebrow = Bir şarkıdan başla
+home-quick-picks-empty = Birkaç şarkı beğen, burada görünsünler
+
+# search page
+search-placeholder = Ne dinlemek istersin?
+search-browse = Tümüne göz at
+genre-empty = Burada henüz gösterilecek bir şey yok
+search-best-match = En iyi eşleşme
+search-no-matches = Eşleşme yok
+search-results = Sonuçlar
+search-songs = Şarkılar
+search-artists = Sanatçılar
+search-albums-playlists = Albümler ve çalma listeleri
+search-tag = { $kind } ·
+search-saved =
+    { $count ->
+       *[other] Kitaplıkta { $count } şarkı
+    }
+kind-song = Şarkı
+kind-artist = Sanatçı
+kind-album = Albüm
+kind-playlist = Çalma listesi
+
+# song page
+song-eyebrow = Şarkı
+song-play = Şarkıyı çal
+song-view-album = Albümü gör
+song-loading = Şarkı bilgileri yükleniyor…
+song-about = Bu şarkı hakkında
+song-album = Albüm
+song-released = Yayınlanma
+song-streams = Dinlenme
+song-position = Sıra
+song-label = Etiket
+song-popularity = Popülerlik
+song-popularity-value = { $value }%
+song-disc-track = Disk { $disc }, parça { $track }
+song-track = Parça { $track }
+song-credits = Katkıda bulunanlar
+song-performed-by = Seslendiren
+song-details = Türler ve ayrıntılar
+song-genres = Türler
+song-language = Dil
+song-content = İçerik
+song-explicit = Müstehcen
+song-clean = Temiz
+artist-about = Sanatçı hakkında
+artist-about-fallback = Sanatçının popüler şarkılarını ve yayınlarını keşfet.
+artist-about-open = Sanatçıya git
+song-copyright = © { $notice }
+
+# song languages
+language-ar = Arapça
+language-de = Almanca
+language-en = İngilizce
+language-es = İspanyolca
+language-fr = Fransızca
+language-hi = Hintçe
+language-it = İtalyanca
+language-ja = Japonca
+language-ko = Korece
+language-pt = Portekizce
+language-ru = Rusça
+language-tr = Türkçe
+language-uk = Ukraynaca
+language-zh = Çince
+language-zxx = Sözsüz
+
+# counts
+count-songs =
+    { $count ->
+       *[other] { $count } şarkı
+    }
+count-tracks =
+    { $count ->
+       *[other] { $count } parça
+    }
+
+# dates
+date-just-now = Az önce
+date-minute-ago = Bir dakika önce
+date-minutes-ago = { $count } dakika önce
+date-today = Bugün { $time }
+date-yesterday = Dün { $time }
+date-time = { $date }, { $time }
+date-full = { $day } { $month } { $year }
+month-1 = Oca
+month-2 = Şub
+month-3 = Mar
+month-4 = Nis
+month-5 = May
+month-6 = Haz
+month-7 = Tem
+month-8 = Ağu
+month-9 = Eyl
+month-10 = Eki
+month-11 = Kas
+month-12 = Ara
+
+# settings
+settings-tab-general = Genel
+settings-tab-appearance = Görünüm
+settings-tab-playback = Çalma
+settings-tab-privacy = Gizlilik
+settings-theme = Tema
+settings-theme-detail = Uygulamanın renk paletini seç
+settings-opacity = Saydamlık
+settings-opacity-detail = Uygulama arka planının saydamlığını ayarla
+settings-opacity-value = { $percent }%
+settings-theme-config = Yapılandırmayı aç
+settings-adaptive = Uyarlanabilir tema
+settings-adaptive-detail = Paleti, çalan albümün kapağıyla renklendir
+settings-visualizer = Görselleştirici
+settings-visualizer-detail = Tam ekran kapağın arkasında spektrum çubukları göster
+settings-icons = Simge paketi
+settings-icons-detail = Arayüzün kullandığı simge setini seç
+settings-motion = Hareketi azalt
+settings-motion-detail = Arayüz animasyonlarını ve geçişlerini atla
+settings-pace = Animasyon hızı
+settings-pace-detail = Arayüz animasyonlarının ne kadar hızlı oynatılacağı
+settings-saver = Pil tasarrufu
+settings-saver-detail = Sonora odakta değilken animasyonların kare hızını sınırla, sonraki açılıştan başlayarak uygulanır
+settings-corners = Köşeler
+settings-corners-detail = Yüzeylerin ve denetimlerin ne kadar yuvarlak olduğu
+settings-blur = Bulanıklık
+settings-blur-detail = Pencereyi bulanık bir masaüstünün üzerine çizer. %100'ün altında bir saydamlık gerekir
+settings-font = Yazı boyutu
+settings-font-detail = Temel metin boyutu, diğer her şey buna göre ölçeklenir
+settings-font-value = { $size } px
+settings-startup = Açılışta göster
+settings-startup-detail = Sonora'nın açılışta gösterdiği ekran
+settings-entries = Kenar çubuğu girdileri
+settings-entries-detail = Kenar çubuğunda listelenen bölümler
+settings-entries-pick = Girdileri seç
+settings-language = Dil
+settings-language-detail = Sonora'nın arayüz genelinde kullandığı dil
+settings-language-system = Sistem
+settings-language-search = Dil ara
+settings-language-none = Dil bulunamadı
+settings-typeface = Yazı tipi
+settings-typeface-detail = Sonora'nın arayüz genelinde kullandığı yazı tipi
+settings-typeface-system = Varsayılan
+settings-typeface-search = Yazı tipi ara
+settings-typeface-none = Yazı tipi bulunamadı
+settings-server-side-decorations = Sunucu taraflı süslemeler
+settings-server-side-decorations-detail = Başlık çubuğunu, kenarlığı ve gölgeyi bileşiklendirici çizsin
+settings-typeface-loading = Yükleniyor…
+settings-window-controls = Pencere denetimleri
+settings-window-controls-detail = Başlık çubuğuna küçült, büyüt ve kapat düğmelerini çiz
+settings-controls-side = Denetimlerin yönü
+settings-controls-side-detail = Denetimlerin başlık çubuğunun hangi ucunda duracağı
+settings-close-to-tray = Kapatınca çalmayı sürdür
+settings-close-to-tray-detail = Penceresi kapandıktan sonra Sonora'yı sistem tepsisinde tut ve çalmayı sürdür
+settings-normalisation = Ses düzeyini eşitle
+settings-normalisation-detail = Parçaları tutarlı bir ses düzeyinde tutar
+settings-gapless = Boşluksuz çalma
+settings-gapless-detail = Bir parçayı, albüm nasıl kurgulandıysa öyle, araya boşluk koymadan diğerine bağlar
+settings-sleep = Uyku zamanlayıcısı
+settings-sleep-detail = Belirlenen sürenin sonunda müziğin kendiliğinden durmasını sağlar, böylece seni uyutabilir
+settings-panel-lyrics-size = Şarkı sözü boyutu (panel)
+settings-panel-lyrics-size-detail = Yan paneldeki şarkı sözü metninin, temel yazı boyutuna eklenen boyutu
+settings-fullscreen-lyrics-size = Şarkı sözü boyutu (tam ekran)
+settings-fullscreen-lyrics-size-detail = Tam ekran oynatıcıdaki şarkı sözü metninin, temel yazı boyutuna eklenen boyutu
+settings-lyrics-size-value = { $size }%
+settings-lyrics-for-local-files = Yerel dosyalar için şarkı sözleri
+settings-lyrics-for-local-files-detail = Şarkı sözlerini internetten getirmek için yerel dosyaların üstverisini kullan
+settings-karaoke-lyrics = Karaoke şarkı sözleri
+settings-karaoke-lyrics-detail = Zamanlama varsa şarkı sözlerini sözcük sözcük vurgula
+settings-blur-lyrics = Etkin olmayan sözleri bulanıklaştır
+settings-blur-lyrics-detail = Şarkı sözü panelinde gelecek ve geçmiş satırları bulanıklaştır
+settings-romanized-lyrics = Latin harfli şarkı sözleri
+settings-romanized-lyrics-detail = Seçilen yazı sistemleri için yerel olarak üretilen okunuşu göster
+settings-romanization-writing-systems = Yazı sistemleri
+settings-romanization-japanese = Japonca
+settings-romanization-chinese = Çince
+settings-romanization-korean = Korece
+settings-romanization-cyrillic = Kiril
+settings-romanization-greek = Yunan
+settings-romanization-arabic = Arap
+settings-romanization-other = Diğer yazı sistemleri
+settings-advanced = Gelişmiş
+settings-group-window = Pencere
+settings-group-accounts = Hesaplar
+settings-group-library = Kitaplık
+settings-group-text = Metin
+settings-group-motion = Hareket
+settings-group-title-bar = Başlık çubuğu
+settings-group-window-style = Pencere biçemi
+settings-group-lyrics = Şarkı sözleri
+settings-group-project = Proje
+settings-adaptive-menu = Uyarlanabilir bağlam menüsü
+settings-adaptive-menu-detail = Satırın zaten gösterdiği albüm ya da sanatçı gibi girdileri dışarıda bırakır
+settings-accounts = Hesapları yönet
+settings-accounts-detail = Bu cihazın çalabileceği servisler
+settings-provider-none = Bağlı değil
+settings-provider-connected = Bağlı
+settings-provider-current = Bu servisten çalıyor
+settings-provider-guest = Konuk olarak çalıyor
+settings-provider-switch = Şuna geç
+settings-sign-out = Oturumu kapat
+settings-local-folder = Müzik klasörleri
+settings-local-folder-empty = Yapılandırılmadı
+settings-choose-folder = Klasör seç…
+settings-add-folder = Klasör ekle
+settings-remove-folder = Klasörü kaldır
+settings-rescan = Yeniden tara
+settings-tab-about = Hakkında
+settings-version = Sürüm
+settings-version-detail = Çalıştırdığın sonora yapısı
+settings-license = Lisans
+settings-license-detail = GNU Genel Kamu Lisansı sürüm 3 ya da sonrası
+settings-license-view = Lisansı oku
+settings-source = Kaynak kodu
+settings-source-detail = Bu yapıya karşılık gelen kaynak
+settings-source-view = Depoyu aç
+settings-team = Ekip
+settings-team-github = GitHub
+settings-role-lead-maintainer = Baş Bakımcı
+settings-role-maintainer = Bakımcı
+settings-role-contributor = Katkıda Bulunan
+settings-notice = Copyright © 2026 Sonora Contributors. Sonora kesinlikle hiçbir garanti vermez. Bu özgür bir yazılımdır ve GNU Genel Kamu Lisansı sürüm 3 ya da sonrasının koşulları altında yeniden dağıtabilirsin. Sonora resmi değildir ve Spotify AB ile bağlantısı yoktur.
+
+# themes
+theme-system = Sistem
+theme-dark = Koyu
+theme-light = Açık
+theme-midnight = Gece yarısı
+theme-forest = Orman
+theme-ocean = Okyanus
+theme-rose = Gül
+theme-lavender = Lavanta
+theme-amber = Kehribar
+
+# corners
+corners-square = Köşeli
+corners-subtle = Hafif
+corners-rounded = Yuvarlatılmış
+corners-round = Yuvarlak
+
+# motion
+motion-system = Sistem
+motion-always = Her zaman
+motion-never = Asla
+pace-slow = Yavaş
+pace-base = Standart
+pace-quick = Hızlı
+saver-off = Kapalı
+saver-light = Hafif ({ $fps } FPS)
+saver-medium = Orta ({ $fps } FPS)
+saver-strong = Güçlü ({ $fps } FPS)
+
+toast-playlist-created = Çalma listesi oluşturuldu
+toast-playlist-renamed = Çalma listesi yeniden adlandırıldı
+toast-playlist-deleted = Çalma listesi silindi
+toast-playlist-added = Çalma listesi kitaplığına eklendi
+toast-playlist-removed = Çalma listesi kitaplığından çıkarıldı
+toast-playlist-visibility = Çalma listesinin görünürlüğü değişti
+toast-track-added = { $name } listesine eklendi
+toast-track-removed = { $name } listesinden çıkarıldı
+toast-playlist-failed = Bu değişiklik kaydedilemedi
+toast-playlist-busy = Başka bir değişiklik hâlâ sürüyor
+toast-playlist-signed-out = Çalma listelerini değiştirmek için oturum aç
+toast-queued-track = { $name } sıraya eklendi
+toast-next-track = Sırada { $name } çalacak
+toast-queued-album = Albüm sıraya eklendi
+toast-next-album = Sırada albüm çalacak
+toast-queued-playlist = Çalma listesi sıraya eklendi
+toast-next-playlist = Sırada çalma listesi çalacak
+toast-queued-artist = Sanatçı sıraya eklendi
+toast-next-artist = Sırada sanatçı çalacak
+toast-queue-failed = Bu, sıraya eklenemedi
+toast-keys-refused = Spotify bu hesaba çalma anahtarları vermiyor
+toast-sign-in-to-play = { $name } yalnızca oturum açmış dinleyicilere yayınlanır
+toast-track-unplayable = { $name } çalınamadı
+toast-library-add-failed = { $name } kitaplığına eklenemedi
+toast-library-remove-failed = { $name } kitaplığından çıkarılamadı
+
+# lyrics
+lyrics-title = Şarkı sözleri
+lyrics-idle = Sözlerini görmek için bir şey çal
+lyrics-loading = Şarkı sözleri aranıyor…
+lyrics-missing = Şarkı sözü bulunamadı, üzgünüz!
+lyrics-instrumental = Bu şarkı enstrümantal
+lyrics-failed = Şarkı sözü servisine ulaşılamadı
+lyrics-follow = Şarkıyı yeniden takip et
+lyrics-source = Şarkı sözleri kaynağı: { $source }
+lyrics-writers = Yazan: { $writers }
+
+update-available = Sonora { $version } çıktı
+update-detail = { $running } sürümünü kullanıyorsun. Nelerin değiştiğini oku ya da şimdi güncelle.
+update-detail-notes = { $running } sürümünü kullanıyorsun. Nelerin değiştiğini oku, sonra Sonora'yı kurduğun yoldan güncelle.
+update-notes = Yenilikler
+update-now = Güncelle
+update-later = Daha sonra
+update-working = Güncelleme indiriliyor…
+update-failed = Güncelleme kurulamadı. Yayınlar sayfasından yeniden dene.
+settings-check-updates = Güncellemeleri denetle
+settings-check-updates-detail = Açılışta GitHub'a bir kez daha yeni bir sürüm çıktı mı diye sor. Sonora güncellemeyi yalnızca Windows'ta kendi kurar; diğer yerlerde nelerin değiştiğini gösterir
+
+# tags
+tags-edit-title = Etiketleri düzenle
+tags-sheet-song = Şarkı
+tags-sheet-album = Albüm
+tags-sheet-details = Ayrıntılar
+tags-title = Başlık
+tags-artist = Sanatçı
+tags-track = Parça numarası
+tags-track-total = Yayındaki parça sayısı
+tags-disc = Disk numarası
+tags-disc-total = Yayındaki disk sayısı
+tags-album = Albüm
+tags-album-artist = Albüm sanatçısı
+tags-year = Yıl
+tags-genre = Tür
+tags-composer = Besteci
+tags-publisher = Yayıncı
+tags-isrc = ISRC
+tags-comment = Yorum
+toast-tags-saved = { $name } için etiketler kaydedildi
+toast-tags-failed = Etiketler kaydedilemedi

--- a/crates/i18n/src/language.rs
+++ b/crates/i18n/src/language.rs
@@ -16,10 +16,11 @@ pub enum Language {
     Ukrainian,
     Polish,
     PortugueseBrazilian,
+    Turkish,
 }
 
 impl Language {
-    pub const ALL: [Self; 11] = [
+    pub const ALL: [Self; 12] = [
         Self::English,
         Self::German,
         Self::Spanish,
@@ -31,6 +32,7 @@ impl Language {
         Self::Ukrainian,
         Self::Polish,
         Self::PortugueseBrazilian,
+        Self::Turkish,
     ];
 
     pub fn id(self) -> &'static str {
@@ -46,6 +48,7 @@ impl Language {
             Self::Ukrainian => "uk",
             Self::Polish => "pl",
             Self::PortugueseBrazilian => "pt-BR",
+            Self::Turkish => "tr",
         }
     }
 
@@ -62,6 +65,7 @@ impl Language {
             Self::Ukrainian => "Українська",
             Self::Polish => "Polski",
             Self::PortugueseBrazilian => "Português (Brasil)",
+            Self::Turkish => "Türkçe",
         }
     }
 
@@ -94,6 +98,7 @@ impl Language {
             Self::Ukrainian => langid!("uk"),
             Self::Polish => langid!("pl"),
             Self::PortugueseBrazilian => langid!("pt-BR"),
+            Self::Turkish => langid!("tr"),
         }
     }
 
@@ -110,6 +115,7 @@ impl Language {
             Self::Ukrainian => include_str!("../../../assets/i18n/uk/main.ftl"),
             Self::Polish => include_str!("../../../assets/i18n/pl/main.ftl"),
             Self::PortugueseBrazilian => include_str!("../../../assets/i18n/pt-BR/main.ftl"),
+            Self::Turkish => include_str!("../../../assets/i18n/tr/main.ftl"),
         }
     }
 }


### PR DESCRIPTION
## Summary

- add a full turkish translation, all 547 keys
- list türkçe in the language picker and follow a turkish desktop when the language is on system
- refresh the i18n coverage table in the readme
