### PR TITLE
Feat/tray improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- The tray menu draws the cover of the playing track beside its name.
 - The sleep timer lives under Settings > Playback. Turn it on there and a Configure button opens
   the slider; the moon button leaves the player bar.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- The tray menu draws the cover of the playing track beside its name.
+- The tray menu draws the cover of the playing track beside its name, and clicking that row
+  opens the song page.
 - Hovering the tray icon names the playing track, the way it already did on Linux.
-- The track named at the top of the tray menu opens its song page, and its cover is no
-  longer greyed out.
 - The sleep timer lives under Settings > Playback. Turn it on there and a Configure button opens
   the slider; the moon button leaves the player bar.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - The tray menu draws the cover of the playing track beside its name.
 - Hovering the tray icon names the playing track, the way it already did on Linux.
+- The track named at the top of the tray menu opens its song page, and its cover is no
+  longer greyed out.
 - The sleep timer lives under Settings > Playback. Turn it on there and a Configure button opens
   the slider; the moon button leaves the player bar.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - The tray menu draws the cover of the playing track beside its name.
+- Hovering the tray icon names the playing track, the way it already did on Linux.
 - The sleep timer lives under Settings > Playback. Turn it on there and a Configure button opens
   the slider; the moon button leaves the player bar.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7238,6 +7238,7 @@ dependencies = [
  "dirs",
  "embed",
  "env_logger",
+ "futures",
  "gpui",
  "gpui_platform",
  "i18n",

--- a/crates/sonora/Cargo.toml
+++ b/crates/sonora/Cargo.toml
@@ -13,6 +13,7 @@ bundled-sqlite = ["state/bundled-sqlite"]
 anyhow.workspace = true
 dirs.workspace = true
 env_logger.workspace = true
+futures.workspace = true
 log.workspace = true
 gpui.workspace = true
 gpui_platform.workspace = true

--- a/crates/sonora/src/tray.rs
+++ b/crates/sonora/src/tray.rs
@@ -3,6 +3,11 @@ mod native;
 #[cfg(target_os = "linux")]
 mod sni;
 
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result, bail};
+use futures::AsyncReadExt as _;
+use gpui::http_client::{AsyncBody, HttpClient};
 use gpui::{App, AppContext as _, Context, Entity, Global, Task};
 use i18n::t;
 use state::{PlaybackState, Sonora};
@@ -13,6 +18,10 @@ use native::Icon;
 #[cfg(target_os = "linux")]
 use sni::Icon;
 
