### PR TITLE
fix(views): translate the detail song count when it is drawn, not when it loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - A submenu that has no room beside its menu opens over it instead of under its rows, on whichever
   side has more room. The Add to playlist list in a narrow window no longer shows the context menu's
   items through it.
+- The song count on an album or playlist page follows a language change. It used to keep the
+  language the page was first opened in.
 
 ## [0.33.0] - 2026-09-09
 

--- a/crates/state/src/detail.rs
+++ b/crates/state/src/detail.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use gpui::{Context, Entity, Task};
-use i18n::t;
 use music::{Album, AlbumDetail, ArtistRef, Contributor, Playlist, PlaylistDetail, Track};
 use tokio::task::AbortHandle;
 
@@ -25,7 +24,10 @@ pub struct Header {
     pub artist_refs: Vec<ArtistRef>,
     pub owner: Option<Contributor>,
     pub release_date: Option<String>,
-    pub meta: Vec<String>,
+    /// The owner's name when the provider gives no id to link it to.
+    pub owner_name: Option<String>,
+    /// Zero when the provider does not report a count.
+    pub track_count: u32,
     pub cover: Option<String>,
 }
 
@@ -433,11 +435,6 @@ impl Detail {
 }
 
 fn album_header(album: &Album) -> Header {
-    let mut parts = Vec::new();
-    if album.track_count > 0 {
-        parts.push(t!("count-songs", count = album.track_count).to_string());
-    }
-
     Header {
         kind: Collection::Album,
         title: album.name.clone(),
@@ -448,7 +445,8 @@ fn album_header(album: &Album) -> Header {
             true => (album.year > 0).then(|| album.year.to_string()),
             false => Some(album.release_date.clone()),
         },
-        meta: parts,
+        owner_name: None,
+        track_count: album.track_count,
         cover: album.cover_large.clone(),
     }
 }
@@ -462,13 +460,10 @@ fn playlist_header(playlist: &Playlist) -> Header {
             avatar: None,
         }),
     };
-    let mut parts = match owner.is_some() {
-        true => Vec::new(),
-        false => vec![playlist.owner.clone()],
+    let owner_name = match owner.is_some() {
+        true => None,
+        false => Some(playlist.owner.clone()),
     };
-    if playlist.track_count > 0 {
-        parts.push(t!("count-songs", count = playlist.track_count).to_string());
-    }
 
     Header {
         kind: Collection::Playlist,
@@ -477,7 +472,8 @@ fn playlist_header(playlist: &Playlist) -> Header {
         artist_refs: Vec::new(),
         owner,
         release_date: None,
-        meta: parts,
+        owner_name,
+        track_count: playlist.track_count,
         cover: playlist.cover.clone(),
     }
 }

--- a/crates/views/src/screens/detail.rs
+++ b/crates/views/src/screens/detail.rs
@@ -286,7 +286,8 @@ impl DetailView {
             .unwrap_or_default();
         let owner = header.and_then(|header| header.owner.clone());
         let release_date = header.and_then(|header| header.release_date.as_deref());
-        let meta = header.map(|header| header.meta.clone()).unwrap_or_default();
+        let owner_name = header.and_then(|header| header.owner_name.clone());
+        let track_count = header.map(|header| header.track_count).unwrap_or(0);
         let listed = self.detail.read(cx).tracks();
         let duration: std::time::Duration = listed.iter().map(|track| track.duration).sum();
         let (eyebrow, label) = match kind {
@@ -318,8 +319,11 @@ impl DetailView {
         if let Some(release_date) = release_date {
             strip = strip.text(release_date_label(release_date));
         }
-        for item in meta {
-            strip = strip.text(item);
+        if let Some(owner_name) = owner_name {
+            strip = strip.text(owner_name);
+        }
+        if track_count > 0 {
+            strip = strip.text(t!("count-songs", count = track_count));
         }
         if !duration.is_zero() {
             strip = strip.text(clock(duration));


### PR DESCRIPTION
## Summary

- translate the album and playlist song count while rendering, so it follows a language change
- carry the owner name and the track count on the detail header as data instead of translated strings

Closes #531