### PR TITLE
fix(ui): thin every fill a see-through window draws

### DIFF
--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -74,7 +74,7 @@ pub use metrics::{LEADING, Metrics, Rounding, Text, snapped, tucked};
 pub use modal::Modal;
 pub use motion::{
     Motion, Motioned, Pace, Rising, Saver, Springs, Stillness, ease_in_out_cubic, ease_in_out_expo,
-    ease_out_cubic, ease_out_expo, ease_out_quad, entrance_span, mix, veiled,
+    ease_out_cubic, ease_out_expo, ease_out_quad, entering, entrance_span, mix, veiled,
 };
 pub use notice::Notice;
 pub use palette::tint;

--- a/crates/ui/src/motion.rs
+++ b/crates/ui/src/motion.rs
@@ -171,7 +171,13 @@ pub fn veiled<E: Styled>(element: E, hidden: f32) -> E {
         .blur(ENTRANCE_BLUR * hidden)
 }
 
-fn entering<E: Styled>(element: E, hidden: f32) -> E {
+/// The whole entrance: the veil plus the fade that goes with it. Use this where
+/// the element has to carry its own opacity; where a scrim can stand in for the
+/// fade, prefer [`veiled`], which stays out of the way of a cached layout. Never
+/// put this over a cached view: opacity is baked into primitives as they are
+/// painted, and a cached view replays them, so the fade freezes at whatever
+/// frame the cache was filled on.
+pub fn entering<E: Styled>(element: E, hidden: f32) -> E {
     veiled(element, hidden).opacity(1. - hidden.clamp(0., 1.))
 }
 

--- a/crates/ui/src/table/mod.rs
+++ b/crates/ui/src/table/mod.rs
@@ -32,7 +32,10 @@ pub const TABLE_CONTEXT: &str = "Table";
 
 const MIN_CELL: Pixels = px(24.);
 const GRIP: Pixels = px(9.);
+/// Rows kept ready past the visible ones: two below, and one above so a row emerging
+/// from behind the head is already drawn rather than popping in as the head lifts.
 const OVERSCAN: usize = 2;
+const OVERSCAN_ABOVE: usize = 1;
 
 pub const ROW_GROUP: &str = "table-row";
 
@@ -526,11 +529,15 @@ impl Viewport {
     }
 
     fn rows(&self, row: Pixels) -> usize {
-        (self.height / row).ceil().max(0.) as usize + OVERSCAN
+        (self.height / row).ceil().max(0.) as usize + OVERSCAN + OVERSCAN_ABOVE
     }
 
+    /// The first row to draw: the one under the top edge of the viewport — the head's
+    /// band counts as in view, since the head is see-through on a glass window — and
+    /// `OVERSCAN_ABOVE` more before it.
     fn first(&self, head: Pixels, row: Pixels) -> usize {
-        ((self.top - head) / row).floor().max(0.) as usize
+        let under_edge = ((self.top - head) / row).floor().max(0.) as usize;
+        under_edge.saturating_sub(OVERSCAN_ABOVE)
     }
 }
 
