### PR TITLE
fix(ui): defer a submenu above the rows below it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Sonora speaks Turkish. Pick Türkçe under Settings > General > Language, or leave the language
   on System and it follows a Turkish desktop on its own.
 
+### Fixed
+
+- A submenu (Add to playlist, Go to artist) no longer gets drawn over by the menu rows below it.
+
 ## [0.33.0] - 2026-09-09
 
 ### Added

--- a/crates/ui/src/menu.rs
+++ b/crates/ui/src/menu.rs
@@ -554,7 +554,7 @@ impl RenderOnce for Menu {
                         false => this,
                         true => this.child({
                             let flip_left = submenu.state.flipped(viewport_width);
-                            div()
+                            let popup = div()
                                 .absolute()
                                 .top(SUBMENU_TOP)
                                 .w(px(0.))
@@ -592,7 +592,14 @@ impl RenderOnce for Menu {
                                                 })
                                                 .child(submenu.menu.inline().relative()),
                                         ),
-                                )
+                                );
+                            // A plain nested child still paints in document order, so a later
+                            // sibling row would be drawn over this popup. Deferring it, one
+                            // priority above the parent, keeps it above every row regardless of
+                            // which one it hangs off.
+                            deferred(popup)
+                                .with_priority(priority + 1)
+                                .into_any_element()
                         }),
                     }
                 })


### PR DESCRIPTION
## Summary

- defer a submenu popup above the rows below it instead of letting them paint over it (fixes #322)

<img width="426" height="579" alt="image" src="https://github.com/user-attachments/assets/3eff5731-a857-42fb-ab52-601dc60375c4" />
