### PR TITLE
release 0.34.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.34.3] - 2026-09-12
+
 ### Fixed
 
 - The cookie sign-in window opens natively on Wayland and no longer needs XWayland. It also opens
@@ -1510,7 +1512,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Initial release: a native Spotify client with playback, an interactive queue, the saved library,
 search, album, playlist, artist and song pages, context menus and adaptive theming.
 
-[unreleased]: https://github.com/sonorahq/sonora/compare/v0.34.2...HEAD
+[unreleased]: https://github.com/sonorahq/sonora/compare/v0.34.3...HEAD
+[0.34.3]: https://github.com/sonorahq/sonora/compare/v0.34.2...v0.34.3
 [0.34.2]: https://github.com/sonorahq/sonora/compare/v0.34.1...v0.34.2
 [0.34.1]: https://github.com/sonorahq/sonora/compare/v0.34.0...v0.34.1
 [0.34.0]: https://github.com/sonorahq/sonora/compare/v0.33.0...v0.34.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- The cookie sign-in window opens natively on Wayland and no longer needs XWayland. It also opens
+  on desktops that export `GDK_BACKEND=wayland`, which used to fail with "cannot reach the display
+  server".
+- The Nix package can open the sign-in window: it now ships webkitgtk and the TLS module the page
+  needs, instead of reporting that webkit2gtk is not installed.
+
 ## [0.34.2] - 2026-09-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   server".
 - The Nix package can open the sign-in window: it now ships webkitgtk and the TLS module the page
   needs, instead of reporting that webkit2gtk is not installed.
+- The left sidebar steps aside on the same frame the queue opens or closes, instead of waiting for
+  the next redraw.
 
 ## [0.34.2] - 2026-09-12
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -476,9 +476,12 @@ Rules:
   panel's size is ever a function of the other's.
 - **Hiding is a different question from sizing, and it does look at both panels.** `SidebarLeft`
   auto-hides once the room left for content — viewport minus its own width _and_
-  `Chrome::sidebar_right` — drops below `Room::Wide`, so opening the queue pushes it out of the way
-  without resizing it. It reads last frame's publish, which cannot loop: the decision changes
-  visibility, never width. `SidebarRight` decides its own takeover from the viewport alone.
+  the right sidebar's width — drops below `Room::Wide`, so opening the queue pushes it out of the way
+  without resizing it. `Workspace` hands `SidebarLeft::adapt` this frame's right width before it
+  lays anything out, and a flip calls `cx.refresh_windows()`, which lands once the draw is over. A
+  `cx.notify()` raised inside a render schedules nothing in GPUI, so anything less waits for
+  whatever redraw comes along. It cannot loop: the decision changes visibility, never width, and
+  the refresh fires only on a flip. `SidebarRight` decides its own takeover from the viewport alone.
   Toggling a hidden `SidebarLeft` back on while the window is that narrow overlays it at the width
   the user last chose, so its drag ceiling then comes from the viewport alone — an overlay takes no
   content space, so capping it against content room would only disable resizing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,7 +1906,7 @@ checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "embed"
