### PR TITLE
chore: release 0.34.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.34.1] - 2026-09-11
+
 ### Fixed
 
 - The Flatpak can show what you are playing on Discord. It reaches the Discord socket whether
@@ -1479,7 +1481,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Initial release: a native Spotify client with playback, an interactive queue, the saved library,
 search, album, playlist, artist and song pages, context menus and adaptive theming.
 
-[unreleased]: https://github.com/sonorahq/sonora/compare/v0.34.0...HEAD
+[unreleased]: https://github.com/sonorahq/sonora/compare/v0.34.1...HEAD
+[0.34.1]: https://github.com/sonorahq/sonora/compare/v0.34.0...v0.34.1
 [0.34.0]: https://github.com/sonorahq/sonora/compare/v0.33.0...v0.34.0
 [0.33.0]: https://github.com/sonorahq/sonora/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/sonorahq/sonora/compare/v0.31.0...v0.32.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- The Flatpak can show what you are playing on Discord. It reaches the Discord socket whether
+  Discord is installed natively or as a Flatpak.
+
 ## [0.34.0] - 2026-09-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,7 +1906,7 @@ checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "embed"
-version = "0.34.0"
+version = "0.34.1"
 
 [[package]]
 name = "embed-resource"
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "i18n"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "fluent-bundle",
  "gpui",
@@ -3344,7 +3344,7 @@ dependencies = [
 
 [[package]]
 name = "icons"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "embed",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "input"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "gpui",
  "ui",
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "music"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6450,7 +6450,7 @@ dependencies = [
 
 [[package]]
 name = "router"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "gpui",
  "ui",
@@ -7261,7 +7261,7 @@ dependencies = [
 
 [[package]]
 name = "sonora"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -7402,7 +7402,7 @@ dependencies = [
 
 [[package]]
 name = "state"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7437,7 +7437,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "futures",
  "gpui",
@@ -8846,7 +8846,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "views"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "gpui",
  "i18n",
@@ -9135,7 +9135,7 @@ dependencies = [
 
 [[package]]
 name = "webview"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "block2 0.6.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.34.0"
+version = "0.34.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/sonorahq/sonora"

--- a/flatpak/flatpak-builder.yaml
+++ b/flatpak/flatpak-builder.yaml
@@ -19,6 +19,11 @@ finish-args:
   # Open With passes an arbitrary path as argv; a plain Exec launch (unlike a portal file-open)
   # gets no per-file bind mount, so reading it needs read access to the whole host.
   - --filesystem=host:ro
+  # Discord presence talks to Discord's IPC socket in the host runtime dir: a native Discord
+  # puts it at discord-ipc-0, a Flatpak Discord under app/com.discordapp.Discord, which has to
+  # be created from our side so the bind exists before Discord starts.
+  - --filesystem=xdg-run/discord-ipc-0
+  - --filesystem=xdg-run/app/com.discordapp.Discord:create
 
   # Session Bus Permissions (Same as Spotify flatpak):
   - --talk-name=org.gnome.SettingsDaemon.MediaKeys


### PR DESCRIPTION
## Summary

- let discord presence reach the discord socket from the flatpak
- release 0.34.1