### PR TITLE
fix(state): reload at the seek target on a false end-of-track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Seeking no longer occasionally restarts playback from 0:00. A decoder hiccup right after a seek
+  could be mistaken for the track ending, which under "loop current song" reloaded it from the
+  start instead of landing on the clicked position.
+
 ## [0.33.0] - 2026-09-09
 
 ### Added

--- a/crates/state/src/playback.rs
+++ b/crates/state/src/playback.rs
@@ -87,6 +87,9 @@ const STALE_POSITIONS: u8 = 2;
 /// settles on the packet holding the target, a few tens of milliseconds early at most; showing
 /// the target keeps a lyric clicked at its first word on that line, not the one before.
 const SEEK_SNAP: Duration = Duration::from_millis(100);
+/// How close a seek target may sit to a track's end for a following `Ended` to still count as
+/// that track genuinely finishing, rather than the seek itself surfacing as a false end.
+const END_GRACE: Duration = Duration::from_secs(2);
 const PRELOAD_BEFORE_END: Duration = Duration::from_secs(10);
 const SKIP_DEBOUNCE: Duration = Duration::from_millis(250);
 const RESTART_WINDOW: Duration = Duration::from_secs(3);
@@ -1736,6 +1739,10 @@ impl Playback {
         {
             return;
         }
+        // A seek can surface as a spurious `Ended` on some engines: a decode hiccup right after
+        // landing is indistinguishable, by the time it reaches us, from the track truly
+        // finishing. Remember the pending target so the `Ended` arm below can tell the two apart.
+        let interrupted_seek = self.seek_in_flight;
         match event {
             // A Loading with the current id is the engine restarting the load at a seek
             // target, so a seek queued behind it must survive.
@@ -1824,6 +1831,17 @@ impl Playback {
                 }
             }
             BackendEvent::Ended { .. } => {
+                if let Some(target) = interrupted_seek
+                    && let Some(track) = self.track.clone()
+                    && track.duration.saturating_sub(target) >= END_GRACE
+                {
+                    log::warn!(
+                        "playback: a seek to {target:?} surfaced as an end-of-track well before \
+                         the track ended, reloading instead of restarting"
+                    );
+                    self.load_from(&track, target, Start::Segue, cx);
+                    return;
+                }
                 let ended = self.track.take();
                 self.state = PlaybackState::Idle;
                 self.position = Duration::ZERO;


### PR DESCRIPTION
## Summary

- reload at the seek target instead of restarting from 0:00 when a seek surfaces as a false end-of-track (fixes #527)
