### PR TITLE
feat(local): cache scanned track metadata to skip rescanning unchanged files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Sonora speaks Turkish. Pick Türkçe under Settings > General > Language, or leave the language
   on System and it follows a Turkish desktop on its own.
 
+### Changed
+
+- Local Music remembers what it read from each file's tags, so reopening the app rescans only
+  what changed on disk instead of reopening and re-decoding every track again from scratch.
+
 ## [0.33.0] - 2026-09-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Local Music remembers what it read from each file's tags, so reopening the app rescans only
   what changed on disk instead of reopening and re-decoding every track again from scratch.
+- Local Music shows what was there last time immediately on startup, and updates it once the
+  folders are checked against disk in the background, instead of waiting on that check first.
 
 ## [0.33.0] - 2026-09-09
 

--- a/crates/music/src/lib.rs
+++ b/crates/music/src/lib.rs
@@ -369,6 +369,16 @@ pub trait MusicProvider: Send + Sync {
         None
     }
     async fn restore(&self) -> Result<Option<ProviderSession>>;
+
+    /// A near-instant session built purely from what was cached last time for a provider whose
+    /// library lives at `paths`, with no network or filesystem access — so it may be stale
+    /// until a real [`Self::restore`]/[`Self::sign_in`] reconciles it. Local Files is the only
+    /// provider that overrides this; every other provider restores from stored credentials
+    /// instead, which [`Self::restore`] already covers.
+    fn restore_cached(&self, _paths: &[PathBuf]) -> Option<ProviderSession> {
+        None
+    }
+
     async fn sign_in(
         &self,
         method: SignIn,

--- a/crates/music/src/local/mod.rs
+++ b/crates/music/src/local/mod.rs
@@ -38,12 +38,24 @@ impl LocalProvider {
         let scanned = tokio::task::spawn_blocking(move || scan::scan(&paths, &cache_dir, &cache))
             .await
             .context("local scan task panicked")?;
+        Ok(self.session_from(scanned))
+    }
 
+    /// A session built purely from what was cached for `paths` last time, with no filesystem
+    /// access at all — near-instant, though possibly stale until [`Self::scan_paths`]
+    /// reconciles it. `None` if nothing has been cached for these paths yet.
+    fn restore_paths(&self, paths: &[PathBuf]) -> Option<ProviderSession> {
+        let cache = Store::new(self.database.clone());
+        let scanned = scan::scan_cached(paths, &cache)?;
+        Some(self.session_from(scanned))
+    }
+
+    fn session_from(&self, scanned: scan::Scanned) -> ProviderSession {
         let api: Arc<dyn MusicApi> =
             Arc::new(client::LocalClient::new(scanned, self.database.clone()));
         let playback: Arc<dyn PlaybackFactory> = Arc::new(playback::Factory);
 
-        Ok(ProviderSession {
+        ProviderSession {
             profile: UserProfile {
                 id: "local".to_owned(),
                 display_name: "Local Files".to_owned(),
@@ -53,7 +65,7 @@ impl LocalProvider {
             shape: Shape::Catalog,
             authenticated: false,
             playcounts: false,
-        })
+        }
     }
 }
 
@@ -77,6 +89,10 @@ impl MusicProvider for LocalProvider {
 
     async fn restore(&self) -> Result<Option<ProviderSession>> {
         Ok(None)
+    }
+
+    fn restore_cached(&self, paths: &[PathBuf]) -> Option<ProviderSession> {
+        self.restore_paths(paths)
     }
 
     async fn sign_in(

--- a/crates/music/src/local/mod.rs
+++ b/crates/music/src/local/mod.rs
@@ -13,6 +13,7 @@ use anyhow::{Context as _, Result, anyhow};
 use async_trait::async_trait;
 use storage::Database;
 
+use self::store::Store;
 use crate::{
     InputSource, MusicApi, MusicProvider, PlaybackFactory, PromptSink, ProviderSession, Shape,
     SignIn, UserProfile,
@@ -33,7 +34,8 @@ impl LocalProvider {
 
     async fn scan_paths(&self, paths: Vec<PathBuf>) -> Result<ProviderSession> {
         let cache_dir = self.cache_dir.clone();
-        let scanned = tokio::task::spawn_blocking(move || scan::scan(&paths, &cache_dir))
+        let cache = Store::new(self.database.clone());
+        let scanned = tokio::task::spawn_blocking(move || scan::scan(&paths, &cache_dir, &cache))
             .await
             .context("local scan task panicked")?;
 

--- a/crates/music/src/local/scan.rs
+++ b/crates/music/src/local/scan.rs
@@ -85,6 +85,29 @@ pub fn scan(roots: &[PathBuf], cache_dir: &Path, cache: &Store) -> Scanned {
     scanned
 }
 
+/// Rebuilds the library purely from what [`scan`] cached last time, under any of `roots` — no
+/// filesystem access at all, so it's near-instant but may be stale until a real scan reconciles
+/// it. `None` if nothing has been cached for these roots yet. Artist portraits are left empty:
+/// finding them means walking every folder, which defeats the point of a fast path.
+pub fn scan_cached(roots: &[PathBuf], cache: &Store) -> Option<Scanned> {
+    let cached = cache.cached_tracks().ok()?;
+    let parsed: Vec<(Track, String)> = cached
+        .iter()
+        .filter(|(path, _)| roots.iter().any(|root| Path::new(path).starts_with(root)))
+        .map(|(path, cached)| wire::track_from_cache(Path::new(path), cached))
+        .collect();
+    if parsed.is_empty() {
+        return None;
+    }
+
+    let mut scanned = Scanned {
+        albums: group_albums(&parsed),
+        ..Scanned::default()
+    };
+    scanned.tracks = parsed.into_iter().map(|(track, _)| track).collect();
+    Some(scanned)
+}
+
 fn group_albums(parsed: &[(Track, String)]) -> Vec<Album> {
     let mut order: Vec<String> = Vec::new();
     let mut groups: HashMap<String, Vec<usize>> = HashMap::new();

--- a/crates/music/src/local/scan.rs
+++ b/crates/music/src/local/scan.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use crate::{Album, Track};
 
+use super::store::{CachedTrack, Store};
 use super::wire;
 
 const SEPARATORS: [char; 8] = ['-', '–', '—', '.', '_', '·', ':', ' '];
@@ -21,7 +22,10 @@ pub struct Scanned {
 /// Scans every root and merges the results into one library: tracks are collected from all
 /// roots before albums/artists are grouped, so the same artist or album spread across more
 /// than one folder still merges into a single entry, seamlessly.
-pub fn scan(roots: &[PathBuf], cache_dir: &Path) -> Scanned {
+///
+/// A file whose `modified_at` still matches `cache` is rebuilt from its cached fields instead of
+/// being reopened and re-decoded, which is what keeps a rescan of an unchanged library fast.
+pub fn scan(roots: &[PathBuf], cache_dir: &Path, cache: &Store) -> Scanned {
     let mut scanned = Scanned::default();
 
     let mut files = Vec::new();
@@ -31,9 +35,23 @@ pub fn scan(roots: &[PathBuf], cache_dir: &Path) -> Scanned {
         }
     }
 
+    let cached = cache.cached_tracks().unwrap_or_default();
+    let mut current: Vec<(String, CachedTrack)> = Vec::new();
+
     let parsed: Vec<(Track, String)> = files
         .into_iter()
         .filter_map(|path| {
+            let key = path.to_string_lossy().into_owned();
+            let modified_at = wire::modified_at(&path);
+
+            if let Some(modified_at) = modified_at
+                && let Some(hit) = cached.get(&key)
+                && hit.modified_at == modified_at
+            {
+                current.push((key, hit.clone()));
+                return Some(wire::track_from_cache(&path, hit));
+            }
+
             let artist_hint = path
                 .parent()
                 .and_then(Path::parent)
@@ -44,14 +62,22 @@ pub fn scan(roots: &[PathBuf], cache_dir: &Path) -> Scanned {
                 .unwrap_or_default();
             let album_hint = (!album_hint.is_empty()).then_some(album_hint);
 
-            wire::track_from_file(
+            let parsed = wire::track_from_file(
                 &path,
                 artist_hint.as_deref(),
                 album_hint.as_deref(),
                 cache_dir,
-            )
+            )?;
+            if let Some(modified_at) = modified_at {
+                current.push((key, wire::cache_row(modified_at, &parsed.0, &parsed.1)));
+            }
+            Some(parsed)
         })
         .collect();
+
+    if let Err(error) = cache.set_cached_tracks(&current) {
+        log::warn!("local: cannot save the track cache: {error:#}");
+    }
 
     scanned.portraits = collect_portraits(roots, &parsed);
     scanned.albums = group_albums(&parsed);
@@ -232,9 +258,15 @@ mod tests {
     use super::*;
     use std::fs;
 
+    use storage::Database;
+
     fn touch(path: &Path) {
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         fs::write(path, []).unwrap();
+    }
+
+    fn cache(dir: &Path) -> Store {
+        Store::new(Database::at(dir.join("cache.sqlite")))
     }
 
     #[test]
@@ -242,7 +274,7 @@ mod tests {
         let dir = std::env::temp_dir().join("sonora-scan-test-ignore");
         let _ = fs::remove_dir_all(&dir);
         touch(&dir.join("notes.txt"));
-        let scanned = scan(&[dir.clone()], &dir);
+        let scanned = scan(&[dir.clone()], &dir, &cache(&dir));
         assert!(scanned.tracks.is_empty());
         fs::remove_dir_all(&dir).ok();
     }
@@ -251,7 +283,7 @@ mod tests {
     fn empty_root_yields_nothing() {
         let dir = std::env::temp_dir().join("sonora-scan-test-missing");
         let _ = fs::remove_dir_all(&dir);
-        let scanned = scan(&[dir.clone()], &dir);
+        let scanned = scan(&[dir.clone()], &dir, &cache(&dir));
         assert!(scanned.tracks.is_empty());
         assert!(scanned.albums.is_empty());
     }

--- a/crates/music/src/local/store.rs
+++ b/crates/music/src/local/store.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::{Context as _, Result};
 use rusqlite::{Connection, params};
 use storage::Database;
@@ -8,6 +10,21 @@ pub struct Stored {
     pub id: String,
     pub name: String,
     pub modified_at: i64,
+}
+
+/// A local track's tag-derived fields, cached so a rescan can skip reopening and re-decoding a
+/// file whose `modified_at` still matches.
+#[derive(Clone)]
+pub struct CachedTrack {
+    pub modified_at: i64,
+    pub name: String,
+    pub artist: String,
+    pub album: String,
+    pub album_artist: String,
+    pub cover: Option<String>,
+    pub duration_ms: i64,
+    pub track_number: u32,
+    pub disc_number: u32,
 }
 
 /// Which local favorites table a star lands in.
@@ -198,6 +215,77 @@ impl Store {
 
         rows.collect::<rusqlite::Result<Vec<_>>>()
             .context("cannot read a local playlist")
+    }
+
+    /// Every cached local track, keyed by its absolute path, for a scan to check its files
+    /// against before reopening and re-decoding any of them.
+    pub fn cached_tracks(&self) -> Result<HashMap<String, CachedTrack>> {
+        let connection = self.open()?;
+        let mut query = connection
+            .prepare(
+                "SELECT path, modified_at, name, artist, album, album_artist, cover,
+                        duration_ms, track_number, disc_number
+                 FROM local_tracks",
+            )
+            .context("cannot read the local track cache")?;
+        let rows = query
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    CachedTrack {
+                        modified_at: row.get(1)?,
+                        name: row.get(2)?,
+                        artist: row.get(3)?,
+                        album: row.get(4)?,
+                        album_artist: row.get(5)?,
+                        cover: row.get(6)?,
+                        duration_ms: row.get(7)?,
+                        track_number: row.get(8)?,
+                        disc_number: row.get(9)?,
+                    },
+                ))
+            })
+            .context("cannot read the local track cache")?;
+
+        rows.collect::<rusqlite::Result<_>>()
+            .context("cannot read the local track cache")
+    }
+
+    /// Replaces the whole local track cache with `rows`: a file missing from `rows` falls out
+    /// of the cache, which is how a track removed from disk stops being remembered.
+    pub fn set_cached_tracks(&self, rows: &[(String, CachedTrack)]) -> Result<()> {
+        let mut connection = self.open()?;
+        let transaction = connection
+            .transaction()
+            .context("cannot start a local track cache update")?;
+        transaction
+            .execute("DELETE FROM local_tracks", [])
+            .context("cannot clear the local track cache")?;
+        for (path, cached) in rows {
+            transaction
+                .execute(
+                    "INSERT INTO local_tracks
+                         (path, modified_at, name, artist, album, album_artist, cover,
+                          duration_ms, track_number, disc_number)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    params![
+                        path,
+                        cached.modified_at,
+                        cached.name,
+                        cached.artist,
+                        cached.album,
+                        cached.album_artist,
+                        cached.cover,
+                        cached.duration_ms,
+                        cached.track_number,
+                        cached.disc_number,
+                    ],
+                )
+                .context("cannot write the local track cache")?;
+        }
+        transaction
+            .commit()
+            .context("cannot save the local track cache")
     }
 }
 

--- a/crates/music/src/local/store.rs
+++ b/crates/music/src/local/store.rs
@@ -261,14 +261,19 @@ impl Store {
         transaction
             .execute("DELETE FROM local_tracks", [])
             .context("cannot clear the local track cache")?;
-        for (path, cached) in rows {
-            transaction
-                .execute(
+        {
+            // One statement reused for every row, rather than reparsed per insert.
+            let mut insert = transaction
+                .prepare(
                     "INSERT INTO local_tracks
                          (path, modified_at, name, artist, album, album_artist, cover,
                           duration_ms, track_number, disc_number)
                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    params![
+                )
+                .context("cannot prepare the local track cache write")?;
+            for (path, cached) in rows {
+                insert
+                    .execute(params![
                         path,
                         cached.modified_at,
                         cached.name,
@@ -279,9 +284,9 @@ impl Store {
                         cached.duration_ms,
                         cached.track_number,
                         cached.disc_number,
-                    ],
-                )
-                .context("cannot write the local track cache")?;
+                    ])
+                    .context("cannot write the local track cache")?;
+            }
         }
         transaction
             .commit()

--- a/crates/music/src/local/wire.rs
+++ b/crates/music/src/local/wire.rs
@@ -1,6 +1,7 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::Path;
+use std::time::Duration;
 
 use lofty::file::{AudioFile, TaggedFileExt};
 use lofty::picture::{MimeType, Picture, PictureType};
@@ -14,6 +15,7 @@ use symphonia::core::meta::{MetadataOptions, StandardTagKey};
 use symphonia::core::probe::Hint;
 
 use super::id3;
+use super::store::CachedTrack;
 use crate::{
     Album, ArtistRef, LOCAL_ALBUM_PREFIX, LOCAL_ARTIST_PREFIX, LOCAL_TRACK_PREFIX, ReleaseType,
     Track,
@@ -437,6 +439,53 @@ pub fn track_from_file(
         },
         album_artist,
     ))
+}
+
+/// The row to cache for a freshly parsed track, so a later scan of the same, unmodified file can
+/// skip [`track_from_file`] entirely.
+pub fn cache_row(modified_at: i64, track: &Track, album_artist: &str) -> CachedTrack {
+    CachedTrack {
+        modified_at,
+        name: track.name.clone(),
+        artist: track.artists.clone(),
+        album: track.album.clone(),
+        album_artist: album_artist.to_owned(),
+        cover: track.cover.clone(),
+        duration_ms: track.duration.as_millis().min(i64::MAX as u128) as i64,
+        track_number: track.track_number,
+        disc_number: track.disc_number,
+    }
+}
+
+/// Rebuilds a track straight from its cached fields, without reopening or re-decoding the file.
+pub fn track_from_cache(path: &Path, cached: &CachedTrack) -> (Track, String) {
+    let album_id =
+        (!cached.album.is_empty()).then(|| album_id(&cached.album_artist, &cached.album));
+
+    (
+        Track {
+            id: Some(track_id(path)),
+            name: cached.name.clone(),
+            playable: is_playable(path),
+            artists: cached.artist.clone(),
+            artist_refs: vec![artist_ref(&cached.artist)],
+            album: cached.album.clone(),
+            album_id,
+            cover: cached.cover.clone(),
+            duration: Duration::from_millis(cached.duration_ms.max(0) as u64),
+            added_at: modified_at(path),
+            added_by: None,
+            playcount: None,
+            popularity: 0,
+            explicit: false,
+            track_number: cached.track_number,
+            disc_number: cached.disc_number,
+            tags: Vec::new(),
+            languages: Vec::new(),
+            credits: Vec::new(),
+        },
+        cached.album_artist.clone(),
+    )
 }
 
 pub fn tag_year(path: &Path) -> Option<i32> {

--- a/crates/state/src/session.rs
+++ b/crates/state/src/session.rs
@@ -601,11 +601,39 @@ impl Session {
         cx.emit(SessionEvent::SignedOut);
     }
 
+    /// Shows the local library from what was cached last time, if anything, then verifies it
+    /// against disk in the background — a rescan of an unchanged library is cheap, but still
+    /// has to walk the filesystem, so the cached session covers the gap until it lands.
     fn restore_local(&mut self, cx: &mut Context<Self>) {
         if self.local_folders.is_empty() {
             return;
         }
-        self.rescan_local(cx);
+        let provider = self.local_provider.clone();
+        let folders = self.local_folders.clone();
+        let io = self.io.clone();
+        self.local_task = Some(cx.spawn(async move |this, cx| {
+            let quick = {
+                let provider = provider.clone();
+                let folders = folders.clone();
+                join(io.spawn(async move { Ok(provider.restore_cached(&folders)) })).await
+            };
+            if let Ok(Some(session)) = quick {
+                this.update(cx, |this, cx| this.local_signed_in(session, cx))
+                    .ok();
+            }
+
+            let prompt: PromptSink = Arc::new(|_| {});
+            let (_tx, rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+            let signed_in = join(
+                io.spawn(async move { provider.sign_in(SignIn::Path(folders), prompt, rx).await }),
+            )
+            .await;
+            this.update(cx, |this, cx| match signed_in {
+                Ok(session) => this.local_signed_in(session, cx),
+                Err(error) => log::warn!("session: cannot load local music: {error:#}"),
+            })
+            .ok();
+        }));
     }
 
     /// Adds a folder to the local library, then rescans every configured folder together so

--- a/crates/state/src/session.rs
+++ b/crates/state/src/session.rs
@@ -618,6 +618,7 @@ impl Session {
                 join(io.spawn(async move { Ok(provider.restore_cached(&folders)) })).await
             };
             if let Ok(Some(session)) = quick {
+                log::debug!("session: showing the local library from cache while it's verified");
                 this.update(cx, |this, cx| this.local_signed_in(session, cx))
                     .ok();
             }
@@ -629,7 +630,10 @@ impl Session {
             )
             .await;
             this.update(cx, |this, cx| match signed_in {
-                Ok(session) => this.local_signed_in(session, cx),
+                Ok(session) => {
+                    log::debug!("session: local library verified against disk");
+                    this.local_signed_in(session, cx);
+                }
                 Err(error) => log::warn!("session: cannot load local music: {error:#}"),
             })
             .ok();

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -56,6 +56,18 @@ const SCHEMA: &str = "
     CREATE TABLE IF NOT EXISTS favorite_artists (
         artist_id TEXT PRIMARY KEY,
         added_at INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS local_tracks (
+        path TEXT PRIMARY KEY,
+        modified_at INTEGER NOT NULL,
+        name TEXT NOT NULL,
+        artist TEXT NOT NULL,
+        album TEXT NOT NULL,
+        album_artist TEXT NOT NULL,
+        cover TEXT,
+        duration_ms INTEGER NOT NULL,
+        track_number INTEGER NOT NULL,
+        disc_number INTEGER NOT NULL
     );";
 
 #[derive(Clone)]


### PR DESCRIPTION
## Summary

- cache each local track's tag-derived fields (title, artist, album, cover, duration, track/disc number) keyed by file path and modified time
- reuse a cached row on rescan instead of reopening and re-decoding the file when its modified time hasn't changed
- drop a file's cache row automatically when it's no longer found on disk (fixes #342)