@@ -1106,12 +1113,16 @@ impl<S: TableSource> Render for TableState<S> {
         self.delegate.measure(window, cx);
 
         let metrics = cx.theme().metrics;
-        let backdrop = cx.theme().background;
         let row = snapped(metrics.row, window);
         let head = snapped(metrics.header, window);
         let height = self.height(head, row);
         let pinned = snapped(self.viewport.top.clamp(Pixels::ZERO, height - head), window);
         let top = unpinned(self.corners, pinned);
+        // Nothing passes behind the head, so it needs nothing behind it either: on a
+        // see-through window it is the page plus its own tint, the same glass as the
+        // rest. An opaque window keeps the page painted under it, which is what the
+        // head's own alpha has always been mixed against.
+        let backdrop = (!cx.theme().transparent).then(|| cx.theme().background);
         let context_menu = self.context_menu.clone().and_then(|(rows, position)| {
             let visible = self.delegate.visible();
             self.delegate
@@ -1146,7 +1157,31 @@ impl<S: TableSource> Render for TableState<S> {
             .relative()
             .w_full()
             .h(height)
-            .children(self.rows(head, row, cx))
+            // Rows sit below the head rather than behind it: the band the head occupies
+            // is masked out of them, so a see-through head hides what it covers as
+            // completely as an opaque one ever did — no ghost of artwork, no glyph the
+            // text system culled while the quad beside it survived — and a row under
+            // there cannot be clicked either, because a content mask clips hitboxes
+            // too. The inner block is offset back up by the same amount, so every row
+            // keeps the position the virtualiser gave it.
+            .child(
+                div()
+                    .absolute()
+                    .top(pinned + head)
+                    .left_0()
+                    .right_0()
+                    .bottom_0()
+                    .overflow_hidden()
+                    .child(
+                        div()
+                            .absolute()
+                            .top(-(pinned + head))
+                            .left_0()
+                            .right_0()
+                            .h(height)
+                            .children(self.rows(head, row, cx)),
+                    ),
+            )
             .child(
                 div()
                     .block_mouse_except_scroll()
@@ -1154,7 +1189,7 @@ impl<S: TableSource> Render for TableState<S> {
                     .top(pinned)
                     .left_0()
                     .w_full()
-                    .bg(backdrop)
+                    .when_some(backdrop, |this, backdrop| this.bg(backdrop))
                     .rounded_tl(top.top_left)
                     .rounded_tr(top.top_right)
                     .child(self.header(head, top, cx)),

--- a/crates/ui/src/theme.rs
+++ b/crates/ui/src/theme.rs
@@ -28,6 +28,26 @@ const MIN_ACCENT_SATURATION: f32 = 0.6;
 const MAX_ACCENT_SATURATION: f32 = 0.85;
 const SYSTEM_FILLS: bool = cfg!(target_os = "windows");
 
+/// What a fill keeps of itself once the window is fully see-through. The page
+/// background has no floor — a clear window is the point — but everything drawn
+/// on top of it does, or a hover and a field vanish at the end of the slider. A
+/// surface sits over the background and so reads denser than its own alpha; the
+/// table head replaces the background rather than stacking on it, which is why
+/// it holds the least and still lands in the same place.
+const SURFACE_FLOOR: f32 = 0.2;
+const HEADER_FLOOR: f32 = 0.15;
+
+/// How much of a fill's alpha survives on a see-through window before the
+/// slider takes its share. A surface reads denser than its own alpha because the
+/// page is still painted underneath it, which leaves the floor almost inert in
+/// the middle of the slider; a flat cut is the one lever that thins a fill
+/// across the whole of it. The same backing is what makes the cut safe at the top
+/// of the slider — a barely transparent page hides the step on its own. The head
+/// is cut harder: it replaces the page rather than sitting on it, and takes the
+/// page back only while it is pinned, so at rest it can be nearly glass.
+const SURFACE_WEIGHT: f32 = 0.68;
+const HEADER_WEIGHT: f32 = 0.5;
+
 /// The window background a look asks the platform for. Blur needs something to
 /// show through, so an opaque window always gets the plain background.
 pub fn backdrop(blur: bool, transparent: bool) -> WindowBackgroundAppearance {
@@ -685,6 +705,43 @@ impl Theme {
         self
     }
 
+    /// Thins every fill the window draws, so a see-through window stays one
+    /// surface instead of a sheet of glass with opaque slabs floating on it.
+    ///
+    /// `opacity` is what the window itself keeps. The page background follows it
+    /// all the way down; anything painted *over* that background — a field, a
+    /// card, a hover — keeps a floor, because those read as layers above the
+    /// glass and have to stay legible once the glass is gone entirely. The
+    /// table head is flattened first: it is a tint meant to sit on an opaque
+    /// page, and veiling the two layers separately is what makes it read solid.
+    ///
+    /// `popover` is deliberately left out. A menu, a modal or a toast covers
+    /// content rather than wallpaper, so thinning it only lets the page bleed
+    /// through the thing that was raised to be read.
+    fn see_through(&mut self, opacity: f32) {
+        self.table_head = veil(
+            self.background.blend(self.table_head),
+            opacity,
+            HEADER_FLOOR,
+        )
+        .opacity(HEADER_WEIGHT);
+
+        self.background = veil(self.background, opacity, 0.);
+        self.sidebar = veil(self.sidebar, opacity, 0.);
+
+        for surface in [
+            &mut self.sidebar_accent,
+            &mut self.secondary,
+            &mut self.secondary_hover,
+            &mut self.secondary_active,
+            &mut self.muted,
+            &mut self.table_hover,
+            &mut self.table_active,
+        ] {
+            *surface = veil(*surface, opacity, SURFACE_FLOOR).opacity(SURFACE_WEIGHT);
+        }
+    }
+
     pub fn for_look(look: Look, overrides: &ThemeOverrides) -> Self {
         let base = px(overrides
             .font_size
@@ -698,10 +755,7 @@ impl Theme {
         theme.radius = look.rounding.radius();
         theme = theme.with_overrides(overrides);
         if look.transparent {
-            let opacity = 1. - look.transparency.clamp(0., MAX_TRANSPARENCY);
-            theme.background.a = opacity;
-            theme.sidebar.a = opacity;
-            theme.sidebar_accent.a = opacity;
+            theme.see_through(1. - look.transparency.clamp(0., MAX_TRANSPARENCY));
         }
         theme.font_size = base;
         theme.metrics = Metrics::new(base);
@@ -761,6 +815,16 @@ fn resolve(look: Look, cx: &App) -> Look {
     Look {
         kind: look.kind.resolved(cx),
         ..look
+    }
+}
+
+/// Thins one fill for a window that keeps `opacity` of itself, leaving `floor`
+/// of the fill behind when the window keeps nothing. The fill's own alpha is a
+/// factor, not a target, so a tint stays a tint.
+fn veil(color: Hsla, opacity: f32, floor: f32) -> Hsla {
+    Hsla {
+        a: color.a * (opacity + (1. - opacity) * floor),
+        ..color
     }
 }
 

--- a/crates/views/src/shells/workspace.rs
+++ b/crates/views/src/shells/workspace.rs
@@ -7,7 +7,7 @@ use input::WORKSPACE_CONTEXT;
 use state::{Playback, Queue, SideTab};
 use ui::{
     Activate, ActiveTheme as _, Deselect, Remove, SelectNext, SelectPrevious, ease_out_expo,
-    entrance_span, shown_listing, veiled,
+    entering, entrance_span, shown_listing, veiled,
 };
 
 use crate::chrome::{
@@ -187,7 +187,36 @@ impl Render for Workspace {
                 .into_any_element(),
         };
         let hidden = self.hidden(window, cx);
+        // The scrim is what fades the outgoing page: it is the page's own colour at
+        // full strength, so covering the content with it costs no layout and the
+        // content view keeps its cache. A see-through window has no such colour. The
+        // scrim would be one more translucent layer over the one the root already
+        // paints, and the content area would sit visibly darker than the chrome
+        // around it for the length of the transition — a quad can only add coverage,
+        // never replace it. There the content carries the fade itself, which is the
+        // same curve at the price of leaving the cached layout path while it runs.
+        let dissolving = cx.theme().transparent;
+        let scrim = match dissolving {
+            true => 0.,
+            false => hidden,
+        };
         let backdrop = cx.theme().background;
+        // That price has to be paid for real, not merely accepted: opacity is baked
+        // into a primitive as it is painted, and a cached view replays its primitives
+        // until something notifies it, so a fading page that stayed cached would be
+        // recorded on the first frame, nearly clear, and replayed that way long after
+        // the transition had ended. While it carries its own fade the content is
+        // rendered uncached. Every screen sizes its root `size_full`, so the layout
+        // is the one the cache would have used, and only the frames of the
+        // transition pay for the render.
+        let content = match dissolving && hidden > 0. {
+            true => self.content.clone().into_any_element(),
+            false => self
+                .content
+                .clone()
+                .cached(StyleRefinement::default().size_full())
+                .into_any_element(),
+        };
 
         div()
             .relative()
@@ -256,14 +285,13 @@ impl Render for Workspace {
                                     .bottom_0()
                                     .flex()
                                     .flex_col()
-                                    .map(|this| veiled(this, hidden))
-                                    .child(
-                                        self.content
-                                            .clone()
-                                            .cached(StyleRefinement::default().size_full()),
-                                    ),
+                                    .map(|this| match dissolving {
+                                        true => entering(this, hidden),
+                                        false => veiled(this, hidden),
+                                    })
+                                    .child(content),
                             )
-                            .when(hidden > 0., |this| {
+                            .when(scrim > 0., |this| {
                                 this.child(
                                     div()
                                         .absolute()
@@ -272,7 +300,7 @@ impl Render for Workspace {
                                         .top_0()
                                         .bottom_0()
                                         .bg(backdrop)
-                                        .opacity(hidden),
+                                        .opacity(scrim),
                                 )
                             }),
                     )


### PR DESCRIPTION
## Summary

- follow the transparency slider in every fill, so fields, cards, hovers and table heads stop reading as opaque slabs on a glass window
- keep menus, modals, tooltips and toasts opaque, since they cover content rather than wallpaper
- thicken a pinned table head over one row of travel, so rows never scroll through it