### PR TITLE
perf(views): draw only the pinned entries on screen in the sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The left sidebar stays smooth with a long Pinned section or Show full library on. It used to
+  build every entry on every frame, even the ones scrolled out of view. Now it draws only the rows
+  on screen and rebuilds the list only when something in it changes.
 - On Nix, the YouTube Music sign-in no longer goes black after the email step. The package now
   gives WebKit the GStreamer plugins it needs to play a page's media.
 - On Windows, the sign-in window opens when Sonora is installed under Program Files. It used to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - On Nix, the YouTube Music sign-in no longer goes black after the email step. The package now
   gives WebKit the GStreamer plugins it needs to play a page's media.
+- On Windows, the sign-in window opens when Sonora is installed under Program Files. It used to
+  fail with `0x80070005` because the browser it embeds tried to keep its data next to the program,
+  where a normal user cannot write. That data now lives under your local app data.
 
 ## [0.34.3] - 2026-09-12
 

--- a/crates/state/src/pins.rs
+++ b/crates/state/src/pins.rs
@@ -1,4 +1,7 @@
+use std::cell::OnceCell;
 use std::collections::HashSet;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::rc::Rc;
 
 use gpui::{App, Context, Entity};
 use music::{LibraryItem, LibraryItemKind};
@@ -50,6 +53,14 @@ pub struct Pins {
     session: Entity<Session>,
     /// The uris the provider last reported as pinned, so only a change since then is followed.
     mirrored: HashSet<String>,
+    /// `entries` as last laid out. Cleared whenever the settings, the session or the library
+    /// move, so a frame reads the list without rebuilding it.
+    laid: OnceCell<Rc<Vec<Pin>>>,
+    /// `library` as last laid out, cleared alongside `laid`.
+    rest: OnceCell<Rc<Vec<Pin>>>,
+    /// The digest of what the shelves last listed, so a library notify that changed nothing
+    /// the sidebar shows does not rebuild it.
+    seen: u64,
 }
 
 impl Pins {
@@ -59,30 +70,89 @@ impl Pins {
         session: Entity<Session>,
         cx: &mut Context<Self>,
     ) -> Self {
-        cx.observe(&library, |this, _, cx| this.absorb(cx)).detach();
-        cx.observe(&settings, |_, _, cx| cx.notify()).detach();
-        cx.observe(&session, |_, _, cx| cx.notify()).detach();
+        cx.observe(&library, |this, _, cx| {
+            this.absorb(cx);
+            let seen = this.fingerprint(cx);
+            if this.seen != seen {
+                this.seen = seen;
+                this.changed(cx);
+            }
+        })
+        .detach();
+        cx.observe(&settings, |this, _, cx| this.changed(cx))
+            .detach();
+        cx.observe(&session, |this, _, cx| this.changed(cx))
+            .detach();
 
         Self {
             settings,
             library,
             session,
             mirrored: HashSet::new(),
+            laid: OnceCell::new(),
+            rest: OnceCell::new(),
+            seen: 0,
         }
     }
 
-    /// Every pin of the live providers, laid out the way the user asked for.
-    pub fn entries(&self, cx: &App) -> Vec<Pin> {
-        let slugs = self.session.read(cx).active_slugs();
-        let mut pinned = self.settings.read(cx).pinned(&slugs);
-        self.lay_out(&mut pinned, cx);
-        pinned
+    /// Every pin of the live providers, laid out the way the user asked for. The list is built
+    /// once per change and shared afterwards.
+    pub fn entries(&self, cx: &App) -> Rc<Vec<Pin>> {
+        self.laid
+            .get_or_init(|| {
+                let slugs = self.session.read(cx).active_slugs();
+                let mut pinned = self.settings.read(cx).pinned(&slugs);
+                self.lay_out(&mut pinned, cx);
+                Rc::new(pinned)
+            })
+            .clone()
     }
 
     /// Everything the live shelves hold that is not pinned: albums, artists and playlists, laid
     /// out the same way the pins above them are. Nothing else a provider lists belongs here,
-    /// since the sidebar can only open these three.
-    pub fn library(&self, cx: &App) -> Vec<Pin> {
+    /// since the sidebar can only open these three. Built once per change, like `entries`.
+    pub fn library(&self, cx: &App) -> Rc<Vec<Pin>> {
+        self.rest
+            .get_or_init(|| Rc::new(self.gather_library(cx)))
+            .clone()
+    }
+
+    /// A digest of the albums, artists and playlists the live shelves list, with the names
+    /// and covers the sidebar shows for them.
+    fn fingerprint(&self, cx: &App) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        let library = self.library.read(cx);
+        for shelf in [Shelf::Streaming, Shelf::Local] {
+            if self.session.read(cx).client_of(shelf).is_none() {
+                continue;
+            }
+            let held = library.state(shelf);
+            for playlist in held.playlists() {
+                (&playlist.id, &playlist.name, &playlist.cover).hash(&mut hasher);
+            }
+            for album in held.albums() {
+                (&album.id, &album.name, &album.cover_large, &album.cover).hash(&mut hasher);
+            }
+            for artist in held.artists() {
+                (&artist.id, &artist.name, &artist.cover).hash(&mut hasher);
+            }
+        }
+        hasher.finish()
+    }
+
+    /// Drops both laid-out lists so the next read rebuilds them.
+    fn forget(&mut self) {
+        self.laid.take();
+        self.rest.take();
+    }
+
+    /// Forgets the laid-out lists and tells the observers.
+    fn changed(&mut self, cx: &mut Context<Self>) {
+        self.forget();
+        cx.notify();
+    }
+
+    fn gather_library(&self, cx: &App) -> Vec<Pin> {
         let pinned = self.dragged(cx);
         let library = self.library.read(cx);
         let mut rest = Vec::new();
@@ -157,7 +227,7 @@ impl Pins {
         self.settings.update(cx, |settings, cx| {
             settings.set_sidebar_pin_sort(sort, reversed, cx)
         });
-        cx.notify();
+        self.changed(cx);
     }
 
     pub fn holds(&self, pin: &Pin, cx: &App) -> bool {
@@ -190,7 +260,7 @@ impl Pins {
         if !known {
             self.tell(&pin, true, cx);
         }
-        cx.notify();
+        self.changed(cx);
     }
 
     pub fn unpin(&mut self, pin: Pin, cx: &mut Context<Self>) {
@@ -200,7 +270,7 @@ impl Pins {
         self.settings
             .update(cx, |settings, cx| settings.unpin(slug, &pin, cx));
         self.tell(&pin, false, cx);
-        cx.notify();
+        self.changed(cx);
     }
 
     /// Mirrors a change into the provider's own pins. Nothing happens for a provider that keeps
@@ -238,6 +308,7 @@ impl Pins {
             settings.rearrange(&shown, &slugs, cx);
             settings.set_sidebar_pin_sort(None, false, cx);
         });
+        self.forget();
     }
 
     /// Puts the local list back after the provider refused the change.
@@ -250,7 +321,7 @@ impl Pins {
             true => settings.unpin(slug, &pin, cx),
             false => settings.pin(slug, pin, None, &slugs, cx),
         });
-        cx.notify();
+        self.changed(cx);
     }
 
     /// The provider's own uri for a pin, when the provider lists it and keeps pins itself.
@@ -317,7 +388,7 @@ impl Pins {
                 settings.pin(slug, pin, None, &slugs, cx);
             }
         });
