### PR TITLE
feat(ui): follow system reduced-motion preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - The Motion setting's System option now follows the operating system's reduced-motion preference
-  on Linux, macOS and Windows, refreshing when Sonora comes back to the foreground.
+  on Linux, macOS and Windows, refreshing when Sonora comes back to the foreground. Older Linux
+  portals that do not expose the standardized setting safely keep normal animations.
 
 ## [0.34.1] - 2026-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- The Motion setting's System option now follows the operating system's reduced-motion preference
+  on Linux, macOS and Windows, refreshing when Sonora comes back to the foreground.
+
 ## [0.34.1] - 2026-09-11
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,9 @@ sonora → views → state → music
   and the models in its root; each provider lives in a submodule (`music::spotify`,
   `music::youtube`, `music::local`). `state` and `views` see only the root traits and models — never
   a provider module. Only `sonora/src/main.rs` names a concrete provider.
-- `ui` depends only on `gpui`, `serde` and `i18n`. It must never know about `music`, `state`, or
-  playback.
+- `ui` depends only on `gpui`, `serde` and `i18n`, plus the per-platform crates `ui::motion` needs
+  to read the system reduce-motion preference (`objc2-app-kit`, `windows-sys`, `ashpd`). It must
+  never know about `music`, `state`, or playback.
 - `music` must never depend on `gpui`. It is plain async Rust.
 - `storage` is a leaf shared by `state` and `music`; it owns the only state database path, schema,
   connection setup and legacy database migration.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8510,6 +8510,7 @@ dependencies = [
 name = "ui"
 version = "0.34.1"
 dependencies = [
+ "ashpd",
  "futures",
  "gpui",
  "gpui_platform",
@@ -8517,8 +8518,10 @@ dependencies = [
  "icons",
  "image",
  "log",
+ "objc2-app-kit 0.3.2",
  "serde",
  "unicode-segmentation",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,15 @@ objc2-web-kit = { version = "0.3", default-features = false, features = [
   "WKWebViewConfiguration",
   "WKWebsiteDataStore",
 ] }
-objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSApplication", "NSResponder", "NSRunningApplication"] }
+objc2-app-kit = { version = "0.3", default-features = false, features = [
+  "std",
+  "NSAccessibility",
+  "NSApplication",
+  "NSResponder",
+  "NSRunningApplication",
+  "NSWorkspace",
+] }
+ashpd = { version = "0.13", default-features = false, features = ["async-io", "settings"] }
 reqwest = { version = "0.13", default-features = false, features = [
   "blocking",
   "json",

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -14,5 +14,14 @@ log.workspace = true
 serde.workspace = true
 unicode-segmentation.workspace = true
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-app-kit.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows-sys.workspace = true
+
+[target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
+ashpd.workspace = true
+
 [dev-dependencies]
 gpui_platform.workspace = true

--- a/crates/ui/src/motion.rs
+++ b/crates/ui/src/motion.rs
@@ -291,11 +291,12 @@ impl Stillness {
         }
     }
 
-    pub fn still(self) -> bool {
+    /// Whether motion is reduced: `Some` for a hard choice, `None` when the system decides.
+    pub fn still(self) -> Option<bool> {
         match self {
-            Self::System => system_still(),
-            Self::Always => true,
-            Self::Never => false,
+            Self::System => None,
+            Self::Always => Some(true),
+            Self::Never => Some(false),
         }
     }
 }
@@ -329,7 +330,10 @@ pub fn apply(stillness: Stillness, pace: Pace, cx: &mut App) {
         },
         Ordering::Relaxed,
     );
-    cx.set_reduce_motion(stillness.still());
+    match stillness.still() {
+        Some(still) => cx.set_reduce_motion(still),
+        None => system::settle(cx),
+    }
 }
 
 pub fn animates(cx: &App) -> bool {
@@ -360,13 +364,80 @@ impl Movement {
     }
 }
 
-fn system_still() -> bool {
-    false
+/// The operating system's reduce-motion preference. Every probe answers
+/// through `App::set_reduce_motion`, which repaints on a change, late answer is harmless.
+mod system {
+    use gpui::App;
+
+    /// Reduce Motion under System Settings > Accessibility > Display.
+    #[cfg(target_os = "macos")]
+    pub(super) fn settle(cx: &mut App) {
+        use objc2_app_kit::NSWorkspace;
+
+        let still = NSWorkspace::sharedWorkspace().accessibilityDisplayShouldReduceMotion();
+        cx.set_reduce_motion(still);
+    }
+
+    /// "Animation effects" under Settings > Accessibility > Visual effects.
+    #[cfg(windows)]
+    pub(super) fn settle(cx: &mut App) {
+        use windows_sys::Win32::UI::WindowsAndMessaging::{
+            SPI_GETCLIENTAREAANIMATION, SystemParametersInfoW,
+        };
+
+        let mut animated: windows_sys::core::BOOL = 1;
+        // SAFETY: SPI_GETCLIENTAREAANIMATION writes one BOOL through pvparam, which is what
+        // `animated` is, and asks nothing else of the caller.
+        let answered = unsafe {
+            SystemParametersInfoW(SPI_GETCLIENTAREAANIMATION, 0, (&raw mut animated).cast(), 0)
+        };
+        cx.set_reduce_motion(answered != 0 && animated == 0);
+    }
+
+    /// Reads the standardized XDG reduced-motion preference.
+    ///
+    /// Requires a backend that supports `org.freedesktop.appearance.reduced-motion`;
+    /// older versions may not expose it.
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    pub(super) fn settle(cx: &mut App) {
+        use ashpd::desktop::settings::{ReducedMotion, Settings};
+        use gpui::AppContext as _;
+
+        cx.spawn(async move |cx| {
+            let still = cx
+                .background_spawn(async {
+                    let settings = Settings::new().await.ok()?;
+                    let reduced = settings.reduced_motion().await.ok()?;
+
+                    Some(reduced == ReducedMotion::ReducedMotion)
+                })
+                .await;
+            cx.update(|cx| cx.set_reduce_motion(still.unwrap_or(false)));
+        })
+        .detach();
+    }
+
+    #[cfg(not(any(
+        target_os = "macos",
+        windows,
+        target_os = "linux",
+        target_os = "freebsd"
+    )))]
+    pub(super) fn settle(cx: &mut App) {
+        cx.set_reduce_motion(false);
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn system_motion_leaves_the_preference_to_the_platform() {
+        assert_eq!(Stillness::System.still(), None);
+        assert_eq!(Stillness::Always.still(), Some(true));
+        assert_eq!(Stillness::Never.still(), Some(false));
+    }
 
     #[test]
     fn expo_easing_has_css_endpoints_and_shape() {

--- a/crates/ui/src/motion.rs
+++ b/crates/ui/src/motion.rs
@@ -400,8 +400,8 @@ mod system {
 
     /// Reads the standardized XDG reduced-motion preference.
     ///
-    /// Requires a backend that supports `org.freedesktop.appearance.reduced-motion`;
-    /// Older portals may not expose it; those failures leave animations enabled.
+    /// Older portals may not expose `org.freedesktop.appearance.reduced-motion`; that failure
+    /// leaves animations enabled.
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     pub(super) fn settle(cx: &mut App, generation: u64) {
         use ashpd::desktop::settings::{ReducedMotion, Settings};

--- a/crates/ui/src/motion.rs
+++ b/crates/ui/src/motion.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use gpui::{
@@ -322,6 +322,7 @@ impl<E: IntoElement + 'static> Motioned for E {
 }
 
 pub fn apply(stillness: Stillness, pace: Pace, cx: &mut App) {
+    let generation = APPLY_GENERATION.fetch_add(1, Ordering::SeqCst) + 1;
     PACE.store(
         match pace {
             Pace::Slow => 0,
@@ -332,7 +333,7 @@ pub fn apply(stillness: Stillness, pace: Pace, cx: &mut App) {
     );
     match stillness.still() {
         Some(still) => cx.set_reduce_motion(still),
-        None => system::settle(cx),
+        None => system::settle(cx, generation),
     }
 }
 
@@ -364,14 +365,17 @@ impl Movement {
     }
 }
 
-/// The operating system's reduce-motion preference. Every probe answers
-/// through `App::set_reduce_motion`, which repaints on a change, late answer is harmless.
+static APPLY_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+/// The operating system's reduce-motion preference. Every probe answers through
+/// `App::set_reduce_motion`, which repaints on a change. A generation check keeps a late probe
+/// from replacing a newer motion setting.
 mod system {
     use gpui::App;
 
     /// Reduce Motion under System Settings > Accessibility > Display.
     #[cfg(target_os = "macos")]
-    pub(super) fn settle(cx: &mut App) {
+    pub(super) fn settle(cx: &mut App, _generation: u64) {
         use objc2_app_kit::NSWorkspace;
 
         let still = NSWorkspace::sharedWorkspace().accessibilityDisplayShouldReduceMotion();
@@ -380,7 +384,7 @@ mod system {
 
     /// "Animation effects" under Settings > Accessibility > Visual effects.
     #[cfg(windows)]
-    pub(super) fn settle(cx: &mut App) {
+    pub(super) fn settle(cx: &mut App, _generation: u64) {
         use windows_sys::Win32::UI::WindowsAndMessaging::{
             SPI_GETCLIENTAREAANIMATION, SystemParametersInfoW,
         };
@@ -397,11 +401,14 @@ mod system {
     /// Reads the standardized XDG reduced-motion preference.
     ///
     /// Requires a backend that supports `org.freedesktop.appearance.reduced-motion`;
-    /// older versions may not expose it.
+    /// Older portals may not expose it; those failures leave animations enabled.
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-    pub(super) fn settle(cx: &mut App) {
+    pub(super) fn settle(cx: &mut App, generation: u64) {
         use ashpd::desktop::settings::{ReducedMotion, Settings};
         use gpui::AppContext as _;
+        use std::sync::atomic::Ordering;
+
+        use super::APPLY_GENERATION;
 
         cx.spawn(async move |cx| {
             let still = cx
@@ -412,7 +419,11 @@ mod system {
                     Some(reduced == ReducedMotion::ReducedMotion)
                 })
                 .await;
-            cx.update(|cx| cx.set_reduce_motion(still.unwrap_or(false)));
+            cx.update(|cx| {
+                if APPLY_GENERATION.load(Ordering::SeqCst) == generation {
+                    cx.set_reduce_motion(still.unwrap_or(false));
+                }
+            });
         })
         .detach();
     }
@@ -423,7 +434,7 @@ mod system {
         target_os = "linux",
         target_os = "freebsd"
     )))]
-    pub(super) fn settle(cx: &mut App) {
+    pub(super) fn settle(cx: &mut App, _generation: u64) {
         cx.set_reduce_motion(false);
     }
 }

--- a/crates/views/src/root.rs
+++ b/crates/views/src/root.rs
@@ -12,7 +12,7 @@ use state::{
 };
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use ui::WindowFrame;
-use ui::{ActiveTheme as _, Dismiss, Look, Theme, ThemeKind, clear_listing};
+use ui::{ActiveTheme as _, Dismiss, Look, Stillness, Theme, ThemeKind, clear_listing};
 
 use crate::chrome::{TitleBar, TitleBarEvent, TitleBarOptions, Toolbar, Tooled};
 use crate::screens::search::SearchView;
@@ -171,6 +171,24 @@ impl Root {
                 .shells
                 .workspace
                 .update(cx, |workspace, cx| workspace.toggle_sidebar_right(cx)),
+        })
+        .detach();
+
+        // The system reduce-motion preference has no change event here, so it is re-read each
+        // time the user comes back to the window, which is when they could have flipped it.
+        cx.observe_window_activation(window, |_, window, cx| {
+            if !window.is_window_active() {
+                return;
+            }
+            let settings = Sonora::global(cx).settings.clone();
+            let (stillness, pace) = {
+                let settings = settings.read(cx);
+                (settings.stillness(), settings.pace())
+            };
+            if stillness != Stillness::System {
+                return;
+            }
+            ui::motion::apply(stillness, pace, cx);
         })
         .detach();
 

--- a/crates/views/src/root.rs
+++ b/crates/views/src/root.rs
@@ -174,8 +174,9 @@ impl Root {
         })
         .detach();
 
-        // The system reduce-motion preference has no change event here, so it is re-read each
-        // time the user comes back to the window, which is when they could have flipped it.
+        // Re-read the system preference when the window becomes active instead of keeping a
+        // long-lived portal listener alive. This picks up changes after the user returns from
+        // the desktop accessibility settings.
         cx.observe_window_activation(window, |_, window, cx| {
             if !window.is_window_active() {
                 return;


### PR DESCRIPTION
## Summary

Adds support for Sonora's **Motion → System** option to follow the operating system's reduced-motion preference.

The detected preference is forwarded to GPUI's existing `set_reduce_motion` support, so existing Sonora animations that already respect GPUI reduced motion automatically follow the system setting.

## Platform behavior

* **Linux / FreeBSD:** reads the standardized `org.freedesktop.appearance.reduced-motion` setting through `ashpd`.
* **macOS:** reads `accessibilityDisplayShouldReduceMotion`.
* **Windows:** reads the system client-area animation preference using `SystemParametersInfoW`.

On Linux, the portal query is asynchronous. Older portal implementations that do not expose the standardized reduced-motion setting safely fall back to normal animations.

## Notes

This overlaps with the earlier work in #471. This PR targets the current `main` branch and includes Linux verification and protection against stale asynchronous preference updates.
