### PR TITLE
fix(views): draw the fullscreen volume slider over the dock clip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - On Windows, the sign-in window opens when Sonora is installed under Program Files. It used to
   fail with `0x80070005` because the browser it embeds tried to keep its data next to the program,
   where a normal user cannot write. That data now lives under your local app data.
+- In the fullscreen view, the volume slider is no longer cut off when you hover the speaker button
+  while the controls are still sliding in.
 
 ## [0.34.3] - 2026-09-12
 

--- a/crates/views/src/shells/fullscreen.rs
+++ b/crates/views/src/shells/fullscreen.rs
@@ -8,7 +8,7 @@ use gpui::{
     MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point, Render, ScrollWheelEvent,
     SharedString, SpringState, Task,
 };
-use gpui::{Window, canvas, div, px, relative};
+use gpui::{Window, canvas, deferred, div, px, relative};
 use i18n::t;
 use input::{ToggleFullscreen, WORKSPACE_CONTEXT};
 use router::{Destination, navigate};
@@ -760,7 +760,7 @@ impl FullscreenView {
                     ),
             )
             .when(self.volume_open(), |this| {
-                this.child(
+                this.child(deferred(
                     div()
                         .id("fullscreen-volume-zone")
                         .absolute()
@@ -819,7 +819,7 @@ impl FullscreenView {
                                     ),
                                 ),
                         ),
-                )
+                ))
             })
     }
 


### PR DESCRIPTION
## Summary

- draw the fullscreen volume popover deferred so the dock's reveal clip no longer cuts it off when the speaker button is hovered while the controls slide in