-        cx.notify();
+        self.changed(cx);
     }
 }
 

--- a/crates/ui/src/deck.rs
+++ b/crates/ui/src/deck.rs
@@ -1,18 +1,25 @@
 use std::ops::Range;
+use std::panic::Location;
 
 use gpui::prelude::*;
-use gpui::{AnyElement, App, Div, ElementId, Pixels, StyleRefinement, Window, div};
+use gpui::{
+    AnyElement, App, AvailableSpace, Bounds, ElementId, GlobalElementId, InspectorElementId,
+    LayoutId, Pixels, Style, StyleRefinement, Window, div, point, relative, size,
+};
 
 use crate::table::Viewport;
 
 type Draw = Box<dyn Fn(usize, &mut Window, &mut App) -> AnyElement>;
 type Measure = Box<dyn Fn(Pixels, &mut Window, &mut App)>;
 
-#[derive(IntoElement)]
+/// A run of rows of known heights inside a scrolling region, of which only the ones in view are
+/// built. The element takes the extent of the whole run, so the region scrolls and its
+/// scrollbar measures as if every row were there, and it finds the rows on screen from its own
+/// bounds and the region's clip while it is laid out, so it is never a frame behind the scroll
+/// and needs nothing measured by its caller. `across` turns the run sideways for a rail.
 pub struct Deck {
-    base: Div,
     id: ElementId,
-    viewport: Viewport,
+    style: StyleRefinement,
     rows: Vec<Pixels>,
     gap: Pixels,
     across: bool,
@@ -24,9 +31,8 @@ impl Deck {
     #[track_caller]
     pub fn new(id: impl Into<ElementId>) -> Self {
         Self {
-            base: div(),
             id: id.into(),
-            viewport: Viewport::default(),
+            style: StyleRefinement::default(),
             rows: Vec::new(),
             gap: Pixels::ZERO,
             across: false,
@@ -40,11 +46,6 @@ impl Deck {
         self
     }
 
-    pub fn viewport(mut self, viewport: Viewport) -> Self {
-        self.viewport = viewport;
-        self
-    }
-
     pub fn rows(mut self, rows: impl IntoIterator<Item = Pixels>) -> Self {
         self.rows = rows.into_iter().collect();
         self
@@ -55,6 +56,7 @@ impl Deck {
         self
     }
 
+    /// Builds the row at an index. Asked only for the rows in view, every frame they are.
     pub fn draw(
         mut self,
         draw: impl Fn(usize, &mut Window, &mut App) -> AnyElement + 'static,
@@ -63,6 +65,9 @@ impl Deck {
         self
     }
 
+    /// Reports where the run's leading edge landed, in window coordinates, once it is laid
+    /// out. A caller that aims a scroll at one of the rows needs that to know how far down the
+    /// region the run begins.
     pub fn on_measure(mut self, measure: impl Fn(Pixels, &mut Window, &mut App) + 'static) -> Self {
         self.measure = Some(Box::new(measure));
         self
@@ -85,62 +90,134 @@ impl Deck {
 
 impl Styled for Deck {
     fn style(&mut self) -> &mut StyleRefinement {
-        self.base.style()
+        &mut self.style
     }
 }
 
-impl RenderOnce for Deck {
-    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
-        let Self {
-            mut base,
-            id,
-            viewport,
-            rows,
-            gap,
-            across,
-            draw,
-            measure,
-        } = self;
+impl IntoElement for Deck {
+    type Element = Self;
 
-        let tops = tops(&rows, gap);
-        let shown = span(&tops, &rows, viewport);
-        let overrides = std::mem::take(base.style());
-        let first = tops.get(shown.start).copied().unwrap_or(Pixels::ZERO);
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
 
-        let base = base.when_some(measure, |this, measure| {
-            this.on_children_prepainted(move |bounds, window, cx| {
-                let Some(head) = bounds.first() else {
-                    return;
+impl Element for Deck {
+    type RequestLayoutState = ();
+    type PrepaintState = Vec<AnyElement>;
+
+    fn id(&self) -> Option<ElementId> {
+        Some(self.id.clone())
+    }
+
+    fn source_location(&self) -> Option<&'static Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        let reach = extent(&self.rows, self.gap);
+        let mut style = Style::default();
+        match self.across {
+            true => {
+                style.size.width = reach.into();
+                style.size.height = relative(1.).into();
+            }
+            false => {
+                style.size.width = relative(1.).into();
+                style.size.height = reach.into();
+            }
+        }
+        style.flex_shrink = 0.;
+        style.refine(&self.style);
+
+        (window.request_layout(style, [], cx), ())
+    }
+
+    fn prepaint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Self::PrepaintState {
+        let across = self.across;
+        let lead = match across {
+            true => bounds.origin.x,
+            false => bounds.origin.y,
+        };
+        if let Some(measure) = &self.measure {
+            measure(lead, window, cx);
+        }
+        let Some(draw) = &self.draw else {
+            return Vec::new();
+        };
+
+        // The region clips to its own bounds, so the mask is the part of the run on screen.
+        let view = window.content_mask().bounds;
+        let viewport = match across {
+            true => Viewport {
+                top: view.origin.x - lead,
+                height: view.size.width,
+            },
+            false => Viewport {
+                top: view.origin.y - lead,
+                height: view.size.height,
+            },
+        };
+        let tops = tops(&self.rows, self.gap);
+        let shown = span(&tops, &self.rows, viewport);
+
+        let mut built = Vec::with_capacity(shown.len());
+        for index in shown {
+            let (width, height) = match across {
+                true => (self.rows[index], bounds.size.height),
+                false => (bounds.size.width, self.rows[index]),
+            };
+            let mut element = div()
+                .overflow_hidden()
+                .w(width)
+                .h(height)
+                .child(draw(index, window, cx))
+                .into_any_element();
+            element.layout_as_root(
+                size(
+                    AvailableSpace::Definite(width),
+                    AvailableSpace::Definite(height),
+                ),
+                window,
+                cx,
+            );
+            let origin = bounds.origin
+                + match across {
+                    true => point(tops[index], Pixels::ZERO),
+                    false => point(Pixels::ZERO, tops[index]),
                 };
-                let start = match across {
-                    true => head.origin.x,
-                    false => head.origin.y,
-                };
-                measure(start - first, window, cx);
-            })
-        });
-        let reach = extent(&rows, gap);
+            element.prepaint_at(origin, window, cx);
+            built.push(element);
+        }
+        built
+    }
 
-        let mut deck = base.id(id).relative().when_else(
-            across,
-            |this| this.h_full().w(reach),
-            |this| this.w_full().h(reach),
-        );
-        deck.style().refine(&overrides);
-
-        match draw {
-            None => deck,
-            Some(draw) => deck.children(shown.map(|index| {
-                div()
-                    .absolute()
-                    .when_else(
-                        across,
-                        |this| this.left(tops[index]).top_0().h_full().w(rows[index]),
-                        |this| this.top(tops[index]).left_0().w_full().h(rows[index]),
-                    )
-                    .overflow_hidden()
-                    .child(draw(index, window, cx))
-            })),
+    fn paint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        built: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        for element in built {
+            element.paint(window, cx);
         }
     }
 }
@@ -167,6 +244,7 @@ fn extent(rows: &[Pixels], gap: Pixels) -> Pixels {
     }
 }
 
+/// The rows that overlap the viewport, `top` being how far into the run the viewport starts.
 fn span(tops: &[Pixels], rows: &[Pixels], viewport: Viewport) -> Range<usize> {
     if tops.is_empty() {
         return 0..0;

--- a/crates/views/src/chrome/sidebar_left.rs
+++ b/crates/views/src/chrome/sidebar_left.rs
@@ -1,6 +1,9 @@
+use std::rc::Rc;
+
 use ui::{
-    ActiveTheme as _, Button, Card, DraggedPin, Edge, MenuItem, Panel, Picker, Pin, Pinnable as _,
-    Popup, SNUG, Scroller, Shield, Side, Spot, Tabs, Text, Vacancy, drop_gap, drop_marker,
+    ActiveTheme as _, Button, Card, Deck, DraggedPin, Edge, MenuItem, Panel, Picker, Pin,
+    Pinnable as _, Popup, SNUG, Scroller, Shield, Side, Spot, Tabs, Text, Vacancy, drop_gap,
+    drop_marker,
 };
 
 use gpui::prelude::*;
@@ -70,6 +73,27 @@ const HINT_HEIGHT: Pixels = px(42.);
 const VACANCY_HEIGHT: Pixels = px(88.);
 /// How far the pin mark on a library row falls back from the accent.
 const PIN_MARK: f32 = 0.7;
+/// The space between two pinned entries, the same as the `gap_1` between the rows above them.
+const ROW_GAP: Pixels = px(4.);
+
+/// The three navigation entries that expand into tabs rather than navigate.
+#[derive(Clone, Copy, PartialEq)]
+enum Group {
+    Library,
+    Local,
+    Settings,
+}
+
+impl Group {
+    fn of(destination: &Destination) -> Option<Self> {
+        match destination {
+            Destination::Library(_) => Some(Self::Library),
+            Destination::Local(_) => Some(Self::Local),
+            Destination::Settings(_) => Some(Self::Settings),
+            _ => None,
+        }
+    }
+}
 
 pub(crate) struct SidebarLeft {
     settings: Entity<AppSettings>,
@@ -241,8 +265,29 @@ impl SidebarLeft {
         }
     }
 
-    /// The pinned section: its header, and its entries once it is expanded.
-    fn pins(&self, cx: &mut Context<Self>) -> Vec<AnyElement> {
+    /// The navigation entries, each followed by its tabs while its group is open.
+    fn navigation(&self, cx: &mut Context<Self>) -> Vec<AnyElement> {
+        let authenticated = self.session.read(cx).authenticated();
+        let mut rows = Vec::new();
+        for (index, (entry, _, destination)) in NAV.iter().enumerate() {
+            if entry.is_some_and(|entry| !self.settings.read(cx).nav_shown(entry.id())) {
+                continue;
+            }
+            let group = Group::of(destination);
+            if group == Some(Group::Library) && !authenticated {
+                continue;
+            }
+            rows.push(self.nav(index, cx));
+            if let Some(group) = group.filter(|group| self.opened(*group)) {
+                rows.push(self.tabs(group, cx));
+            }
+        }
+        rows
+    }
+
+    /// The pinned section: its header, and its entries once it is expanded. The entries are a
+    /// `Deck`, so only the ones on screen are ever built.
+    fn pins(&self, window: &Window, cx: &mut Context<Self>) -> Vec<AnyElement> {
         if !self.settings.read(cx).nav_shown(NavEntry::Pins.id()) {
             return Vec::new();
         }
@@ -252,11 +297,11 @@ impl SidebarLeft {
             return rows;
         }
 
-        let pinned = self.pins.read(cx).entries(cx);
-        let count = pinned.len();
+        let pins = self.pins.read(cx);
+        let pinned = pins.entries(cx);
         let rest = match self.settings.read(cx).sidebar_full_library() {
-            true => self.pins.read(cx).library(cx),
-            false => Vec::new(),
+            true => pins.library(cx),
+            false => Rc::new(Vec::new()),
         };
         if pinned.is_empty() && rest.is_empty() {
             rows.push(match self.dropping {
@@ -266,14 +311,43 @@ impl SidebarLeft {
             return rows;
         }
 
-        rows.extend(
-            pinned
-                .into_iter()
-                .chain(rest)
-                .enumerate()
-                .map(|(index, pin)| self.pin_row(index, pin, count, cx)),
+        let held = pinned.len();
+        let count = held + rest.len();
+        let row = ui::snapped(cx.theme().metrics.list_row, window);
+        rows.push(
+            Deck::new("sidebar-pins-deck")
+                .rows((0..count).map(|_| row))
+                .gap(ROW_GAP)
+                .draw(cx.processor(move |this, index: usize, _, cx| {
+                    let pin = match index < held {
+                        true => pinned.get(index),
+                        false => rest.get(index - held),
+                    };
+                    match pin {
+                        Some(pin) => this.pin_row(index, pin.clone(), held, cx),
+                        None => div().into_any_element(),
+                    }
+                }))
+                .into_any_element(),
         );
         rows
+    }
+
+    fn opened(&self, group: Group) -> bool {
+        match group {
+            Group::Library => self.library_open,
+            Group::Local => self.local_open,
+            Group::Settings => self.settings_open,
+        }
+    }
+
+    fn flip(&mut self, group: Group) {
+        let open = match group {
+            Group::Library => &mut self.library_open,
+            Group::Local => &mut self.local_open,
+            Group::Settings => &mut self.settings_open,
+        };
+        *open = !*open;
     }
 
     fn pins_header(&self, cx: &mut Context<Self>) -> AnyElement {
@@ -388,7 +462,7 @@ impl SidebarLeft {
         .into_any_element()
     }
 
-    /// One entry. The first `count` of them are the pins, which carry the drop slots; the rest
+    /// One entry. The first `count` of them are the pins, which carry the drop slots. The rest
     /// is the library underneath, which can be dragged up into the pins but holds no slot.
     fn pin_row(&self, index: usize, pin: Pin, count: usize, cx: &mut Context<Self>) -> AnyElement {
         let theme = *cx.theme();
@@ -467,145 +541,75 @@ impl SidebarLeft {
             .into_any_element()
     }
 
-    fn navigation(&mut self, cx: &mut Context<Self>) -> Vec<AnyElement> {
+    /// One navigation entry. An expandable one flips its group open and shut, any other one
+    /// navigates and is lit while its section is current.
+    fn nav(&self, index: usize, cx: &mut Context<Self>) -> AnyElement {
         let theme = *cx.theme();
-        let sidebar_accent = theme.sidebar_accent;
-        let foreground = theme.foreground;
-        let muted = theme.muted_foreground;
+        let accent = theme.sidebar_accent;
+        let (entry, icon, destination) = NAV[index].clone();
+        let key = entry.map_or("nav-settings", NavEntry::key);
         let current = self.trail.read(cx).current();
-        let authenticated = self.session.read(cx).authenticated();
-        let shown = |entry: NavEntry, cx: &App| self.settings.read(cx).nav_shown(entry.id());
+        let group = Group::of(&destination);
+        let active = match group {
+            Some(group) => Group::of(&current) == Some(group),
+            None => destination.same_section(&current),
+        };
+        let tint = match active {
+            true => theme.foreground,
+            false => theme.muted_foreground,
+        };
+        let row = nav_row(index, key, tint, accent).icon(icon);
 
-        let mut rows: Vec<AnyElement> = Vec::new();
-        for (index, (entry, icon, destination)) in NAV.into_iter().enumerate() {
-            let key = entry.map_or("nav-settings", NavEntry::key);
-            if entry.is_some_and(|entry| !shown(entry, cx)) {
-                continue;
-            }
-
-            if matches!(destination, Destination::Library(_)) {
-                if !authenticated {
-                    continue;
-                }
-                let inside = matches!(current, Destination::Library(_));
-                let text = if inside { foreground } else { muted };
-
-                rows.push(
-                    nav_row(index, key, text, sidebar_accent)
-                        .icon(icon)
-                        .trailing(chevron(self.library_open))
-                        .on_click(cx.listener(|this, _, _, cx| {
-                            this.library_open = !this.library_open;
-                            cx.notify();
-                        }))
-                        .into_any_element(),
-                );
-
-                if self.library_open {
-                    rows.push(
-                        Tabs::new()
-                            .items(LIBRARY_TABS.into_iter().map(|(name, tab)| {
-                                let chosen = current == Destination::Library(tab);
-                                let tint = if chosen { foreground } else { muted };
-
-                                nav_row(name, name, tint, sidebar_accent)
-                                    .flex_1()
-                                    .when(chosen, |button| button.bg(sidebar_accent))
-                                    .on_click(move |_, _, cx| {
-                                        navigate(Destination::Library(tab), cx)
-                                    })
-                            }))
-                            .into_any_element(),
-                    );
-                }
-                continue;
-            }
-
-            if matches!(destination, Destination::Local(_)) {
-                let inside = matches!(current, Destination::Local(_));
-                let text = if inside { foreground } else { muted };
-
-                rows.push(
-                    nav_row(index, key, text, sidebar_accent)
-                        .icon(icon)
-                        .trailing(chevron(self.local_open))
-                        .on_click(cx.listener(|this, _, _, cx| {
-                            this.local_open = !this.local_open;
-                            cx.notify();
-                        }))
-                        .into_any_element(),
-                );
-
-                if self.local_open {
-                    rows.push(
-                        Tabs::new()
-                            .items(LIBRARY_TABS.into_iter().enumerate().map(
-                                |(slot, (name, tab))| {
-                                    let chosen = current == Destination::Local(tab);
-                                    let tint = if chosen { foreground } else { muted };
-
-                                    nav_row(("local-tab", slot as u32), name, tint, sidebar_accent)
-                                        .flex_1()
-                                        .when(chosen, |button| button.bg(sidebar_accent))
-                                        .on_click(move |_, _, cx| {
-                                            navigate(Destination::Local(tab), cx)
-                                        })
-                                },
-                            ))
-                            .into_any_element(),
-                    );
-                }
-                continue;
-            }
-
-            if matches!(destination, Destination::Settings(_)) {
-                let inside = matches!(current, Destination::Settings(_));
-                let text = if inside { foreground } else { muted };
-
-                rows.push(
-                    nav_row(index, key, text, sidebar_accent)
-                        .icon(icon)
-                        .trailing(chevron(self.settings_open))
-                        .on_click(cx.listener(|this, _, _, cx| {
-                            this.settings_open = !this.settings_open;
-                            cx.notify();
-                        }))
-                        .into_any_element(),
-                );
-
-                if self.settings_open {
-                    rows.push(
-                        Tabs::new()
-                            .items(SETTINGS_TABS.into_iter().map(|(name, tab)| {
-                                let chosen = current == Destination::Settings(tab);
-                                let tint = if chosen { foreground } else { muted };
-
-                                nav_row(name, name, tint, sidebar_accent)
-                                    .flex_1()
-                                    .when(chosen, |button| button.bg(sidebar_accent))
-                                    .on_click(move |_, _, cx| {
-                                        navigate(Destination::Settings(tab), cx)
-                                    })
-                            }))
-                            .into_any_element(),
-                    );
-                }
-                continue;
-            }
-
-            let active = destination.same_section(&current);
-            let text = if active { foreground } else { muted };
-
-            rows.push(
-                nav_row(index, key, text, sidebar_accent)
-                    .icon(icon)
-                    .when(active, |button| button.bg(sidebar_accent))
-                    .on_click(move |_, _, cx| navigate(destination.clone(), cx))
-                    .into_any_element(),
-            );
+        match group {
+            Some(group) => row
+                .trailing(chevron(self.opened(group)))
+                .on_click(cx.listener(move |this, _, _, cx| {
+                    this.flip(group);
+                    cx.notify();
+                })),
+            None => row
+                .when(active, |button| button.bg(accent))
+                .on_click(move |_, _, cx| navigate(destination.clone(), cx)),
         }
+        .into_any_element()
+    }
 
-        rows
+    /// The tabs under an expanded group.
+    fn tabs(&self, group: Group, cx: &mut Context<Self>) -> AnyElement {
+        let theme = *cx.theme();
+        let accent = theme.sidebar_accent;
+        let current = self.trail.read(cx).current();
+        let tab = |id: ElementId, key: &'static str, destination: Destination| {
+            let chosen = destination == current;
+            let tint = match chosen {
+                true => theme.foreground,
+                false => theme.muted_foreground,
+            };
+
+            nav_row(id, key, tint, accent)
+                .flex_1()
+                .when(chosen, |button| button.bg(accent))
+                .on_click(move |_, _, cx| navigate(destination.clone(), cx))
+        };
+
+        match group {
+            Group::Library => Tabs::new().items(
+                LIBRARY_TABS
+                    .into_iter()
+                    .map(|(name, tab_id)| tab(name.into(), name, Destination::Library(tab_id))),
+            ),
+            Group::Local => Tabs::new().items(LIBRARY_TABS.into_iter().enumerate().map(
+                |(slot, (name, tab_id))| {
+                    tab(("local-tab", slot).into(), name, Destination::Local(tab_id))
+                },
+            )),
+            Group::Settings => Tabs::new().items(
+                SETTINGS_TABS
+                    .into_iter()
+                    .map(|(name, tab_id)| tab(name.into(), name, Destination::Settings(tab_id))),
+            ),
+        }
+        .into_any_element()
     }
 
     fn persist(&self, cx: &mut Context<Self>) {
@@ -632,7 +636,7 @@ impl Render for SidebarLeft {
         }
 
         let mut rows = self.navigation(cx);
-        rows.extend(self.pins(cx));
+        rows.extend(self.pins(window, cx));
 
         let overlaid = self.overlays();
         let panel = Panel::new("sidebar-left", Side::Left, self.width)

--- a/crates/views/src/screens/genre.rs
+++ b/crates/views/src/screens/genre.rs
@@ -102,10 +102,8 @@ impl Render for GenreView {
         let sections = detail.sections();
         let empty = !loading && sections.is_empty();
         let (mode, width) = (self.mode, self.width);
-        let scroll = self.scrollbar.read(cx).scroll().clone();
-        let viewport = self.shelves.read(cx).viewport(&scroll, window);
         let shelves = self.shelves.update(cx, |shelves, cx| {
-            shelves.render(sections, mode, width, viewport, window, cx)
+            shelves.render(sections, mode, width, window, cx)
         });
 
         div().flex().flex_col().size_full().child(

--- a/crates/views/src/screens/home/mod.rs
+++ b/crates/views/src/screens/home/mod.rs
@@ -203,13 +203,11 @@ impl Render for HomeView {
         let sections = self.home.read(cx).sections();
         let feeding = self.home.read(cx).is_feeding();
         let width = self.width;
-        let scroll = self.scrollbar.read(cx).scroll().clone();
-        let viewport = self.shelves.read(cx).viewport(&scroll, window);
         let shelves = self
             .shelves
             .update(cx, |shelves, cx| match sections.is_empty() && feeding {
                 true => shelves.pending(width, cx),
-                false => vec![shelves.render(sections, Mode::Grid, width, viewport, window, cx)],
+                false => vec![shelves.render(sections, Mode::Grid, width, window, cx)],
             });
 
         Scroller::new("home-page", &self.scrollbar)

--- a/crates/views/src/screens/library/mod.rs
+++ b/crates/views/src/screens/library/mod.rs
@@ -792,8 +792,6 @@ impl LibraryView {
             scroll.set_offset(point(Pixels::ZERO, -(top + into + inset)));
         }
 
-        let visible = scroll.bounds().size.height;
-        let viewport = Viewport::measured(scrolled(&scroll) - inset, visible, window);
         let rows = self.card_rows.clone();
         let section = self.section;
         let view = self.me.clone();
@@ -802,7 +800,6 @@ impl LibraryView {
             .py(inset)
             .child(
                 Deck::new("library-deck")
-                    .viewport(viewport)
                     .rows(heights)
                     .gap(gap)
                     .draw(move |index, _, cx| {

--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -18,8 +18,8 @@ use state::{AlbumHit, ArtistHit, Genres, Hit, Kind, Playback, PlaylistHit, Searc
 use ui::ActiveTheme as _;
 use ui::{
     Activate, Card, Deck, Deselect, Pinnable, Popup, Room, Scrollbar, Scroller, SelectLeft,
-    SelectNext, SelectPrevious, SelectRight, Separator, Text, Theme, VAST, Viewport, clock,
-    eyebrow, scrolled, snapped, vacant,
+    SelectNext, SelectPrevious, SelectRight, Separator, Text, Theme, VAST, clock, eyebrow,
+    scrolled, snapped, vacant,
 };
 
 use crate::shared::cards;
@@ -611,10 +611,7 @@ impl SearchView {
         let theme = *cx.theme();
         let pad = theme.metrics.inset;
         let width = cells::content_width(window, pad * 2., cx);
-        let scroll = self.browsing.read(cx).scroll().clone();
-        let seen = scroll.bounds().size.height;
-        let viewport = Viewport::measured(scrolled(&scroll), seen, window);
-        let plates = shelves::grid("genre", found, width, viewport, window, cx);
+        let plates = shelves::grid("genre", found, width, window, cx);
 
         div()
             .flex()
@@ -703,17 +700,10 @@ impl SearchView {
         let theme = *cx.theme();
         let row = snapped(theme.metrics.list_row, window);
         let scroll = bar.read(cx).scroll().clone();
-        let seen = scroll.bounds().size.height;
-        let above = match lead.is_some() {
-            true => self.lead.get(),
-            false => Pixels::ZERO,
-        };
-        let viewport = Viewport::measured(scrolled(&scroll) - above, seen, window);
         let me = cx.entity().downgrade();
         let measured = self.lead.clone();
         let tracked = scroll.clone();
         let deck = Deck::new(format!("{id}-deck"))
-            .viewport(viewport)
             .rows((0..seats.len()).map(|_| row))
             .gap(theme.font_size * ROW_GAP)
             .when(lead.is_some(), |deck| {

--- a/crates/views/src/shared/shelves.rs
+++ b/crates/views/src/shared/shelves.rs
@@ -3,15 +3,13 @@ use gpui::{
     AnyElement, App, Context, Div, ElementId, Entity, EntityId, FontWeight, MouseDownEvent, Pixels,
     Point, ScrollHandle, ScrollWheelEvent, SharedString, WeakEntity, Window, div, point, px,
 };
-use std::cell::Cell;
 use std::rc::Rc;
 
 use music::{Album, GenreItem, GenreSection, Playlist};
 use router::{Destination, navigate};
 use state::Playback;
 use ui::{
-    ActiveTheme as _, Button, Card, Deck, Glide, Mode, Popup, Skeleton, Text, Viewport, heading,
-    snapped,
+    ActiveTheme as _, Button, Card, Deck, Glide, Mode, Popup, Skeleton, Text, heading, snapped,
 };
 
 use crate::shared::album_grid::CardGrid;
@@ -37,7 +35,6 @@ pub(crate) struct Shelves {
     host: EntityId,
     playback: Entity<Playback>,
     rails: Vec<Rail>,
-    above: Rc<Cell<Option<Pixels>>>,
     context_menu: Option<(Item, Point<Pixels>)>,
 }
 
@@ -48,7 +45,6 @@ impl Shelves {
             host,
             playback,
             rails: Vec::new(),
-            above: Rc::new(Cell::new(None)),
             context_menu: None,
         }
     }
@@ -107,7 +103,6 @@ impl Shelves {
         sections: Rc<Vec<GenreSection>>,
         mode: Mode,
         width: Pixels,
-        viewport: Viewport,
         window: &Window,
         cx: &mut Context<Self>,
     ) -> AnyElement {
@@ -125,13 +120,10 @@ impl Shelves {
             .map(|section| self.height(section, mode, width, window, cx))
             .collect();
         let me = cx.entity().downgrade();
-        let above = self.above.clone();
 
         let stack = Deck::new(self.tag("stack", 0))
-            .viewport(viewport)
             .rows(heights)
             .gap(STACK_GAP)
-            .on_measure(move |top, _, _| above.set(Some(top)))
             .draw(move |place, window, cx| {
                 let Some(view) = me.upgrade() else {
                     return div().into_any_element();
@@ -154,17 +146,6 @@ impl Shelves {
             .child(stack)
             .children(self.popup(cx))
             .into_any_element()
-    }
-
-    pub(crate) fn viewport(&self, scroll: &ScrollHandle, window: &Window) -> Viewport {
-        let seen = scroll.bounds().size.height;
-
-        let top = match self.above.get() {
-            Some(above) => scroll.bounds().origin.y - above,
-            None => Pixels::ZERO,
-        };
-
-        Viewport::measured(top, seen, window)
     }
 
     fn height(
@@ -238,14 +219,6 @@ impl Shelves {
         let layout = CardGrid::layout(width);
         let (handle, glide) = self.rails[place].clone();
         let crowded = section.items.len() > layout.columns;
-        let seen = match handle.bounds().size.width {
-            reach if reach > Pixels::ZERO => reach,
-            _ => width,
-        };
-        let viewport = Viewport {
-            top: -handle.offset().x.min(Pixels::ZERO),
-            height: seen,
-        };
         let feed = sections.clone();
         let drawn = me.clone();
         let card = layout.card;
@@ -288,7 +261,6 @@ impl Shelves {
                     .child(
                         Deck::new(self.tag("rail", place))
                             .across()
-                            .viewport(viewport)
                             .rows(section.items.iter().map(|_| card))
                             .gap(RAIL_GAP)
                             .draw(move |index, _, cx| {
@@ -451,7 +423,6 @@ pub(crate) fn grid(
     id: &'static str,
     genres: Rc<Vec<music::Genre>>,
     width: Pixels,
-    viewport: Viewport,
     window: &Window,
     cx: &App,
 ) -> AnyElement {
@@ -460,7 +431,6 @@ pub(crate) fn grid(
     let rows = genres.len().div_ceil(lanes);
 
     Deck::new(id)
-        .viewport(viewport)
         .rows((0..rows).map(|_| row))
         .gap(LANE_GAP)
         .draw(move |place, _, cx| {


### PR DESCRIPTION
## Summary

- build only the pinned entries on screen in the left sidebar, so a long Pinned section or Show full library no longer stutters
- rebuild the pinned and library lists only when the pins, the session or the library contents change, instead of on every frame
- let Deck find its visible rows from its own bounds during layout, dropping the viewport bookkeeping in shelves, search and the library cards