### PR TITLE
release 0.34.2: queue arrow fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   portals that do not expose the standardized setting safely keep normal animations.
 - Local M4A files show their embedded cover art.
 - On Linux under Wayland, the cookie sign-in window draws its page instead of staying blank.
+- The arrow that floats over a scrolled queue brings the now-playing track back into view
+  instead of jumping to the top of the history. It only goes to the top when nothing is playing.
 
 ## [0.34.1] - 2026-09-11
 

--- a/README.md
+++ b/README.md
@@ -154,19 +154,19 @@ AI-assisted proofreading and translation of human-written text are permitted.
 
 | Language | Translated | Coverage |
 | --- | --- | --- |
-| English (`en-US`) | 579/579 | 100% |
-| Deutsch (`de`) | 536/579 | 93% |
-| Español (`es`) | 574/579 | 99% |
-| Français (`fr`) | 498/579 | 86% |
-| Italiano (`it`) | 495/579 | 85% |
-| Bahasa Indonesia (`id`) | 525/579 | 91% |
-| 日本語 (`ja`) | 508/579 | 88% |
-| Русский (`ru`) | 528/579 | 91% |
-| Українська (`uk`) | 574/579 | 99% |
-| Polski (`pl`) | 574/579 | 99% |
-| Português (Brasil) (`pt-BR`) | 514/579 | 89% |
-| 简体中文 (`zh-CN`) | 573/579 | 99% |
-| Türkçe (`tr`) | 548/579 | 95% |
+| English (`en-US`) | 580/580 | 100% |
+| Deutsch (`de`) | 536/580 | 92% |
+| Español (`es`) | 574/580 | 99% |
+| Français (`fr`) | 498/580 | 86% |
+| Italiano (`it`) | 495/580 | 85% |
+| Bahasa Indonesia (`id`) | 525/580 | 91% |
+| 日本語 (`ja`) | 508/580 | 88% |
+| Русский (`ru`) | 529/580 | 91% |
+| Українська (`uk`) | 575/580 | 99% |
+| Polski (`pl`) | 575/580 | 99% |
+| Português (Brasil) (`pt-BR`) | 514/580 | 89% |
+| 简体中文 (`zh-CN`) | 573/580 | 99% |
+| Türkçe (`tr`) | 548/580 | 94% |
 
 <!-- i18n:end -->
 

--- a/assets/i18n/en-US/main.ftl
+++ b/assets/i18n/en-US/main.ftl
@@ -204,6 +204,7 @@ queue-clear = Clear
 queue-empty = Your queue is empty
 queue-similar = Similar tracks
 queue-radio = Autoplay similar tracks
+queue-return-playing = Back to now playing
 
 # player bar
 player-nothing-playing = Nothing playing

--- a/assets/i18n/pl/main.ftl
+++ b/assets/i18n/pl/main.ftl
@@ -219,6 +219,7 @@ queue-clear = Wyczyść
 queue-empty = Twoja kolejka jest pusta
 queue-similar = Podobne utwory
 queue-radio = Automatycznie odtwarzaj podobne utwory
+queue-return-playing = Do bieżącego utworu
 
 # player bar
 player-nothing-playing = Nic nie jest odtwarzane

--- a/assets/i18n/ru/main.ftl
+++ b/assets/i18n/ru/main.ftl
@@ -138,6 +138,7 @@ queue-clear = Очистить
 queue-empty = Очередь пуста
 queue-similar = Похожие треки
 queue-radio = Автовоспроизведение похожих треков
+queue-return-playing = К текущему треку
 
 # player bar
 player-nothing-playing = Ничего не играет

--- a/assets/i18n/uk/main.ftl
+++ b/assets/i18n/uk/main.ftl
@@ -217,6 +217,7 @@ queue-clear = Очистити
 queue-empty = Черга порожня
 queue-similar = Схожі треки
 queue-radio = Автовідтворення схожих треків
+queue-return-playing = До поточного треку
 
 # player bar
 player-nothing-playing = Нічого не грає

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -84,7 +84,7 @@ pub use pin::{DraggedPin, Pin, PinKind, Pinnable, Spot};
 pub use popover::{Popover, Popovers};
 pub use popup::Popup;
 pub use scrollbar::{Scrollbar, quantize, scrolled};
-pub use scroller::{Scroller, perch_room, perched, return_top};
+pub use scroller::{Scroller, perch_room, perched, return_to, return_top};
 pub use scrubber::{Scrubber, ScrubberState};
 pub use separator::Separator;
 pub use shield::Shield;

