### PR TITLE
feat(views): line up song lengths with tabular digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Updated and completed the Indonesian translation.
+- Song lengths in tables and track lists use equal-width digits, so the column lines up.
 
 ### Fixed
 

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -100,7 +100,7 @@ pub use theme::{
     ActiveTheme, BACKDROP_TRANSPARENCY, Look, MAX_FONT, MAX_LYRICS_SCALE, MAX_TRANSPARENCY,
     MIN_FONT, MIN_LYRICS_SCALE, Theme, ThemeKind, ThemeOverrides, backdrop,
 };
-pub use time::clock;
+pub use time::{clock, tabular};
 pub use toast::Toast;
 pub use tooltip::{Perch, Tooltip};
 pub use traffic_light_controls::TrafficLightControls;

--- a/crates/ui/src/time.rs
+++ b/crates/ui/src/time.rs
@@ -1,6 +1,7 @@
+use std::sync::Arc;
 use std::time::Duration;
 
-use gpui::SharedString;
+use gpui::{FontFeatures, SharedString};
 
 pub fn clock(value: Duration) -> SharedString {
     let total = value.as_secs();
@@ -11,4 +12,10 @@ pub fn clock(value: Duration) -> SharedString {
         0 => SharedString::from(format!("{minutes}:{seconds:02}")),
         _ => SharedString::from(format!("{hours}:{minutes:02}:{seconds:02}")),
     }
+}
+
+/// Font features that give every digit the same width, so a column of clock
+/// values lines up like monospace text while staying in the UI font.
+pub fn tabular() -> FontFeatures {
+    FontFeatures(Arc::new(vec![("tnum".into(), 1)]))
 }

--- a/crates/views/src/screens/search.rs
+++ b/crates/views/src/screens/search.rs
@@ -19,7 +19,7 @@ use ui::ActiveTheme as _;
 use ui::{
     Activate, Card, Deck, Deselect, Pinnable, Popup, Room, Scrollbar, Scroller, SelectLeft,
     SelectNext, SelectPrevious, SelectRight, Separator, Text, Theme, VAST, clock, eyebrow,
-    scrolled, snapped, vacant,
+    scrolled, snapped, tabular, vacant,
 };
 
 use crate::shared::cards;
@@ -413,6 +413,7 @@ impl SearchView {
                             .whitespace_nowrap()
                             .text_size(theme.text(Text::Small))
                             .text_color(theme.muted_foreground)
+                            .font_features(tabular())
                             .child(clock(track.duration)),
                     )
                     .press(pressed(Press::Song(Box::new(track.clone())), me))

--- a/crates/views/src/shared/cells.rs
+++ b/crates/views/src/shared/cells.rs
@@ -13,7 +13,7 @@ use router::{Destination, Link as _, navigate};
 use state::{Playback, PlaybackState};
 use ui::{
     ActiveTheme as _, Artwork, Avatar, Cell, ExplicitBadge, InlineLink, InlineLinks, ROW_GROUP,
-    Theme,
+    Theme, clock, tabular,
 };
 
 use crate::chrome::Chrome;
@@ -294,6 +294,14 @@ fn line<F>(cell: &Cell<F>, color: Option<Hsla>) -> Div {
 pub(crate) fn dim<F>(cell: &Cell<F>, value: impl Into<SharedString>, muted: Hsla) -> AnyElement {
     line(cell, Some(muted))
         .child(value.into())
+        .into_any_element()
+}
+
+/// A track length in tabular digits, so the column reads as a monospace strip.
+pub(crate) fn length<F>(cell: &Cell<F>, value: Duration, muted: Hsla) -> AnyElement {
+    line(cell, Some(muted))
+        .font_features(tabular())
+        .child(clock(value))
         .into_any_element()
 }
 

--- a/crates/views/src/shared/track_card.rs
+++ b/crates/views/src/shared/track_card.rs
@@ -4,7 +4,7 @@ use gpui::prelude::*;
 use gpui::{App, Entity, MouseDownEvent, SharedString, Window, div};
 use music::Track;
 use state::{Playback, PlaybackState};
-use ui::{ActiveTheme as _, Card, Pinnable, Text, clock};
+use ui::{ActiveTheme as _, Card, Pinnable, Text, clock, tabular};
 
 use crate::shared::cells;
 use crate::shared::pins::Pinned as _;
@@ -90,6 +90,7 @@ impl TrackCard {
             div()
                 .text_size(theme.text(Text::Small))
                 .text_color(theme.muted_foreground)
+                .font_features(tabular())
                 .child(clock(track.duration))
         });
 

--- a/crates/views/src/shared/tracks/mod.rs
+++ b/crates/views/src/shared/tracks/mod.rs
@@ -17,9 +17,7 @@ use gpui::{
 use music::{Shape, Track};
 use router::Destination;
 use state::{Detail, History, Library, Origin, Playback, PlaybackState, Shelf, Sonora};
-use ui::{
-    Button, Cell, ColumnSpec, Menu, Pin, ROW_GROUP, Scrollbar, TableSource, TableState, clock,
-};
+use ui::{Button, Cell, ColumnSpec, Menu, Pin, ROW_GROUP, Scrollbar, TableSource, TableState};
 
 use crate::shared::cells;
 use crate::shared::confirm::{Confirm, Kind};
@@ -590,7 +588,7 @@ impl TableSource for TrackSource {
                 track.playcount.map(cells::count).unwrap_or_default(),
                 detail,
             ),
-            TrackField::Duration => cells::dim(&cell, clock(track.duration), detail),
+            TrackField::Duration => cells::length(&cell, track.duration, detail),
             TrackField::Index => cells::blank(&cell),
         }
     }


### PR DESCRIPTION
## Summary

- render song lengths in tables, track cards and search results with equal-width digits so the column lines up
- add a `tabular` font-feature helper to `ui` beside `clock`