### PR TITLE
fix(ui): draw a submenu above its menu and open it on the roomier side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The sleep timer lives under Settings > Playback. Turn it on there and a Configure button opens
   the slider; the moon button leaves the player bar.
 
+### Fixed
+
+- A submenu that has no room beside its menu opens over it instead of under its rows, on whichever
+  side has more room. The Add to playlist list in a narrow window no longer shows the context menu's
+  items through it.
+
 ## [0.33.0] - 2026-09-09
 
 ### Added

--- a/crates/ui/src/menu.rs
+++ b/crates/ui/src/menu.rs
@@ -134,6 +134,8 @@ impl SubmenuState {
         self.menu_bounds.set(Some(bounds));
     }
 
+    /// Whether the submenu opens to the left of its menu. Decided once from the panel width
+    /// measured last time it was open, or a guess before that; `measure_reach` corrects it.
     fn flipped(&self, viewport_width: Pixels) -> bool {
         if let Some(flip) = self.flip.get() {
             return flip;
@@ -146,18 +148,21 @@ impl SubmenuState {
             .get()
             .map(|bounds| bounds.size.width)
             .unwrap_or(SUBMENU_FALLBACK_WIDTH);
-        let flip = menu.right() + width + WINDOW_MARGIN > viewport_width;
+        let flip = flips(menu, width, viewport_width);
         self.flip.set(Some(flip));
         flip
     }
 
+    /// Re-decides the side once the submenu's real width is known, so a wrong guess flips it
+    /// and a submenu too wide for either side lands on the roomier one.
     fn measure_reach(&self, bounds: Bounds<Pixels>, window: &Window, cx: &mut App) {
-        if self.flip.get() == Some(true)
-            || bounds.right() + WINDOW_MARGIN <= window.viewport_size().width
-        {
+        let Some(menu) = self.menu_bounds.get() else {
+            return;
+        };
+        let flip = flips(menu, bounds.size.width, window.viewport_size().width);
+        if self.flip.replace(Some(flip)) == Some(flip) {
             return;
         }
-        self.flip.set(Some(true));
         cx.refresh_windows();
     }
 
@@ -554,7 +559,7 @@ impl RenderOnce for Menu {
                         false => this,
                         true => this.child({
                             let flip_left = submenu.state.flipped(viewport_width);
-                            div()
+                            let panel = div()
                                 .absolute()
                                 .top(SUBMENU_TOP)
                                 .w(px(0.))
@@ -592,7 +597,8 @@ impl RenderOnce for Menu {
                                                 })
                                                 .child(submenu.menu.inline().relative()),
                                         ),
-                                )
+                                );
+                            deferred(panel).with_priority(priority + 1)
                         }),
                     }
                 })
@@ -804,6 +810,18 @@ fn arm(close: Close, cx: &mut App) {
 
     let armed = cx.global::<Escape>().0.clone();
     *armed.borrow_mut() = Some(close);
+}
+
+/// Picks the side a submenu of `width` opens on: the right when it fits, else the left when
+/// that fits, else whichever side has more room and lets it overlap the menu.
+fn flips(menu: Bounds<Pixels>, width: Pixels, viewport_width: Pixels) -> bool {
+    let right = viewport_width - menu.right() - WINDOW_MARGIN;
+    let left = menu.left() - WINDOW_MARGIN;
+    match (right >= width, left >= width) {
+        (true, _) => false,
+        (false, true) => true,
+        (false, false) => left > right,
+    }
 }
 
 fn grown(bounds: Bounds<Pixels>, x: Pixels, y: Pixels) -> Bounds<Pixels> {


### PR DESCRIPTION
## Summary

- draw an open submenu above every row of its parent menu, so overlapping rows no longer show through it or take its hover
- open a submenu on the right when it fits, on the left when only the left fits, and on the roomier side when neither does
- re-decide the side from the submenu's real width once it is measured