--- a/crates/ui/src/scroller.rs
+++ b/crates/ui/src/scroller.rs
@@ -139,9 +139,22 @@ pub fn perch_room(cx: &App) -> Pixels {
 /// region has been scrolled far enough for the trip to be worth one. The parent has to be
 /// `relative`.
 pub fn return_top(id: impl Into<ElementId>, bar: &Entity<Scrollbar>, cx: &App) -> Option<Div> {
+    return_to(id, bar, Pixels::ZERO, "nav-return-top", cx)
+}
+
+/// A perched button that glides a scrolling region back to a resting offset, in either
+/// direction. It stays away until the region has drifted far enough from that spot for the trip
+/// to be worth one. `tooltip` is an i18n key. The parent has to be `relative`.
+pub fn return_to(
+    id: impl Into<ElementId>,
+    bar: &Entity<Scrollbar>,
+    goal: Pixels,
+    tooltip: &'static str,
+    cx: &App,
+) -> Option<Div> {
     let viewport = bar.read(cx).viewport();
     let reach = (cx.theme().metrics.list_row * REACH).min(viewport / 2.);
-    if viewport <= Pixels::ZERO || bar.read(cx).offset() < reach {
+    if viewport <= Pixels::ZERO || (bar.read(cx).offset() - goal).abs() < reach {
         return None;
     }
     let bar = bar.clone();
@@ -149,9 +162,9 @@ pub fn return_top(id: impl Into<ElementId>, bar: &Entity<Scrollbar>, cx: &App) -
     Some(perched(
         Button::new(id)
             .icon("icons/undo-2.svg")
-            .tooltip("nav-return-top")
+            .tooltip(tooltip)
             .on_click(move |_, window, cx| {
-                bar.update(cx, |bar, _| bar.aim(Pixels::ZERO, window));
+                bar.update(cx, |bar, _| bar.aim(goal, window));
             }),
         cx,
     ))

--- a/crates/views/src/chrome/aside.rs
+++ b/crates/views/src/chrome/aside.rs
@@ -895,13 +895,20 @@ impl Aside {
         )
     }
 
-    /// The trip back to the top of the queue, once it has scrolled far enough to want one.
-    fn recall(&self, cx: &mut Context<Self>) -> Option<Div> {
+    /// The trip back to the now-playing row, or to the top while nothing is playing, once the
+    /// queue has drifted far enough from it to want one.
+    fn recall(&self, sections: Sections, window: &Window, cx: &mut Context<Self>) -> Option<Div> {
         if self.tab != SideTab::Queue {
             return None;
         }
+        let goal = self.resting_offset(sections, window, cx)?;
+        let tooltip = match sections.current {
+            true => "queue-return-playing",
+            false => "nav-return-top",
+        };
+        let perch = ui::return_to("queue-return-top", &self.scrollbar, goal, tooltip, cx)?;
 
-        Some(self.raised(ui::return_top("queue-return-top", &self.scrollbar, cx)?))
+        Some(self.raised(perch))
     }
 
     /// Lifts a floating control clear of the transport a stripped aside leaves underneath it.
@@ -1583,11 +1590,34 @@ impl Aside {
             return;
         }
 
-        let row = snapped(cx.theme().metrics.list_row, window);
-        let above = (viewport * PINNED_SHARE / row).round() as usize;
+        let above = Self::rows_above(viewport, window, cx);
         self.scroll
             .scroll_to_item_strict_with_offset(index, ScrollStrategy::Top, above);
         self.anchor = false;
+    }
+
+    /// How many rows `pin` keeps above the now-playing one, so it sits a quarter of the way down.
+    fn rows_above(viewport: Pixels, window: &Window, cx: &App) -> usize {
+        let row = snapped(cx.theme().metrics.list_row, window);
+        (viewport * PINNED_SHARE / row).round() as usize
+    }
+
+    /// Where the queue rests once `pin` has placed the now-playing row, in scrolled pixels,
+    /// clamped the way gpui clamps the deferred scroll. Zero while nothing is playing, so a
+    /// recall falls back to the top, and None before the list has been laid out.
+    fn resting_offset(&self, sections: Sections, window: &Window, cx: &App) -> Option<Pixels> {
+        let handle = self.scroll.0.borrow().base_handle.clone();
+        let viewport = handle.bounds().size.height;
+        if viewport <= px(0.) {
+            return None;
+        }
+        let Some(index) = sections.current_index() else {
+            return Some(Pixels::ZERO);
+        };
+        let row = snapped(cx.theme().metrics.list_row, window);
+        let above = Self::rows_above(viewport, window, cx);
+        let goal = row * index.saturating_sub(above) as f32;
+        Some(goal.clamp(Pixels::ZERO, handle.max_offset().y))
     }
 
     // unnamed origins stay unlabelled
@@ -1781,7 +1811,7 @@ impl Render for Aside {
                         )
                     })
                     .children(self.follow(cx))
-                    .children(self.recall(cx)),
+                    .children(self.recall(sections, window, cx)),
             )
             .children(self.menu(cx))
     }


### PR DESCRIPTION
## Summary

- return the queue's floating arrow to the now-playing track instead of the top of the history