### PR TITLE
fix(ui): input drag propagation

### DIFF
--- a/crates/ui/src/input/mod.rs
+++ b/crates/ui/src/input/mod.rs
@@ -482,11 +482,11 @@ impl Input {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        cx.stop_propagation();
+        self.focus(window, cx);
         if event.button == MouseButton::Right {
             self.context_menu = Some(event.position);
-            self.focus(window, cx);
             window.prevent_default();
-            cx.stop_propagation();
             cx.notify();
             return;
         }

--- a/crates/ui/src/menu.rs
+++ b/crates/ui/src/menu.rs
@@ -661,6 +661,10 @@ impl RenderOnce for Menu {
                 .min_w_0()
                 .min_h_0()
                 .gap_1()
+                .on_children_prepainted({
+                    let panel = panel.clone();
+                    move |bounds, _, _| panel.observe(bounds)
+                })
                 .child(div().w_full().py_1().child(header))
                 .child(body)
                 .into_any_element(),


### PR DESCRIPTION
## Summary

- keep title bar drag from hijacking text selection in search fields
- keep menus open when clicking their header, e. g. "Search a language"