### PR TITLE
fix(webview): give webview2 a writable user data folder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9142,6 +9142,7 @@ version = "0.34.3"
 dependencies = [
  "anyhow",
  "block2 0.6.2",
+ "dirs",
  "libc",
  "log",
  "objc2 0.6.4",

--- a/crates/webview/Cargo.toml
+++ b/crates/webview/Cargo.toml
@@ -26,6 +26,7 @@ objc2-foundation = { workspace = true, features = [
 objc2-web-kit.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
+dirs.workspace = true
 webview2-com.workspace = true
 windows.workspace = true
 

--- a/crates/webview/src/windows.rs
+++ b/crates/webview/src/windows.rs
@@ -8,8 +8,8 @@ use std::rc::{Rc, Weak};
 
 use anyhow::{Context as _, Result};
 use webview2_com::Microsoft::Web::WebView2::Win32::{
-    CreateCoreWebView2Environment, ICoreWebView2, ICoreWebView2_2, ICoreWebView2Controller,
-    ICoreWebView2Environment10,
+    CreateCoreWebView2EnvironmentWithOptions, ICoreWebView2, ICoreWebView2_2,
+    ICoreWebView2Controller, ICoreWebView2Environment10,
 };
 use webview2_com::{
     CoTaskMemPWSTR, CreateCoreWebView2ControllerCompletedHandler,
@@ -173,8 +173,28 @@ fn begin_environment(hwnd: HWND, url: &str, browser: Weak<RefCell<Option<Browser
             Ok(())
         },
     ));
-    unsafe { CreateCoreWebView2Environment(&handler) }
-        .context("cannot start the WebView2 environment")
+    let folder = user_data_folder()?;
+    unsafe {
+        CreateCoreWebView2EnvironmentWithOptions(
+            PCWSTR::null(),
+            PCWSTR(folder.as_ptr()),
+            None,
+            &handler,
+        )
+    }
+    .context("cannot start the WebView2 environment")
+}
+
+/// Sonora's own cache folder for WebView2's browser state, as a wide string. WebView2 otherwise
+/// writes beside the executable, which an installed copy under Program Files cannot do.
+fn user_data_folder() -> Result<Vec<u16>> {
+    let folder = dirs::cache_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join("sonora")
+        .join("webview2");
+    std::fs::create_dir_all(&folder)
+        .with_context(|| format!("cannot create {}", folder.display()))?;
+    Ok(wide(&folder.to_string_lossy()))
 }
 
 /// Configures an InPrivate profile and starts its controller asynchronously.


### PR DESCRIPTION
## What changed

- Create the WebView2 environment with an explicit user data folder under Sonora's cache root instead of letting the runtime pick its default.
- Add `dirs` to the webview crate's Windows dependencies.

## Why

`CreateCoreWebView2Environment` puts browser state in `Sonora.exe.WebView2`, beside the executable. A copy installed under `C:\Program Files` cannot write there, so the runtime fails the environment with `E_ACCESSDENIED` (`0x80070005`) and the sign-in window never opens. Microsoft recommends a custom user data folder for exactly this reason. The InPrivate controller profile does not remove the need for a writable environment folder.

## User impact

Signing in works on a normally installed Sonora on Windows, without running it as administrator.

## Notes

The folder is `dirs::cache_dir()/sonora/webview2`, which is `%LOCALAPPDATA%\sonora\webview2` on Windows and matches the cache root every other crate already uses. The temp dir stays as the fallback when no cache dir exists.

## Validation

- `cargo check -p webview` on Linux, which compiles the Linux backend only.
- `rustfmt --edition 2024 crates/webview/src/windows.rs`
- The Windows target is not installed here, so `windows.rs` was not compiled. I verified the `CreateCoreWebView2EnvironmentWithOptions` signature and the `Param` impls against webview2-com-sys 0.39.0 and windows-core 0.62.2 by hand. The fix is untested on Windows; a release build is the first real check.
