### PR TITLE
feat(local): split multi-artist tags, normalize artist names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Local artist tags separated by commas, "feat.", etc. are now recognized as multiple artists.
+  Artist names that only differ in capitalization no longer create duplicate entries.
+
 ### Fixed
 
 - Local M4A files show their embedded cover art.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4444,6 +4444,7 @@ dependencies = [
 name = "music"
 version = "0.34.1"
 dependencies = [
+ "aho-corasick",
  "anyhow",
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ ui = { path = "crates/ui" }
 views = { path = "crates/views" }
 webview = { path = "crates/webview" }
 
+aho-corasick = "1.1"
 anyhow = "1.0"
 async-trait = "0.1"
 base64 = "0.22"

--- a/crates/music/Cargo.toml
+++ b/crates/music/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 bundled-sqlite = ["rusqlite/bundled", "storage/bundled-sqlite"]
 
 [dependencies]
+aho-corasick.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 base64.workspace = true

--- a/crates/music/src/local/client.rs
+++ b/crates/music/src/local/client.rs
@@ -95,32 +95,45 @@ impl LocalClient {
         tracks
     }
 
-    /// Every artist in the scan, one per distinct artist string, sorted by name.
+    /// Every artist in the scan, one or more per track, sorted by name.
     fn artists(&self) -> Vec<SavedArtist> {
         let scanned = self.scanned.read().unwrap();
         let mut artists: Vec<SavedArtist> = Vec::new();
         for track in &scanned.tracks {
-            if let Some(known) = artists.iter_mut().find(|known| known.name == track.artists) {
-                known.added_at = known.added_at.max(track.added_at);
-                continue;
+            for artist_ref in &track.artist_refs {
+                if let Some(known) = artists
+                    .iter_mut()
+                    .find(|known| known.name == artist_ref.name)
+                {
+                    known.added_at = known.added_at.max(track.added_at);
+                    continue;
+                }
+                artists.push(SavedArtist {
+                    id: artist_ref
+                        .id
+                        .clone()
+                        .unwrap_or_else(|| wire::artist_id(&artist_ref.name)),
+                    name: artist_ref.name.clone(),
+                    cover: scanned
+                        .portraits
+                        .get(&artist_ref.name)
+                        .cloned()
+                        .or_else(|| {
+                            scanned
+                                .albums
+                                .iter()
+                                .find(|album| {
+                                    album
+                                        .artist_refs
+                                        .iter()
+                                        .any(|album_ref| album_ref.name == artist_ref.name)
+                                })
+                                .and_then(|album| album.cover.clone())
+                        })
+                        .or_else(|| track.cover.clone()),
+                    added_at: track.added_at,
+                });
             }
-            artists.push(SavedArtist {
-                id: wire::artist_id(&track.artists),
-                name: track.artists.clone(),
-                cover: scanned
-                    .portraits
-                    .get(&track.artists)
-                    .cloned()
-                    .or_else(|| {
-                        scanned
-                            .albums
-                            .iter()
-                            .find(|album| album.artists == track.artists)
-                            .and_then(|album| album.cover.clone())
-                    })
-                    .or_else(|| track.cover.clone()),
-                added_at: track.added_at,
-            });
         }
         artists.sort_by_key(|artist| artist.name.to_lowercase());
         artists
@@ -184,13 +197,23 @@ impl MusicApi for LocalClient {
             top_tracks: scanned
                 .tracks
                 .iter()
-                .filter(|track| track.artists == name)
+                .filter(|track| {
+                    track
+                        .artist_refs
+                        .iter()
+                        .any(|artist_ref| artist_ref.name == name)
+                })
                 .cloned()
                 .collect(),
             albums: scanned
                 .albums
                 .iter()
-                .filter(|album| album.artists == name)
+                .filter(|album| {
+                    album
+                        .artist_refs
+                        .iter()
+                        .any(|artist_ref| artist_ref.name == name)
+                })
                 .cloned()
                 .collect(),
         })

--- a/crates/music/src/local/client.rs
+++ b/crates/music/src/local/client.rs
@@ -94,50 +94,6 @@ impl LocalClient {
         });
         tracks
     }
-
-    /// Every artist in the scan, one or more per track, sorted by name.
-    fn artists(&self) -> Vec<SavedArtist> {
-        let scanned = self.scanned.read().unwrap();
-        let mut artists: Vec<SavedArtist> = Vec::new();
-        for track in &scanned.tracks {
-            for artist_ref in &track.artist_refs {
-                if let Some(known) = artists
-                    .iter_mut()
-                    .find(|known| known.name == artist_ref.name)
-                {
-                    known.added_at = known.added_at.max(track.added_at);
-                    continue;
-                }
-                artists.push(SavedArtist {
-                    id: artist_ref
-                        .id
-                        .clone()
-                        .unwrap_or_else(|| wire::artist_id(&artist_ref.name)),
-                    name: artist_ref.name.clone(),
-                    cover: scanned
-                        .portraits
-                        .get(&artist_ref.name)
-                        .cloned()
-                        .or_else(|| {
-                            scanned
-                                .albums
-                                .iter()
-                                .find(|album| {
-                                    album
-                                        .artist_refs
-                                        .iter()
-                                        .any(|album_ref| album_ref.name == artist_ref.name)
-                                })
-                                .and_then(|album| album.cover.clone())
-                        })
-                        .or_else(|| track.cover.clone()),
-                    added_at: track.added_at,
-                });
-            }
-        }
-        artists.sort_by_key(|artist| artist.name.to_lowercase());
-        artists
-    }
 }
 
 fn playlist_from(id: String, name: String, modified_at: i64, tracks: &[Track]) -> Playlist {
@@ -186,12 +142,16 @@ impl MusicApi for LocalClient {
     }
 
     async fn artist(&self, artist_id: &str) -> Result<Artist> {
-        let name = wire::artist_name_from_id(artist_id)
-            .ok_or_else(|| anyhow!("{artist_id} is not a local artist id"))?;
         let scanned = self.scanned.read().unwrap();
+        let artist = scanned
+            .artists
+            .iter()
+            .find(|artist| artist.id == artist_id)
+            .cloned()
+            .ok_or_else(|| anyhow!("cannot find local artist {artist_id}"))?;
         Ok(Artist {
-            name: name.to_owned(),
-            cover_large: scanned.portraits.get(name).cloned(),
+            name: artist.name,
+            cover_large: artist.cover,
             biography: None,
             monthly_listeners: None,
             top_tracks: scanned
@@ -201,7 +161,7 @@ impl MusicApi for LocalClient {
                     track
                         .artist_refs
                         .iter()
-                        .any(|artist_ref| artist_ref.name == name)
+                        .any(|artist_ref| artist_ref.id.as_deref() == Some(artist_id))
                 })
                 .cloned()
                 .collect(),
@@ -212,7 +172,7 @@ impl MusicApi for LocalClient {
                     album
                         .artist_refs
                         .iter()
-                        .any(|artist_ref| artist_ref.name == name)
+                        .any(|artist_ref| artist_ref.id.as_deref() == Some(artist_id))
                 })
                 .cloned()
                 .collect(),
@@ -220,12 +180,16 @@ impl MusicApi for LocalClient {
     }
 
     async fn artist_profile(&self, artist_id: &str) -> Result<ArtistProfile> {
-        let name = wire::artist_name_from_id(artist_id)
-            .ok_or_else(|| anyhow!("{artist_id} is not a local artist id"))?;
         let scanned = self.scanned.read().unwrap();
+        let artist = scanned
+            .artists
+            .iter()
+            .find(|artist| artist.id == artist_id)
+            .cloned()
+            .ok_or_else(|| anyhow!("cannot find local artist {artist_id}"))?;
         Ok(ArtistProfile {
-            name: name.to_owned(),
-            cover_large: scanned.portraits.get(name).cloned(),
+            name: artist.name,
+            cover_large: artist.cover,
             biography: None,
         })
     }
@@ -235,8 +199,7 @@ impl MusicApi for LocalClient {
         Ok(ids
             .into_iter()
             .filter_map(|id| {
-                let name = wire::artist_name_from_id(&id)?;
-                let portrait = scanned.portraits.get(name)?;
+                let portrait = scanned.portraits.get(&id)?;
                 Some((id.clone(), portrait.clone()))
             })
             .collect())
@@ -398,12 +361,16 @@ impl MusicApi for LocalClient {
 
     async fn saved_artists(&self, limit: u32) -> Result<Vec<SavedArtist>> {
         let starred = self.store.starred(Starred::Artists)?;
-        let known = self.artists();
+        let scanned = self.scanned.read().unwrap();
         Ok(starred
             .into_iter()
             .take(limit as usize)
             .filter_map(|(id, added_at)| {
-                let mut artist = known.iter().find(|artist| artist.id == id).cloned()?;
+                let mut artist = scanned
+                    .artists
+                    .iter()
+                    .find(|artist| artist.id == id)
+                    .cloned()?;
                 artist.added_at = Some(added_at);
                 Some(artist)
             })
@@ -411,9 +378,13 @@ impl MusicApi for LocalClient {
     }
 
     async fn all_artists(&self, limit: u32) -> Result<Vec<SavedArtist>> {
-        let mut artists = self.artists();
-        artists.truncate(limit as usize);
-        Ok(artists)
+        let scanned = self.scanned.read().unwrap();
+        Ok(scanned
+            .artists
+            .iter()
+            .take(limit as usize)
+            .cloned()
+            .collect())
     }
 
     async fn set_artist_saved(&self, artist_id: &str, saved: bool) -> Result<()> {

--- a/crates/music/src/local/scan.rs
+++ b/crates/music/src/local/scan.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use crate::{Album, Track};
+use crate::{Album, SavedArtist, Track};
 
 use super::wire;
 
@@ -15,6 +15,7 @@ const AUDIO_EXTENSIONS: &[&str] = &[
 pub struct Scanned {
     pub tracks: Vec<Track>,
     pub albums: Vec<Album>,
+    pub artists: Vec<SavedArtist>,
     pub portraits: HashMap<String, String>,
 }
 
@@ -52,6 +53,7 @@ pub fn scan(roots: &[PathBuf], cache_dir: &Path) -> Scanned {
 
     scanned.portraits = collect_portraits(roots, &parsed);
     scanned.albums = group_albums(&parsed);
+    scanned.artists = group_artists(&parsed, &scanned.portraits, &scanned.albums);
     scanned.tracks = parsed.into_iter().map(|(track, _)| track).collect();
     scanned
 }
@@ -109,13 +111,73 @@ fn album_year(indices: &[usize], parsed: &[(Track, String)]) -> i32 {
         .unwrap_or(0)
 }
 
+fn group_artists(
+    parsed: &[(Track, String)],
+    portraits: &HashMap<String, String>,
+    albums: &[Album],
+) -> Vec<SavedArtist> {
+    let mut order: Vec<String> = Vec::new();
+    let mut groups: HashMap<String, Vec<usize>> = HashMap::new();
+
+    for (index, (track, _)) in parsed.iter().enumerate() {
+        for artist_ref in &track.artist_refs {
+            let id = artist_ref
+                .id
+                .clone()
+                .unwrap_or_else(|| wire::artist_id(&artist_ref.name));
+            if !groups.contains_key(&id) {
+                order.push(id.clone());
+            }
+            groups.entry(id).or_default().push(index);
+        }
+    }
+
+    order
+        .into_iter()
+        .filter_map(|id| {
+            let indices = groups.get(&id)?;
+            let name = indices.iter().find_map(|&i| {
+                parsed[i].0.artist_refs.iter().find_map(|artist_ref| {
+                    (artist_ref.id.as_deref() == Some(id.as_str())).then(|| artist_ref.name.clone())
+                })
+            })?;
+            let cover = portraits
+                .get(&id)
+                .cloned()
+                .or_else(|| {
+                    albums
+                        .iter()
+                        .find(|album| {
+                            album
+                                .artist_refs
+                                .iter()
+                                .any(|album_ref| album_ref.id.as_deref() == Some(id.as_str()))
+                        })
+                        .and_then(|album| album.cover.clone())
+                })
+                .or_else(|| indices.iter().find_map(|&i| parsed[i].0.cover.clone()));
+            Some(SavedArtist {
+                id,
+                name,
+                cover,
+                added_at: indices.iter().filter_map(|&i| parsed[i].0.added_at).max(),
+            })
+        })
+        .collect()
+}
+
 fn collect_portraits(roots: &[PathBuf], parsed: &[(Track, String)]) -> HashMap<String, String> {
-    let mut by_normalized: HashMap<String, String> = HashMap::new();
+    let mut known: HashSet<String> = HashSet::new();
     for (track, _) in parsed {
         for artist_ref in &track.artist_refs {
-            by_normalized
-                .entry(wire::normalize(&artist_ref.name))
-                .or_insert_with(|| artist_ref.name.clone());
+            match artist_ref.id.as_deref() {
+                Some(id) => {
+                    known.insert(id.to_owned());
+                }
+                None => {
+                    known.insert(wire::artist_id(&artist_ref.name));
+                }
+            }
         }
     }
 
@@ -126,14 +188,12 @@ fn collect_portraits(roots: &[PathBuf], parsed: &[(Track, String)]) -> HashMap<S
 
     let mut portraits = HashMap::new();
     for dir in dirs {
-        let Some(artist) = by_normalized.get(&wire::normalize(&folder_name(&dir))) else {
-            continue;
-        };
-        if portraits.contains_key(artist) {
+        let id = wire::artist_id(&folder_name(&dir));
+        if !known.contains(&id) || portraits.contains_key(&id) {
             continue;
         }
         if let Some(portrait) = wire::artist_cover(&dir) {
-            portraits.insert(artist.clone(), portrait);
+            portraits.insert(id, portrait);
         }
     }
     portraits

--- a/crates/music/src/local/scan.rs
+++ b/crates/music/src/local/scan.rs
@@ -112,9 +112,11 @@ fn album_year(indices: &[usize], parsed: &[(Track, String)]) -> i32 {
 fn collect_portraits(roots: &[PathBuf], parsed: &[(Track, String)]) -> HashMap<String, String> {
     let mut by_normalized: HashMap<String, String> = HashMap::new();
     for (track, _) in parsed {
-        by_normalized
-            .entry(wire::normalize(&track.artists))
-            .or_insert_with(|| track.artists.clone());
+        for artist_ref in &track.artist_refs {
+            by_normalized
+                .entry(wire::normalize(&artist_ref.name))
+                .or_insert_with(|| artist_ref.name.clone());
+        }
     }
 
     let mut dirs = Vec::new();

--- a/crates/music/src/local/wire.rs
+++ b/crates/music/src/local/wire.rs
@@ -1,7 +1,9 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::Path;
+use std::sync::LazyLock;
 
+use aho_corasick::AhoCorasick;
 use lofty::file::{AudioFile, TaggedFileExt};
 use lofty::picture::{MimeType, Picture, PictureType};
 use lofty::prelude::Accessor;
@@ -49,7 +51,12 @@ const PLAYABLE_EXTENSIONS: &[&str] = &[
     "mp3", "flac", "m4a", "mp4", "aac", "ogg", "oga", "wav", "opus", "webm", "mka", "wv", "ape",
 ];
 
-const ARTIST_SEPARATORS: &[&str] = &[",", ";", " ft. ", " feat ", " feat. ", " featuring "];
+static ARTIST_SEPARATORS: LazyLock<AhoCorasick> = LazyLock::new(|| {
+    AhoCorasick::builder()
+        .ascii_case_insensitive(true)
+        .build(&[",", ";", " ft. ", " feat ", " feat. ", " featuring "])
+        .expect("artist separators are valid patterns")
+});
 
 fn is_playable(path: &Path) -> bool {
     path.extension()
@@ -127,25 +134,12 @@ fn artist_refs(artist: &str) -> Vec<ArtistRef> {
 }
 
 fn split_artists(value: &str) -> Vec<String> {
-    let lower = value.to_ascii_lowercase();
-    let bytes = lower.as_bytes();
-
     let mut parts = Vec::new();
     let mut start = 0;
-    let mut i = 0;
 
-    while i < bytes.len() {
-        match ARTIST_SEPARATORS
-            .iter()
-            .find(|sep| bytes[i..].starts_with(sep.as_bytes()))
-        {
-            Some(sep) => {
-                parts.push(value[start..i].trim().to_owned());
-                i += sep.len();
-                start = i;
-            }
-            None => i += 1,
-        }
+    for found in ARTIST_SEPARATORS.find_iter(value) {
+        parts.push(value[start..found.start()].trim().to_owned());
+        start = found.end();
     }
     parts.push(value[start..].trim().to_owned());
 

--- a/crates/music/src/local/wire.rs
+++ b/crates/music/src/local/wire.rs
@@ -99,6 +99,10 @@ pub fn id3v2_end(path: &Path) -> u64 {
     skip
 }
 
+pub fn normalize(value: &str) -> String {
+    value.trim().to_lowercase()
+}
+
 pub fn album_id(artist: &str, name: &str) -> String {
     let mut hasher = DefaultHasher::new();
     normalize(artist).hash(&mut hasher);
@@ -106,24 +110,18 @@ pub fn album_id(artist: &str, name: &str) -> String {
     format!("{LOCAL_ALBUM_PREFIX}{:016x}", hasher.finish())
 }
 
-pub fn normalize(value: &str) -> String {
-    value.trim().to_lowercase()
-}
-
 pub fn artist_id(name: &str) -> String {
-    format!("{LOCAL_ARTIST_PREFIX}{name}")
-}
-
-pub fn artist_name_from_id(id: &str) -> Option<&str> {
-    id.strip_prefix(LOCAL_ARTIST_PREFIX)
+    let mut hasher = DefaultHasher::new();
+    normalize(name).hash(&mut hasher);
+    format!("{LOCAL_ARTIST_PREFIX}{:016x}", hasher.finish())
 }
 
 fn artist_refs(artist: &str) -> Vec<ArtistRef> {
     split_artists(artist)
-        .iter()
-        .map(|name| ArtistRef {
-            name: name.to_owned(),
-            id: Some(artist_id(name)),
+        .into_iter()
+        .map(|name| {
+            let id = artist_id(&name);
+            ArtistRef { name, id: Some(id) }
         })
         .collect()
 }

--- a/crates/music/src/local/wire.rs
+++ b/crates/music/src/local/wire.rs
@@ -49,6 +49,8 @@ const PLAYABLE_EXTENSIONS: &[&str] = &[
     "mp3", "flac", "m4a", "mp4", "aac", "ogg", "oga", "wav", "opus", "webm", "mka", "wv", "ape",
 ];
 
+const ARTIST_SEPARATORS: &[&str] = &[",", ";", " ft. ", " feat ", " feat. ", " featuring "];
+
 fn is_playable(path: &Path) -> bool {
     path.extension()
         .and_then(|extension| extension.to_str())
@@ -116,11 +118,41 @@ pub fn artist_name_from_id(id: &str) -> Option<&str> {
     id.strip_prefix(LOCAL_ARTIST_PREFIX)
 }
 
-fn artist_ref(name: &str) -> ArtistRef {
-    ArtistRef {
-        name: name.to_owned(),
-        id: Some(artist_id(name)),
+fn artist_refs(artist: &str) -> Vec<ArtistRef> {
+    split_artists(artist)
+        .iter()
+        .map(|name| ArtistRef {
+            name: name.to_owned(),
+            id: Some(artist_id(name)),
+        })
+        .collect()
+}
+
+fn split_artists(value: &str) -> Vec<String> {
+    let lower = value.to_ascii_lowercase();
+    let bytes = lower.as_bytes();
+
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut i = 0;
+
+    while i < bytes.len() {
+        match ARTIST_SEPARATORS
+            .iter()
+            .find(|sep| bytes[i..].starts_with(sep.as_bytes()))
+        {
+            Some(sep) => {
+                parts.push(value[start..i].trim().to_owned());
+                i += sep.len();
+                start = i;
+            }
+            None => i += 1,
+        }
     }
+    parts.push(value[start..].trim().to_owned());
+
+    parts.retain(|p| !p.is_empty());
+    parts
 }
 
 fn clean(value: Option<std::borrow::Cow<'_, str>>) -> Option<String> {
@@ -419,7 +451,7 @@ pub fn track_from_file(
             name,
             playable: is_playable(path),
             artists: artist.clone(),
-            artist_refs: vec![artist_ref(&artist)],
+            artist_refs: artist_refs(&artist),
             album: album_name,
             album_id,
             cover,
@@ -461,7 +493,7 @@ pub fn album_from_tracks(name: &str, artist: &str, tracks: &[Track], year: i32) 
         id: album_id(artist, name),
         name: name.to_owned(),
         artists: artist.to_owned(),
-        artist_refs: vec![artist_ref(artist)],
+        artist_refs: artist_refs(artist),
         cover: cover.clone(),
         cover_large: cover,
         release_type: ReleaseType::Album,


### PR DESCRIPTION
## Summary

- split local artist tags on `,`, `;`, ` ft. `, ` feat `, ` feat. `, ` featuring ` (case-insensitive) into separate artists
- identify local artists by normalized and hashed id computed at scan time
- treat local artist names as case-insensitive so the artist page shows all their songs regardless of capitalization

Closes #439