+/// The longest side of the cover handed to the menu. macOS draws it 18pt tall whatever it
+/// measures, Windows and the status notifier hosts draw it at its own size.
+const COVER: u32 = 32;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Event {
     Show,
@@ -22,8 +31,17 @@ pub enum Event {
     Quit,
 }
 
+/// The cover of the playing track, decoded and scaled for a menu row.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Art {
+    pub data: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Shown {
+    pub artwork: Option<Art>,
     pub caption: String,
     pub toggle: String,
     pub previous: String,
@@ -52,6 +70,10 @@ pub fn install(show: impl Fn(&mut App) + 'static, cx: &mut App) -> bool {
 pub struct Tray {
     icon: Icon,
     shown: Shown,
+    /// The cover the art below was loaded from, so a repeat of the same track loads nothing.
+    cover: Option<String>,
+    art: Option<Art>,
+    artwork: Option<Task<()>>,
     _events: Task<()>,
 }
 
@@ -86,26 +108,106 @@ impl Tray {
         cx.observe(&playback, |this, _, cx| this.publish(cx))
             .detach();
 
-        let shown = shown(cx);
+        let shown = shown(None, cx);
         icon.show(&shown);
-        Self {
+        let mut tray = Self {
             icon,
             shown,
+            cover: None,
+            art: None,
+            artwork: None,
             _events,
-        }
+        };
+        tray.follow(cx);
+        tray
     }
 
     fn publish(&mut self, cx: &mut Context<Self>) {
-        let shown = shown(cx);
+        self.follow(cx);
+        let shown = shown(self.art.clone(), cx);
         if shown == self.shown {
             return;
         }
         self.icon.show(&shown);
         self.shown = shown;
     }
+
+    /// Starts loading the cover of the track that is playing now. Dropping the task cancels the
+    /// load for the track that was playing before, so a run of skips only draws the last cover.
+    fn follow(&mut self, cx: &mut Context<Self>) {
+        let cover = Sonora::global(cx)
+            .playback
+            .read(cx)
+            .track()
+            .and_then(|track| track.cover.clone());
+        if cover == self.cover {
+            return;
+        }
+
+        self.cover = cover.clone();
+        self.art = None;
+        self.artwork = cover.map(|cover| self.load(cover, cx));
+    }
+
+    fn load(&self, cover: String, cx: &mut Context<Self>) -> Task<()> {
+        let http = cx.http_client();
+        cx.spawn(async move |this, cx| {
+            let art = match cx.background_spawn(art(cover, http)).await {
+                Ok(art) => art,
+                Err(error) => return log::warn!("tray: cannot draw the cover: {error:#}"),
+            };
+            this.update(cx, |this, cx| {
+                this.art = Some(art);
+                this.publish(cx);
+            })
+            .ok();
+        })
+    }
 }
 
-fn shown(cx: &App) -> Shown {
+/// Reads a cover, over http or from the disk, and scales it down to a menu row. An unreadable
+/// cover leaves the caption on its own rather than holding up the rest of the menu.
+async fn art(cover: String, http: Arc<dyn HttpClient>) -> Result<Art> {
+    let bytes = match cover.starts_with("http://") || cover.starts_with("https://") {
+        true => fetch(&http, &cover).await?,
+        false => {
+            let path = cover.strip_prefix("file://").unwrap_or(&cover);
+            std::fs::read(path).context("cannot read the cover")?
+        }
+    };
+    let image = image::load_from_memory(&bytes)
+        .context("cannot decode the cover")?
+        .thumbnail(COVER, COVER)
+        .into_rgba8();
+
+    let (width, height) = image.dimensions();
+    Ok(Art {
+        data: image.into_raw(),
+        width,
+        height,
+    })
+}
+
+async fn fetch(http: &Arc<dyn HttpClient>, url: &str) -> Result<Vec<u8>> {
+    let mut response = http
+        .get(url, AsyncBody::empty(), true)
+        .await
+        .context("cannot fetch the cover")?;
+    if !response.status().is_success() {
+        bail!("the cover request answered {}", response.status());
+    }
+
+    let mut bytes = Vec::new();
+    response
+        .body_mut()
+        .read_to_end(&mut bytes)
+        .await
+        .context("cannot read the cover")?;
+
+    Ok(bytes)
+}
+
+fn shown(artwork: Option<Art>, cx: &App) -> Shown {
     let playback = Sonora::global(cx).playback.read(cx);
     let playing = matches!(
         playback.state(),
@@ -116,6 +218,7 @@ fn shown(cx: &App) -> Shown {
         None => t!("player-nothing-playing").to_string(),
     };
     Shown {
+        artwork,
         caption,
         toggle: match playing {
             true => t!("tray-pause"),

--- a/crates/sonora/src/tray.rs
+++ b/crates/sonora/src/tray.rs
@@ -10,6 +10,7 @@ use futures::AsyncReadExt as _;
 use gpui::http_client::{AsyncBody, HttpClient};
 use gpui::{App, AppContext as _, Context, Entity, Global, Task};
 use i18n::t;
+use router::Destination;
 use state::{PlaybackState, Sonora};
 use tokio::sync::mpsc::{self, UnboundedReceiver};
 
@@ -25,6 +26,7 @@ const COVER: u32 = 32;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Event {
     Show,
+    Song,
     Toggle,
     Previous,
     Next,
@@ -43,6 +45,8 @@ pub struct Art {
 pub struct Shown {
     pub artwork: Option<Art>,
     pub caption: String,
+    /// Whether the caption opens anything, so a row that leads nowhere stays inert.
+    pub song: bool,
     pub toggle: String,
     pub previous: String,
     pub next: String,
@@ -91,6 +95,10 @@ impl Tray {
                 }
                 cx.update(|cx| match event {
                     Event::Show => show(cx),
+                    Event::Song => {
+                        show(cx);
+                        open(cx);
+                    }
                     Event::Quit => cx.quit(),
                     Event::Toggle | Event::Previous | Event::Next => {
                         let playback = Sonora::global(cx).playback.clone();
@@ -165,6 +173,16 @@ impl Tray {
     }
 }
 
+/// Opens the song page of whatever is playing. A track without an id is not an error: the caption
+/// row is only enabled when there is one.
+fn open(cx: &mut App) {
+    let playing = Sonora::global(cx).playback.read(cx).track();
+    let Some(id) = playing.and_then(|track| track.id.clone()) else {
+        return;
+    };
+    router::navigate(Destination::Song(id.into()), cx);
+}
+
 /// Reads a cover, over http or from the disk, and scales it down to a menu row. An unreadable
 /// cover leaves the caption on its own rather than holding up the rest of the menu.
 async fn art(cover: String, http: Arc<dyn HttpClient>) -> Result<Art> {
@@ -217,9 +235,11 @@ fn shown(artwork: Option<Art>, cx: &App) -> Shown {
         Some(track) => format!("{} – {}", track.artists, track.name),
         None => t!("player-nothing-playing").to_string(),
     };
+    let song = playback.track().is_some_and(|track| track.id.is_some());
     Shown {
         artwork,
         caption,
+        song,
         toggle: match playing {
             true => t!("tray-pause"),
             false => t!("tray-play"),

--- a/crates/sonora/src/tray/native.rs
+++ b/crates/sonora/src/tray/native.rs
@@ -1,8 +1,10 @@
 use tokio::sync::mpsc::UnboundedSender;
-use tray_icon::menu::{Menu, MenuEvent, MenuId, MenuItem, PredefinedMenuItem};
+use tray_icon::menu::{
+    Icon as MenuIcon, IconMenuItem, Menu, MenuEvent, MenuId, MenuItem, PredefinedMenuItem,
+};
 use tray_icon::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent};
 
-use super::{Event, Shown};
+use super::{Art, Event, Shown};
 
 const TOOLTIP: &str = "Sonora";
 const PNG: &[u8] = match cfg!(target_os = "macos") {
@@ -13,7 +15,7 @@ const MENU_ON_CLICK: bool = cfg!(target_os = "macos");
 
 pub struct Icon {
     _icon: TrayIcon,
-    caption: MenuItem,
+    caption: IconMenuItem,
     toggle: MenuItem,
     previous: MenuItem,
     next: MenuItem,
@@ -39,7 +41,7 @@ impl Icon {
             }
         };
 
-        let caption = MenuItem::with_id("caption", "", false, None);
+        let caption = IconMenuItem::with_id("caption", "", false, None, None);
         let toggle = MenuItem::with_id("toggle", "", true, None);
         let previous = MenuItem::with_id("previous", "", true, None);
         let next = MenuItem::with_id("next", "", true, None);
@@ -108,11 +110,24 @@ impl Icon {
 
     pub fn show(&mut self, shown: &Shown) {
         self.caption.set_text(&shown.caption);
+        self.caption.set_icon(cover(shown.artwork.as_ref()));
         self.toggle.set_text(&shown.toggle);
         self.previous.set_text(&shown.previous);
         self.next.set_text(&shown.next);
         self.show.set_text(&shown.show);
         self.quit.set_text(&shown.quit);
+    }
+}
+
+/// The cover as a menu icon. A cover that cannot be built is simply left off the row.
+fn cover(art: Option<&Art>) -> Option<MenuIcon> {
+    let art = art?;
+    match MenuIcon::from_rgba(art.data.clone(), art.width, art.height) {
+        Ok(icon) => Some(icon),
+        Err(error) => {
+            log::warn!("tray: cannot build the cover icon: {error:#}");
+            None
+        }
     }
 }
 

--- a/crates/sonora/src/tray/native.rs
+++ b/crates/sonora/src/tray/native.rs
@@ -14,7 +14,7 @@ const PNG: &[u8] = match cfg!(target_os = "macos") {
 const MENU_ON_CLICK: bool = cfg!(target_os = "macos");
 
 pub struct Icon {
-    _icon: TrayIcon,
+    icon: TrayIcon,
     caption: IconMenuItem,
     toggle: MenuItem,
     previous: MenuItem,
@@ -98,7 +98,7 @@ impl Icon {
         }));
 
         Some(Self {
-            _icon: icon,
+            icon,
             caption,
             toggle,
             previous,
@@ -109,6 +109,11 @@ impl Icon {
     }
 
     pub fn show(&mut self, shown: &Shown) {
+        // the status notifier hosts read the caption off the tooltip themselves; here it has to
+        // be pushed, or hovering the icon only ever says Sonora
+        if let Err(error) = self.icon.set_tooltip(Some(&shown.caption)) {
+            log::warn!("tray: cannot set the tooltip: {error:#}");
+        }
         self.caption.set_text(&shown.caption);
         self.caption.set_icon(cover(shown.artwork.as_ref()));
         self.toggle.set_text(&shown.toggle);

--- a/crates/sonora/src/tray/native.rs
+++ b/crates/sonora/src/tray/native.rs
@@ -116,6 +116,7 @@ impl Icon {
         }
         self.caption.set_text(&shown.caption);
         self.caption.set_icon(cover(shown.artwork.as_ref()));
+        self.caption.set_enabled(shown.song);
         self.toggle.set_text(&shown.toggle);
         self.previous.set_text(&shown.previous);
         self.next.set_text(&shown.next);
@@ -138,6 +139,7 @@ fn cover(art: Option<&Art>) -> Option<MenuIcon> {
 
 fn translate(id: &MenuId) -> Option<Event> {
     Some(match id.0.as_str() {
+        "caption" => Event::Song,
         "toggle" => Event::Toggle,
         "previous" => Event::Previous,
         "next" => Event::Next,

--- a/crates/sonora/src/tray/sni.rs
+++ b/crates/sonora/src/tray/sni.rs
@@ -130,7 +130,8 @@ impl ksni::Tray for Item {
             StandardItem {
                 label: shown.caption.clone(),
                 icon_data: cover(shown.artwork.as_ref()).unwrap_or_default(),
-                enabled: false,
+                enabled: shown.song,
+                activate: Box::new(|this: &mut Self| this.send(Event::Song)),
                 ..Default::default()
             }
             .into(),

--- a/crates/sonora/src/tray/sni.rs
+++ b/crates/sonora/src/tray/sni.rs
@@ -3,7 +3,7 @@ use ksni::menu::{MenuItem, StandardItem};
 use ksni::{Category, ToolTip};
 use tokio::sync::mpsc::UnboundedSender;
 
-use super::{Event, Shown};
+use super::{Art, Event, Shown};
 
 const ID: &str = "sonora";
 const ICON_NAME: &str = "sonora";
@@ -129,6 +129,7 @@ impl ksni::Tray for Item {
         vec![
             StandardItem {
                 label: shown.caption.clone(),
+                icon_data: cover(shown.artwork.as_ref()).unwrap_or_default(),
                 enabled: false,
                 ..Default::default()
             }
@@ -141,5 +142,23 @@ impl ksni::Tray for Item {
             self.entry(&shown.show, Event::Show),
             self.entry(&shown.quit, Event::Quit),
         ]
+    }
+}
+
+/// The cover as the png a menu item carries. A cover that cannot be encoded is simply left off
+/// the row.
+fn cover(art: Option<&Art>) -> Option<Vec<u8>> {
+    let art = art?;
+    let image = image::RgbaImage::from_raw(art.width, art.height, art.data.clone())?;
+
+    let mut png = Vec::new();
+    let written = image::DynamicImage::ImageRgba8(image)
+        .write_to(&mut std::io::Cursor::new(&mut png), image::ImageFormat::Png);
+    match written {
+        Ok(()) => Some(png),
+        Err(error) => {
+            log::warn!("tray: cannot encode the cover: {error:#}");
+            None
+        }
     }
 }


### PR DESCRIPTION
## Summary

- draw the playing track's cover beside its name in the tray menu
- name the playing track in the tray icon tooltip on macOS and Windows
- open the song page from the tray menu caption

<img width="203" height="220" alt="Screenshot 2026-09-10 at 3 35 10 PM" src="https://github.com/user-attachments/assets/3d37745d-8c39-4820-ad37-b56b3f7931be" />