-version = "0.34.2"
+version = "0.34.3"
 
 [[package]]
 name = "embed-resource"
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "i18n"
-version = "0.34.2"
+version = "0.34.3"
 dependencies = [
  "fluent-bundle",
  "gpui",
@@ -3344,7 +3344,7 @@ dependencies = [
 
 [[package]]
 name = "icons"
-version = "0.34.2"
+version = "0.34.3"
 dependencies = [
  "anyhow",
  "embed",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "input"
-version = "0.34.2"
+version = "0.34.3"
 dependencies = [
  "gpui",
  "ui",
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "music"
-version = "0.34.2"
+version = "0.34.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6450,7 +6450,7 @@ dependencies = [
 
 [[package]]
 name = "router"
-version = "0.34.2"
+version = "0.34.3"
 dependencies = [
  "gpui",
  "ui",
@@ -7261,7 +7261,7 @@ dependencies = [
 
 [[package]]
 name = "sonora"
-version = "0.34.2"
+version = "0.34.3"
 dependencies = [
  "anyhow",
  "dirs",
@@ -7402,7 +7402,7 @@ dependencies = [
 
 [[package]]
 name = "state"
-version = "0.34.2"
+version = "0.34.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7437,7 +7437,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage"
-version = "0.34.2"
+version = "0.34.3"
 dependencies = [
  "anyhow",
  "dirs",
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.34.2"
+version = "0.34.3"
 dependencies = [
  "ashpd",
  "futures",
@@ -8849,7 +8849,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "views"
-version = "0.34.2"
+version = "0.34.3"
 dependencies = [
  "gpui",
  "i18n",
@@ -9138,7 +9138,7 @@ dependencies = [
 
 [[package]]
 name = "webview"
-version = "0.34.2"
+version = "0.34.3"
 dependencies = [
  "anyhow",
  "block2 0.6.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.34.2"
+version = "0.34.3"
 edition = "2024"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/sonorahq/sonora"

--- a/crates/views/src/chrome/sidebar_left.rs
+++ b/crates/views/src/chrome/sidebar_left.rs
@@ -225,15 +225,19 @@ impl SidebarLeft {
         super::cap(MIN_WIDTH, MAX_WIDTH, reserved, window)
     }
 
-    pub fn adapt(&mut self, window: &Window, cx: &mut Context<Self>) {
+    /// Flips into or out of the cramped state from the room the window leaves
+    /// beside a right sidebar of `right` pixels. This runs inside a render,
+    /// where a notify schedules nothing, so a flip asks for a full window
+    /// refresh instead. That effect lands once the draw is over.
+    pub fn adapt(&mut self, right: Pixels, window: &Window, cx: &mut App) {
         self.width = ui::snapped(self.width, window);
 
-        let taken = self.width + super::Chrome::sidebar_right(cx);
-        let space_left = window.viewport_size().width - taken;
+        let space_left = window.viewport_size().width - self.width - right;
         let cramped = space_left < SNUG;
         if cramped != self.cramped {
             self.cramped = cramped;
             self.forced = None;
+            cx.refresh_windows();
         }
     }
 
@@ -620,7 +624,7 @@ impl Render for SidebarLeft {
 
         let current = self.trail.read(cx).current();
         self.follow(&current);
-        self.adapt(window, cx);
+        self.adapt(super::Chrome::sidebar_right(cx), window, cx);
 
         if !cx.has_active_drag() {
             self.dropping = false;

--- a/crates/views/src/shells/workspace.rs
+++ b/crates/views/src/shells/workspace.rs
@@ -164,11 +164,11 @@ impl Shell for Workspace {
 
 impl Render for Workspace {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let right = self.sidebar_right.read(cx).occupied_width(window);
         self.sidebar
-            .update(cx, |sidebar, cx| sidebar.adapt(window, cx));
+            .update(cx, |sidebar, cx| sidebar.adapt(right, window, cx));
         let left = self.sidebar.read(cx).occupied_width();
         let overlay_width = self.sidebar.read(cx).overlay_width();
-        let right = self.sidebar_right.read(cx).occupied_width(window);
         Chrome::publish(left, right, cx);
         let covered = self.sidebar_right.read(cx).covers_content(window);
         let overlay = self.sidebar.read(cx).overlays();

--- a/crates/webview/src/linux.rs
+++ b/crates/webview/src/linux.rs
@@ -93,6 +93,8 @@ macro_rules! symbols {
 
 symbols! {
     gdk_set_allowed_backends: unsafe extern "C" fn(*const c_char),
+    gdk_display_get_default: unsafe extern "C" fn() -> Ptr,
+    g_type_name_from_instance: unsafe extern "C" fn(Ptr) -> *const c_char,
     gtk_disable_setlocale: unsafe extern "C" fn(),
     gtk_init_check: unsafe extern "C" fn(*mut c_int, *mut *mut *mut c_char) -> Bool,
     gtk_main: unsafe extern "C" fn(),
@@ -486,17 +488,31 @@ fn gtk(api: &'static Api) -> &'static Host {
 /// Initialises GTK, then alternates between parking and running a main loop for as long as there
 /// are windows. Never returns unless GTK itself refuses to start.
 fn run(api: &'static Api, host: &'static Host) {
-    // GTK's Wayland backend will not paint from this thread while GPUI owns the process's
-    // Wayland client, and WebKit's compositor makes it worse. Pinning GDK to X11 sends the
-    // sign-in window through XWayland; the compositing env var has no public setting equivalent
-    // and disables the GL context WebKit still tries to share with the main process.
-    // SAFETY: the webview thread has just been spawned.
-    unsafe { (api.gdk_set_allowed_backends)(c"x11".as_ptr()) };
-    unsafe { std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1") };
+    // GDK opens its own connection to whichever server it finds, Wayland first and X11 through
+    // XWayland otherwise, so the sign-in window never depends on an XWayland being present. A
+    // GDK_BACKEND in the environment outranks this list, which is fine: either name works.
+    unsafe { (api.gdk_set_allowed_backends)(c"wayland,x11".as_ptr()) };
     // gtk_init would otherwise move the whole process onto the user's locale.
     unsafe { (api.gtk_disable_setlocale)() };
     if unsafe { (api.gtk_init_check)(ptr::null_mut(), ptr::null_mut()) } == 0 {
         return host.fail("cannot reach the display server".to_string());
+    }
+    // SAFETY: the display GTK just opened outlives the thread, and its type name is static.
+    let backend = unsafe {
+        let display = (api.gdk_display_get_default)();
+        match display.is_null() {
+            true => String::new(),
+            false => CStr::from_ptr((api.g_type_name_from_instance)(display))
+                .to_string_lossy()
+                .into_owned(),
+        }
+    };
+    log::debug!("webview: gdk opened {backend}");
+    // On X11 WebKit tries to share a GL context with the main process and paints nothing; the
+    // compositing env var has no public setting equivalent. Wayland needs the compositor on.
+    // SAFETY: nothing else in the process reads this variable.
+    if backend == "GdkX11Display" {
+        unsafe { std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1") };
     }
     host.running();
     loop {

--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,8 @@
                 alsa-lib
                 dbus
                 sqlite
+                webkitgtk_4_1
+                glib-networking
               ]
             else
               [ ];
@@ -156,7 +158,8 @@
                 --add-rpath "${pkgs.lib.makeLibraryPath (runtimeLibraries ++ [ pkgs.stdenv.cc.cc.lib ])}" \
                 "$out/bin/sonora"
               wrapProgram "$out/bin/sonora" \
-                --set ALSA_PLUGIN_DIR ${alsaPluginDirectory}
+                --set ALSA_PLUGIN_DIR ${alsaPluginDirectory} \
+                --prefix GIO_EXTRA_MODULES : ${pkgs.glib-networking}/lib/gio/modules
             '';
 
             meta = {
@@ -241,10 +244,14 @@
                 "";
 
             shellHook =
+              # WebKit composites through EGL, which has to find the same drivers.
               pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
                 if [ ! -d /run/opengl-driver ]; then
                   export VK_DRIVER_FILES="${pkgs.mesa}/share/vulkan/icd.d"
                   export VK_IMPLICIT_LAYER_PATH="${pkgs.mesa}/share/vulkan/implicit_layer.d"
+                  export __EGL_VENDOR_LIBRARY_DIRS="${pkgs.mesa}/share/glvnd/egl_vendor.d"
+                  export LIBGL_DRIVERS_PATH="${pkgs.mesa}/lib/dri"
+                  export GBM_BACKENDS_PATH="${pkgs.mesa}/lib/gbm"
                 fi
                 export GIO_EXTRA_MODULES="${pkgs.glib-networking}/lib/gio/modules''${GIO_EXTRA_MODULES:+:$GIO_EXTRA_MODULES}"
               ''


### PR DESCRIPTION
## Summary

- open the cookie sign-in window natively on wayland, falling back to x11
- ship webkitgtk and the tls module in the nix package
- refresh the window when the left sidebar flips into or out of its cramped state